### PR TITLE
Auto download for retina images

### DIFF
--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -10,6 +10,8 @@
 #import "SDWebImageManagerDelegate.h"
 #import "SDWebImageManager.h"
 
+
+
 /**
  * Integrates SDWebImage async downloading and caching of remote images with UIImageView.
  *
@@ -44,6 +46,8 @@
  */
 @interface UIImageView (WebCache) <SDWebImageManagerDelegate>
 
+
++(NSURL *) retinaURL:(NSURL *) url;;
 
 /**
  * Set the imageView `image` with an `url`.
@@ -119,7 +123,7 @@
  * @param success A block to be executed when the image request succeed This block has no return value and takes the retrieved image as argument.
  * @param failure A block object to be executed when the image request failed. This block has no return value and takes the error object describing the network or parsing error that occurred (may be nil).
  */
-- (void)setImageWithURL:(NSURL *)url success:(void (^)(UIImage *image))success failure:(void (^)(NSError *error))failure;
+- (void)setOptimizedImageWithURL:(NSURL *)url success:(void (^)(UIImage *image))success failure:(void (^)(NSError *error))failure;
 /**
  * Set the imageView `image` with an `url`.
  *

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -10,25 +10,38 @@
 
 @interface UIImageView (WebCachePrivate)
 
--(void) retinaURL:(NSURL *) url;
+-(NSURL *) retinaURL:(NSURL *) url;
 -(BOOL) isRetina;
 @end
 
 @implementation UIImageView (WebCache)
 
 
--(BOOL) isRetina{
++(BOOL) isRetina{
     return ([UIScreen mainScreen].scale == 2.0f);
 }
 
--(void) retinaURL:(NSURL *) url{
-    NSString * lastComponent = [url lastPathComponent];
-    
-    NSString *extension = [url pathExtension];
-    if ([lastComponent rangeOfString:@"@2x"].location == NSNotFound) {
-        NSString * replacedLastComponent = [lastComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@".%@",extension] withString:[NSString stringWithFormat:@"@2x.%@",extension]];
-        url = [NSURL URLWithString:[[url absoluteString] stringByReplacingOccurrencesOfString:lastComponent withString:replacedLastComponent]];
++(NSURL *) retinaURL:(NSURL *) url{
+    if ([UIImageView isRetina]) {
+        NSString * lastComponent = [url lastPathComponent];
+        
+        NSString *extension = [url pathExtension];
+        if ([lastComponent rangeOfString:@"_2x"].location == NSNotFound) {
+            NSString * replacedLastComponent = [lastComponent stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@".%@",extension] withString:[NSString stringWithFormat:@"_2x.%@",extension]];
+            url = [NSURL URLWithString:[[[url absoluteString] stringByReplacingOccurrencesOfString:lastComponent withString:replacedLastComponent] stringByAddingPercentEscapesUsingEncoding:NSASCIIStringEncoding]];
+            //[url urlen]
+        }
     }
+    
+    return url;
+}
+
+-(BOOL) isRetina{
+    return [UIImageView isRetina];
+}
+
+-(NSURL *) retinaURL:(NSURL *)url{
+    return [UIImageView retinaURL:url];
 }
 
 - (void)setImageWithURL:(NSURL *)url
@@ -39,9 +52,7 @@
 
 - (void)setOptimizedImageWithURL:(NSURL *)url
 {
-    if ([self isRetina]) {
-        [self retinaURL:url];
-    }
+    url = [self retinaURL:url];
     [self setImageWithURL:url placeholderImage:nil];
 }
 
@@ -52,9 +63,7 @@
 
 - (void)setOptimizedImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder
 {
-    if ([self isRetina]) {
-        [self retinaURL:url];
-    }
+    url = [self retinaURL:url];
     [self setImageWithURL:url placeholderImage:placeholder options:0];
 }
 
@@ -83,9 +92,7 @@
 
     if (url)
     {
-        if ([self isRetina]) {
-            [self retinaURL:url];
-        }
+        url = [self retinaURL:url];
         [manager downloadWithURL:url delegate:self options:options];
     }
 }
@@ -136,8 +143,9 @@
     
     if (url)
     {
-        if ([self isRetina]) {
-            [self retinaURL:url];
+        if ([UIImageView isRetina]) {
+            url = [UIImageView retinaURL:url];
+
         }
         [manager downloadWithURL:url delegate:self options:options success:success failure:failure];
     }


### PR DESCRIPTION
I've boosted the UIImageView+WebCache.

using setOptimizedImage instead of setImage with change the URL for the @2x version.
this way you only have to store the regular URL in your code or DB and the program will make the switch automatically

If you think we can improve or extend the feature, I'll work on it but I guess it will be pretty useful for anyone in need of DB driven image library
