### PR TITLE
Prevent caching of responses in Cache.db

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -253,6 +253,12 @@ NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNot
     self.imageData = nil;
 }
 
+//prevent caching of responses in Cache.db
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse
+{
+    return nil;
+}
+
 #pragma mark SDWebImageDecoderDelegate
 
 - (void)imageDecoder:(SDWebImageDecoder *)decoder didFinishDecodingImage:(UIImage *)image userInfo:(NSDictionary *)aUserInfo


### PR DESCRIPTION
It seems that since iOS 5.0, URL responses also get cached in a file named Cache.db:
http://petersteinberger.com/blog/2012/nsurlcache-uses-a-disk-cache-as-of-ios5/

Because SDWebImage will/can also cache images, you end up using twice the disk space (and IO).

Here are two screenshots showing this behaviour on the simulator and on the device:

http://i.imgur.com/6c2Cv.jpg
http://i.imgur.com/3xWFC.png

I've added a delegate method implementation to avoid caching in Cache.db. Feel free to merge or adopt.
