### PR TITLE
SDWebImageDownloader adds excessive observers when SDNetworkActivityIndicator is used

### DIFF
--- a/SDWebImageDownloader.m
+++ b/SDWebImageDownloader.m
@@ -41,7 +41,13 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
     // To use it, just add #import "SDNetworkActivityIndicator.h" in addition to the SDWebImage import
     if (NSClassFromString(@"SDNetworkActivityIndicator"))
     {
+        
         id activityIndicator = [NSClassFromString(@"SDNetworkActivityIndicator") performSelector:NSSelectorFromString(@"sharedActivityIndicator")];
+
+        // Remove observer in case it was previously added.
+        [[NSNotificationCenter defaultCenter] removeObserver:activityIndicator name:SDWebImageDownloadStartNotification object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:activityIndicator name:SDWebImageDownloadStopNotification object:nil];
+
         [[NSNotificationCenter defaultCenter] addObserver:activityIndicator
                                                  selector:NSSelectorFromString(@"startActivity")
                                                      name:SDWebImageDownloadStartNotification object:nil];


### PR DESCRIPTION
Every time SDWebImageDownloader+downloaderWithURL is called it adds two observers.  This seems to result in an imbalance between SDWebImageDownloadStartNotification and SDWebImageDownloadStopNotification notifications so that the initial activity indicator is squashed when it should be shown.
