### PR TITLE
Adding a new property on SDImageCache called cachingPolicy.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -38,6 +38,14 @@ typedef enum SDImageCacheType SDImageCacheType;
 @property (assign, nonatomic) NSInteger maxCacheAge;
 
 /**
+ * The caching policy for methods where you do not specifically choose one (in the storeImage functions, this applies to the functions where ToDisk is not set).
+ * SDImageCacheTypeDisk saves to memory and disk
+ * SDImageCacheTypeMemory saves to memory only
+ * SDImageCacheTypeNone skips caching
+ */
+@property (nonatomic) SDImageCacheType cachingPolicy;
+
+/**
  * Returns global shared cache instance
  *
  * @return SDImageCache global instance
@@ -52,12 +60,21 @@ typedef enum SDImageCacheType SDImageCacheType;
 - (id)initWithNamespace:(NSString *)ns;
 
 /**
- * Store an image into memory and disk cache at the given key.
+ * Store an image into cache. The type of cache (memory/disk/none) depends on the cachingPolicy property of SDImageCache. Default is disk.
  *
  * @param image The image to store
  * @param key The unique image cache key, usually it's image absolute URL
  */
 - (void)storeImage:(UIImage *)image forKey:(NSString *)key;
+
+/**
+ * Store an image into cache. The type of cache (memory/disk/none) depends on the cachingPolicy property of SDImageCache. Default is disk.
+ *
+ * @param image The image to store
+ * @param data The image data as returned by the server, this representation will be used for disk storage
+ * @param key The unique image cache key, usually it's image absolute URL
+ */
+- (void)storeImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key;
 
 /**
  * Store an image into memory and optionally disk cache at the given key.

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -113,7 +113,7 @@
                 }
                 else if (downloadedImage && finished)
                 {
-                    [self.imageCache storeImage:downloadedImage imageData:data forKey:key toDisk:YES];
+                    [self.imageCache storeImage:downloadedImage imageData:data forKey:key];
                 }
 
                 if (finished)


### PR DESCRIPTION
Adding a new property on SDImageCache called cachingPolicy. I think this is particularly useful for people who don't want to cache to disk, so would rather just cache to memory.

The type of this is SDImageCacheType (reusing the existing enum). It lets you specify the default caching behaviour of one of three values; none (disables loading images from cache completely, forcing reload each time), memory only or disk.

This is so you can be more specific about the caching behaviour. You can leave the behaviour as is and cache to disk, or you can choose not to cache to disk and only cache to memory, or you can choose not to use the cache at all.

The default value of cachingPolicy if you don't change it is "disk" (SDImageCacheTypeDisk) - as was the default before this change.

You can change the value by accessing the shared instance of SDImageCache and modifying the property, e.g:
 [SDImageCache sharedImageCache].cachingPolicy = SDImageCacheTypeMemory;

This cachingPolicy default applies to storeImage:forKey and storeImage:imageData:forKey where the toDisk property doesn't exist. If you call one of the storeImage methods that has the toDisk property, that will take precedence over the cachingPolicy property.

Also changed the call in SDWebImageManager to call the method that uses this property, instead of always being to disk like it was before.
