### PR TITLE
add explanation of where to find the link flag and the header search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,11 @@ If you chose to link against the ARC+MKAnnotation target, click the "+" button a
 
 ### Add headers
 
-Open the "Build Settings" tab, locate the "Other Linker Flags" setting and add the "-ObjC" flag:
+Open the "Build Settings" tab, in the "Linking" section, locate the "Other Linker Flags" setting and add the "-ObjC" flag:
 
 ![Other Linker Flags](http://dl.dropbox.com/u/123346/SDWebImage/10_other_linker_flags.jpg)
 
-Locate "Header Search Paths" (and not "User Header Search Paths") and add two settings: ”$(TARGET_BUILD_DIR)/usr/local/lib/include” and ”$(OBJROOT)/UninstalledProducts/include”. Make sure to include the quotes here:
+In the "Search Paths" section, locate "Header Search Paths" (and not "User Header Search Paths") and add two settings: ”$(TARGET_BUILD_DIR)/usr/local/lib/include” and ”$(OBJROOT)/UninstalledProducts/include”. Make sure to include the quotes here:
 
 ![User Header Search Paths](http://dl.dropbox.com/u/123346/SDWebImage/11_user_header_search_paths.jpg)
 


### PR DESCRIPTION
the Linking section, and the "Search Paths" section added to the instructions
