### PR TITLE
@2x retina support is broken when images pass through UIImage (ForceDecode) addition

### DIFF
--- a/SDWebImageDecoder.m
+++ b/SDWebImageDecoder.m
@@ -116,7 +116,7 @@ static SDWebImageDecoder *sharedInstance;
     CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
     CGContextRelease(context);
 
-    UIImage *decompressedImage = [[UIImage alloc] initWithCGImage:decompressedImageRef];
+    UIImage *decompressedImage = [[UIImage alloc] initWithCGImage:decompressedImageRef scale:image.scale orientation:UIImageOrientationUp];
     CGImageRelease(decompressedImageRef);
     return SDWIReturnAutoreleased(decompressedImage);
 }


### PR DESCRIPTION
The previous commit to add retina image support by scanning the URL for @2x appeared to be broken.

On closer inspection I saw the image was originally correctly picked up and set with a scale of 2, but later when passing through the ForceDecode addition on UIImage, a new UIImage object is returned which defaults back to a scale of 1. This issue manifested itself when attempting to request a retina scaled image via the UIImageView addition.

The solution was to reassign the same scale to the output image from the original input image.
