### PR TITLE
decodedImageWithImage: ignores scale and orientation

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -29,7 +29,7 @@
 	
     CGContextRelease(context);
 	
-    UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef];
+    UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
     CGImageRelease(decompressedImageRef);
     return decompressedImage;
 }


### PR DESCRIPTION
The decodedImageWithImage: method ignores the image's scale and orientation which can result in Retina images (images with @2x in their name) being decoded with a scale of 1.0 which results in them being rendered improperly.

To test create a UIImageView and set its contentMode property to UIViewContentModeCenter. Load an image that is the same size of the UIImageView and then load a Retina version of that same image. The Retina image will be twice the size and render outside the UIImageView's bounds.
