### PR TITLE
Raising a compile time error if ARC is not enabled

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -17,10 +17,6 @@
 #error SDWebImage doesn't support Deployement Target version < 5.0
 #endif
 
-#if !__has_feature(objc_arc)
-#error SDWebImage requires ARC enabled. Add the compiler flag -fobjc-arc.
-#endif
-
 #if !TARGET_OS_IPHONE
 #import <AppKit/AppKit.h>
 #ifndef UIImage

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -9,6 +9,10 @@
 #import "SDWebImageManager.h"
 #import <objc/message.h>
 
+#if !__has_feature(objc_arc)
+#error SDWebImage requires ARC enabled. Add the compiler flag -fobjc-arc.
+#endif
+
 @interface SDWebImageCombinedOperation : NSObject <SDWebImageOperation>
 
 @property (assign, nonatomic, getter = isCancelled) BOOL cancelled;


### PR DESCRIPTION
Right now you see warnings "You maybe have forgotten to call super" if ARC is not enabled in the target or for SDWebImage files.
