### PR TITLE
UIButton+WebCache: set the cached image in the UIControlStateSelected and UIControlStateHighlighted states

### DIFF
--- a/UIButton+WebCache.m
+++ b/UIButton+WebCache.m
@@ -71,6 +71,8 @@
 - (void)webImageManager:(SDWebImageManager *)imageManager didFinishWithImage:(UIImage *)image
 {
     [self setImage:image forState:UIControlStateNormal];
+    [self setImage:image forState:UIControlStateSelected];
+    [self setImage:image forState:UIControlStateHighlighted];
 }
 
 @end


### PR DESCRIPTION
I recently encountered a problem that I couldn't use the UIViewContentModeScaleAspectFit contentMode for UIButton, when the images were set with setImageWithURL.

The problem was fixed by setting the cached image in the UIControlStateSelected and UIControlStateHighlighted states, too.

Thank you for an awesome library!
