### PR TITLE
'prepare' block added to UIImageView category

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -20,6 +20,7 @@ typedef enum
 } SDWebImageOptions;
 
 #if NS_BLOCKS_AVAILABLE
+typedef void(^SDWebImagePrepareBlock)();
 typedef void(^SDWebImageSuccessBlock)(UIImage *image, BOOL cached);
 typedef void(^SDWebImageFailureBlock)(NSError *error);
 #endif
@@ -138,12 +139,26 @@ typedef NSString *(^CacheKeyFilter)(NSURL *url);
  * @param url The URL to the image
  * @param delegate The delegate object used to send result back
  * @param options A mask to specify options to use for this request
- * @param info An NSDictionnary passed back to delegate if provided
+ * @param prepare A block called when image has been identified to not be in cache and is about to be downloaded
  * @param success A block called when image has been retrived successfuly
  * @param failure A block called when couldn't be retrived for some reason
  * @see [SDWebImageManager downloadWithURL:delegate:options:]
  */
-- (void)downloadWithURL:(NSURL *)url delegate:(id)delegate options:(SDWebImageOptions)options userInfo:(NSDictionary *)info success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+- (void)downloadWithURL:(NSURL *)url delegate:(id)delegate options:(SDWebImageOptions)options prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+
+/**
+ * Downloads the image at the given URL if not present in cache or return the cached version otherwise.
+ *
+ * @param url The URL to the image
+ * @param delegate The delegate object used to send result back
+ * @param options A mask to specify options to use for this request
+ * @param info An NSDictionnary passed back to delegate if provided
+ * @param prepare A block called when image has been identified to not be in cache and is about to be downloaded
+ * @param success A block called when image has been retrived successfuly
+ * @param failure A block called when couldn't be retrived for some reason
+ * @see [SDWebImageManager downloadWithURL:delegate:options:]
+ */
+- (void)downloadWithURL:(NSURL *)url delegate:(id)delegate options:(SDWebImageOptions)options userInfo:(NSDictionary *)userInfo prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 #endif
 
 /**

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -121,7 +121,7 @@
     if (url)
     {
         NSDictionary *info = [NSDictionary dictionaryWithObject:@"background" forKey:@"type"];
-        [manager downloadWithURL:url delegate:self options:options userInfo:info success:success failure:failure];
+        [manager downloadWithURL:url delegate:self options:options userInfo:info prepare:nil success:success failure:failure];
     }
 }
 #endif

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -88,6 +88,18 @@
 - (void)setImageWithURL:(NSURL *)url success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 
 /**
+ * Set the imageView `image` with an `url`.
+ *
+ * The downloand is asynchronous and cached.
+ *
+ * @param url The url for the image.
+ * @param prepare A block to be executed when the image is not present in cache and is about to be downloaded This block has no return value and takes no arguments.
+ * @param success A block to be executed when the image request succeed This block has no return value and takes the retrieved image as argument.
+ * @param failure A block object to be executed when the image request failed. This block has no return value and takes the error object describing the network or parsing error that occurred (may be nil).
+ */
+- (void)setImageWithURL:(NSURL *)url prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+
+/**
  * Set the imageView `image` with an `url`, placeholder.
  *
  * The downloand is asynchronous and cached.
@@ -100,6 +112,19 @@
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 
 /**
+ * Set the imageView `image` with an `url`, placeholder.
+ *
+ * The downloand is asynchronous and cached.
+ *
+ * @param url The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param success A block to be executed when the image request succeed This block has no return value and takes the retrieved image as argument.
+ * @param prepare A block to be executed when the image is not present in cache and is about to be downloaded This block has no return value and takes no arguments.
+ * @param failure A block object to be executed when the image request failed. This block has no return value and takes the error object describing the network or parsing error that occurred (may be nil).
+ */
+- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+
+/**
  * Set the imageView `image` with an `url`, placeholder and custom options.
  *
  * The downloand is asynchronous and cached.
@@ -107,10 +132,11 @@
  * @param url The url for the image.
  * @param placeholder The image to be set initially, until the image request finishes.
  * @param options The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param prepare A block to be executed when the image is not present in cache and is about to be downloaded This block has no return value and takes no arguments.
  * @param success A block to be executed when the image request succeed This block has no return value and takes the retrieved image as argument.
  * @param failure A block object to be executed when the image request failed. This block has no return value and takes the error object describing the network or parsing error that occurred (may be nil).
  */
-- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 #endif
 
 /**

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -38,27 +38,38 @@
 #if NS_BLOCKS_AVAILABLE
 - (void)setImageWithURL:(NSURL *)url success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 {
-    [self setImageWithURL:url placeholderImage:nil success:success failure:failure];
+    [self setImageWithURL:url prepare:nil success:success failure:failure];
+}
+
+- (void)setImageWithURL:(NSURL *)url prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+{
+    [self setImageWithURL:url placeholderImage:nil prepare:prepare success:success failure:failure];
 }
 
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
 {
-    [self setImageWithURL:url placeholderImage:placeholder options:0 success:success failure:failure];
+    [self setImageWithURL:url placeholderImage:placeholder options:0 prepare:nil success:success failure:failure];
 }
 
-- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure;
+- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure
+{
+    [self setImageWithURL:url placeholderImage:placeholder options:0 prepare:prepare success:success failure:failure];
+}
+
+- (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options prepare:(SDWebImagePrepareBlock)prepare success:(SDWebImageSuccessBlock)success failure:(SDWebImageFailureBlock)failure
 {
     SDWebImageManager *manager = [SDWebImageManager sharedManager];
-
+    
     // Remove in progress downloader from queue
     [manager cancelForDelegate:self];
-
+    
     self.image = placeholder;
-
+    
     if (url)
     {
-        [manager downloadWithURL:url delegate:self options:options success:success failure:failure];
+        [manager downloadWithURL:url delegate:self options:options prepare:prepare success:success failure:failure];
     }
+
 }
 #endif
 


### PR DESCRIPTION
Hi,

I added a `prepare` block to the UIImageView category, which is called when an image is not found in cache and about to be downloaded.

My use case for this was trying to show a modal view. With the current SDWebImage implementation, I'd have to show the modal view outside of the `setImageWithURL...` call, then `dismiss` it in the `success` block.

If the image is already cached, this results in a flicking modal view that is added and quickly removed, since it is just loaded from cache and `success` is quickly called.

I needed a block for the specific state that occurs right before an image download, when an image is not in cache, so I can add the modal view only if the image needs to download. This is what my new `prepare` argument does.

Hope this helps!
