### PR TITLE
Fix warning: "performSelector may cause a leak because its selector is unknown."

### DIFF
--- a/SDWebImageDownloader.m
+++ b/SDWebImageDownloader.m
@@ -42,7 +42,10 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
     if (NSClassFromString(@"SDNetworkActivityIndicator"))
     {
         
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         id activityIndicator = [NSClassFromString(@"SDNetworkActivityIndicator") performSelector:NSSelectorFromString(@"sharedActivityIndicator")];
+#pragma clang diagnostic pop
 
         // Remove observer in case it was previously added.
         [[NSNotificationCenter defaultCenter] removeObserver:activityIndicator name:SDWebImageDownloadStartNotification object:nil];


### PR DESCRIPTION
In ARC enabled project, I have got the warning: "performSelector may cause a leak because its selector is unknown." at `id activityIndicator = [NSClassFromString(@"SDNetworkActivityIndicator") performSelector:NSSelectorFromString(@"sharedActivityIndicator")];`.

Here is a fix. via http://stackoverflow.com/a/7933931/380774

Thank you for your work.
