### PR TITLE
Fix SDWebImageDecoder to obey the orientation tag

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -116,7 +116,7 @@ static SDWebImageDecoder *sharedInstance;
     CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
     CGContextRelease(context);
 
-    UIImage *decompressedImage = [[UIImage alloc] initWithCGImage:decompressedImageRef scale:image.scale orientation:UIImageOrientationUp];
+    UIImage *decompressedImage = [[UIImage alloc] initWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
     CGImageRelease(decompressedImageRef);
     return SDWIReturnAutoreleased(decompressedImage);
 }


### PR DESCRIPTION
`SDWebImageDecoder +decodedImageWithImage:` ignored the orientation of the original UIImage object.

I made it pass the orientation information from the original image when creating a new UIImage.
