### PR TITLE
Fixed a potential crash when the delegate retainCount = 1, which means th

### DIFF
--- a/SDWebImageManager.m
+++ b/SDWebImageManager.m
@@ -175,7 +175,7 @@ static SDWebImageManager *instance;
         SDWebImageDownloader *aDownloader = [downloaders objectAtIndex:uidx];
         if (aDownloader == downloader)
         {
-            id<SDWebImageManagerDelegate> delegate = [downloadDelegates objectAtIndex:uidx];
+            id<SDWebImageManagerDelegate> delegate = [[[downloadDelegates objectAtIndex:uidx] retain] autorelease];
 
             if (image)
             {
@@ -228,7 +228,7 @@ static SDWebImageManager *instance;
         SDWebImageDownloader *aDownloader = [downloaders objectAtIndex:uidx];
         if (aDownloader == downloader)
         {
-            id<SDWebImageManagerDelegate> delegate = [downloadDelegates objectAtIndex:uidx];
+            id<SDWebImageManagerDelegate> delegate = [[[downloadDelegates objectAtIndex:uidx] retain] autorelease];
 
             if ([delegate respondsToSelector:@selector(webImageManager:didFailWithError:)])
             {


### PR DESCRIPTION
Fixed a potential crash when the delegate retainCount = 1, which means the delegate is only retained by the SDWebImageManager and the delegate's dealloc method has a structure like the code below.

<code>
- (void)dealloc
  {
  [manager cancelForDelegate:self];
  [super dealloc];
  }
  </code>
