### PR TITLE
Fixed Alpha detection when decoding images.

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -100,7 +100,9 @@ static SDWebImageDecoder *sharedInstance;
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(imageRef);
 
-    BOOL imageHasAlphaInfo = (alphaInfo != kCGImageAlphaNone);
+    BOOL imageHasAlphaInfo = (alphaInfo != kCGImageAlphaNone &&
+                              alphaInfo != kCGImageAlphaNoneSkipFirst &&
+                              alphaInfo != kCGImageAlphaNoneSkipLast);
 
     int bytesPerPixel = imageHasAlphaInfo ? 4 : 3;
     CGBitmapInfo bitmapInfo = imageHasAlphaInfo ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNone;


### PR DESCRIPTION
Added kCGImageAlphaNoneSkipFirst and kCGImageAlphaNoneSkipLast to the imageHasAlphaInfo boolean when detecting alpha. Some JPEGs were decoded with alpha and UIImageViews were not opaque.
