### PR TITLE
Added URL redirect caching

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -81,18 +81,27 @@ typedef enum SDImageCacheType SDImageCacheType;
 - (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSString *)key toDisk:(BOOL)toDisk;
 
 /**
+ * Store an NSString (should represent a redirect URL) into memory and optionally disk cache at the given key.
+ *
+ * @param redirect The absolute URL to cache
+ * @param key The unique image cache key, usually it's image absolute URL
+ * @param toDisk Store the redirect to disk cache if YES
+ */
+- (void)storeRedirect:(NSString*)redirect forKey:(NSString*)key toDisk:(BOOL)toDisk;
+
+/**
  * Query the disk cache asynchronousely.
  *
  * @param key The unique key used to store the wanted image
  */
-- (void)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock;
+- (void)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, NSString *redirect, SDImageCacheType cacheType))doneBlock;
 
 /**
  * Query the memory cache.
  *
  * @param key The unique key used to store the wanted image
  */
-- (UIImage *)imageFromMemoryCacheForKey:(NSString *)key;
+- (id)imageFromMemoryCacheForKey:(NSString *)key;
 
 /**
  * Remove the image from memory and disk cache synchronousely

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -33,6 +33,9 @@ UIImage *SDScaledImageForPath(NSString *path, NSObject *imageOrData)
         return nil;
     }
 
+    // Maybe the data received isn't an image.
+    if (!image) return nil;
+    
     if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
     {
         CGFloat scale = 1.0;

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -21,6 +21,7 @@ extern NSString *const SDWebImageDownloadStopNotification;
 
 typedef void(^SDWebImageDownloaderProgressBlock)(NSUInteger receivedSize, long long expectedSize);
 typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, NSError *error, BOOL finished);
+typedef void(^SDWebImageDownloaderRedirectedBlock)(NSURLRequest *redirectRequest);
 
 /**
  * Asynchronous downloader dedicated and optimized for image loading.
@@ -41,6 +42,10 @@ typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, 
  * @param url The URL to the image to download
  * @param options The options to be used for this download
  * @param progress A block called repeatedly while the image is downloading
+ * @param redirected Set this to nil if you want the download to continue after
+ *                   a redirect was requested by the server.
+ *                   Otherwise, this block will be called when a redirect was requested
+ *                   and you will have to decide yourself what to do next.
  * @param completed A block called once the download is completed.
  *                  If the download succeeded, the image parameter is set, in case of error,
  *                  error parameter is set with the error. The last parameter is always YES
@@ -52,6 +57,12 @@ typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, 
  *
  * @return A cancellable SDWebImageOperation
  */
+- (id<SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
+                                        options:(SDWebImageDownloaderOptions)options
+                                       progress:(SDWebImageDownloaderProgressBlock)progressBlock
+                                     redirected:(SDWebImageDownloaderRedirectedBlock)redirectedBlock
+                                      completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
+
 - (id<SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
                                         options:(SDWebImageDownloaderOptions)options
                                        progress:(SDWebImageDownloaderProgressBlock)progressBlock

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -19,6 +19,7 @@
                 queue:(dispatch_queue_t)queue
               options:(SDWebImageDownloaderOptions)options
              progress:(SDWebImageDownloaderProgressBlock)progressBlock
+             redirect:(SDWebImageDownloaderRedirectedBlock)redirectBlock
             completed:(SDWebImageDownloaderCompletedBlock)completedBlock
             cancelled:(void (^)())cancelBlock;
 

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -31,7 +31,11 @@ typedef enum
      * This flag enables progressive download, the image is displayed progressively during download as a browser would do.
      * By default, the image is only displayed once completely downloaded.
      */
-    SDWebImageProgressiveDownload = 1 << 3
+    SDWebImageProgressiveDownload = 1 << 3,
+    /**
+     * This flag enables HTTP redirect caching
+     */
+    SDWebImageCacheRedirects = 1 << 4
 } SDWebImageOptions;
 
 typedef void(^SDWebImageCompletedBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType);


### PR DESCRIPTION
This will be useful if there are different URL's that redirect to the same image URL. For this case, we are currently ending up with the same image being cached multiple times.

This speeds up also the loading time, because no expensive http call is made to figure out, that the image is already cached.
