### PR TITLE
Low priority download mode

### DIFF
--- a/SDWebImageDownloader.h
+++ b/SDWebImageDownloader.h
@@ -21,13 +21,16 @@ extern NSString *const SDWebImageDownloadStopNotification;
     NSURLConnection *connection;
     NSMutableData *imageData;
 	id userInfo;
+    BOOL lowPriority;
 }
 
 @property (nonatomic, retain) NSURL *url;
 @property (nonatomic, assign) id<SDWebImageDownloaderDelegate> delegate;
 @property (nonatomic, retain) NSMutableData *imageData;
 @property (nonatomic, retain) id userInfo;
+@property (nonatomic, readwrite) BOOL lowPriority;
 
++ (id)downloaderWithURL:(NSURL *)url delegate:(id<SDWebImageDownloaderDelegate>)delegate userInfo:(id)userInfo lowPriority:(BOOL)lowPriority;
 + (id)downloaderWithURL:(NSURL *)url delegate:(id<SDWebImageDownloaderDelegate>)delegate userInfo:(id)userInfo;
 + (id)downloaderWithURL:(NSURL *)url delegate:(id<SDWebImageDownloaderDelegate>)delegate;
 - (void)start;

--- a/SDWebImageDownloader.m
+++ b/SDWebImageDownloader.m
@@ -16,7 +16,7 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
 @end
 
 @implementation SDWebImageDownloader
-@synthesize url, delegate, connection, imageData, userInfo;
+@synthesize url, delegate, connection, imageData, userInfo, lowPriority;
 
 #pragma mark Public Methods
 
@@ -28,6 +28,11 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
 + (id)downloaderWithURL:(NSURL *)url delegate:(id<SDWebImageDownloaderDelegate>)delegate userInfo:(id)userInfo
 {
 
+    return [[self class] downloaderWithURL:url delegate:delegate userInfo:userInfo lowPriority:NO];
+}
+
++ (id)downloaderWithURL:(NSURL *)url delegate:(id<SDWebImageDownloaderDelegate>)delegate userInfo:(id)userInfo lowPriority:(BOOL)lowPriority
+{
     // Bind SDNetworkActivityIndicator if available (download it here: http://github.com/rs/SDNetworkActivityIndicator )
     // To use it, just add #import "SDNetworkActivityIndicator.h" in addition to the SDWebImage import
     if (NSClassFromString(@"SDNetworkActivityIndicator"))
@@ -40,11 +45,12 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
                                                  selector:NSSelectorFromString(@"stopActivity")
                                                      name:SDWebImageDownloadStopNotification object:nil];
     }
-
+    
     SDWebImageDownloader *downloader = [[[SDWebImageDownloader alloc] init] autorelease];
     downloader.url = url;
     downloader.delegate = delegate;
     downloader.userInfo = userInfo;
+    downloader.lowPriority = lowPriority;
     [downloader performSelectorOnMainThread:@selector(start) withObject:nil waitUntilDone:YES];
     return downloader;
 }
@@ -59,8 +65,12 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
     // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:15];
     self.connection = [[[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO] autorelease];
-    // Ensure we aren't blocked by UI manipulations (default runloop mode for NSURLConnection is NSEventTrackingRunLoopMode)
-    [connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
+    // If not in low priority mode, ensure we aren't blocked by UI manipulations (default runloop mode for NSURLConnection is NSEventTrackingRunLoopMode)
+    if (!lowPriority)
+    {
+        [connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    }
     [connection start];
     [request release];
 
@@ -106,7 +116,7 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
     {
         [delegate performSelector:@selector(imageDownloaderDidFinish:) withObject:self];
     }
-
+    
     if ([delegate respondsToSelector:@selector(imageDownloader:didFinishWithImage:)])
     {
         UIImage *image = [[UIImage alloc] initWithData:imageData];

--- a/SDWebImageManager.h
+++ b/SDWebImageManager.h
@@ -23,6 +23,7 @@
 - (UIImage *)imageWithURL:(NSURL *)url;
 - (void)downloadWithURL:(NSURL *)url delegate:(id<SDWebImageManagerDelegate>)delegate;
 - (void)downloadWithURL:(NSURL *)url delegate:(id<SDWebImageManagerDelegate>)delegate retryFailed:(BOOL)retryFailed;
+- (void)downloadWithURL:(NSURL *)url delegate:(id<SDWebImageManagerDelegate>)delegate retryFailed:(BOOL)retryFailed lowPriority:(BOOL)lowPriority;
 - (void)cancelForDelegate:(id<SDWebImageManagerDelegate>)delegate;
 
 @end


### PR DESCRIPTION
Partly resolves https://github.com/rs/SDWebImage/issues/11
Add low priority download mode. Low priorities run NSUrlConnection in NSEventTrackingRunLoopMode

What still remains in the full pre-cache only solution is to only download and cache - not decode the downloaded into a UIImage. This, however, requires larger refactorings in webimagemanager and the protocols used
