### PR TITLE
Fix for screen scale detection without forcing to use @2x suffixes.

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -72,7 +72,7 @@ NS_INLINE UIImage *SDScaledImageForPath(NSString *path, NSObject *imageOrData)
 
     if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
     {
-        CGFloat scale = 1.0;
+        CGFloat scale = [[UIScreen mainScreen] scale];
         if (path.length >= 8)
         {
             // Search @2x. at the end of the string, before a 3 to 4 extension length (only if key len is 8 or more @2x. + 4 len ext)


### PR DESCRIPTION
You can't use @2x suffixes when remote images not made specifically for iOS but for various devices and resolutions.
