### PR TITLE
NSInvalidArgumentException is thrown if a nil NSURL is downloaded.

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -144,13 +144,12 @@ static NSString *const kCompletedCallbackKey = @"completed";
 
 - (void)addProgressCallback:(void (^)(NSUInteger, long long))progressBlock andCompletedBlock:(void (^)(UIImage *, NSData *data, NSError *, BOOL))completedBlock forURL:(NSURL *)url createCallback:(void (^)())createCallback
 {
-    // The URL will be used as the key to the callbacks dictionary so it cannot be nil. If it is nil immediately call the completed block with no image or data and an error.
+    // The URL will be used as the key to the callbacks dictionary so it cannot be nil. If it is nil immediately call the completed block with no image or data.
     if(url == nil)
     {
         if (completedBlock != nil)
         {
-            NSError *error = [NSError errorWithDomain:@"SDWebImageErrorDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Could not load an image because URL was nil."}];
-            completedBlock(nil, nil, error, NO);
+            completedBlock(nil, nil, nil, NO);
         }
         return;
     }


### PR DESCRIPTION
If you pass a nil URL to the SDWebImageDownloader a crash occurs because the URL is used as the key for the callbacks dictionary.

Rather than add checks for nil around all the calls in my app I figured simply bailing out of adding the callbacks and immediately calling the completed block was the most elegant solution. It should degrade nicely in the case someone passes in a nil URL.
