### PR TITLE
Change SDWebImageManager to use shared image cache

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -39,7 +39,7 @@
 {
     if ((self = [super init]))
     {
-        _imageCache = SDImageCache.new;
+        _imageCache = [SDImageCache sharedImageCache];
         _imageDownloader = SDWebImageDownloader.new;
         _failedURLs = NSMutableArray.new;
         _runningOperations = NSMutableArray.new;


### PR DESCRIPTION
Currently, each SDWebImageManager creates its own SDImageCache, which in turn creates its own NSCache. If you use more than one SDWebImageManager, you could end up having more than one copy of an image cached. For example, this will happen if you use SDWebImagePrefetcher because the prefetcher creates its own image manager.

This changes SDWebImageManager to use the shared image cache.
