### PR TITLE
Creating the CGBitmapContext with the right bytes per pixel and bitmap info depending on the original image.

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -99,16 +99,21 @@ static SDWebImageDecoder *sharedInstance;
     CGImageRef imageRef = image.CGImage;
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(imageRef);
+
+    BOOL imageHasAlphaInfo = (alphaInfo != kCGImageAlphaNone);
+
+    int bytesPerPixel = imageHasAlphaInfo ? 4 : 3;
+    CGBitmapInfo bitmapInfo = imageHasAlphaInfo ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNone;
+
     CGContextRef context = CGBitmapContextCreate(NULL,
                                                  CGImageGetWidth(imageRef),
                                                  CGImageGetHeight(imageRef),
                                                  8,
-                                                 // Just always return width * 4 will be enough
-                                                 CGImageGetWidth(imageRef) * 4,
+                                                 // Just always return width * bytesPerPixel will be enough
+                                                 CGImageGetWidth(imageRef) * bytesPerPixel,
                                                  // System only supports RGB, set explicitly
                                                  colorSpace,
-                                                 // Makes system don't need to do extra conversion when displayed.
-                                                 alphaInfo | kCGBitmapByteOrder32Little);
+                                                 bitmapInfo);
     CGColorSpaceRelease(colorSpace);
     if (!context) return nil;
 


### PR DESCRIPTION
This removes an error that was making `CGBitmapContext` return `NULL` with some images:

```
<Error>: CGBitmapContextCreate: unsupported parameter combination: 8 integer bits/component; 32 bits/pixel; 3-component color space; kCGImageAlphaLast; 400 bytes/row.
```

Basically, depending on whether the original image has alpha info (its alphaInfo != `kCGImageAlphaNone`), I create a context with alpha info `kCGImageAlphaPremultipliedLast` (basically `RGBA`) or no alpha info at all (`kCGImageAlphaNone`)

From `CGImage.h`:

``` objc
    kCGImageAlphaNone,               /* For example, RGB. */
    kCGImageAlphaPremultipliedLast,  /* For example, premultiplied RGBA */
```
