### PR TITLE
Add synchronous disk-cache loading method.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -95,6 +95,13 @@ typedef enum SDImageCacheType SDImageCacheType;
 - (UIImage *)imageFromMemoryCacheForKey:(NSString *)key;
 
 /**
+ * Query the disk cache synchronousely.
+ *
+ * @param key The unique key used to store the wanted image
+ */
+- (UIImage *)imageFromDiskCacheForKey:(NSString *)key;
+
+/**
  * Remove the image from memory and disk cache synchronousely
  *
  * @param key The unique image cache key

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -155,6 +155,27 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     return [self.memCache objectForKey:key];
 }
 
+- (UIImage *)imageFromDiskCacheForKey:(NSString *)key
+{
+    // First check the in-memory cache...
+    UIImage *image = [self imageFromMemoryCacheForKey:key];
+    if (image)
+    {
+        return image;
+    }
+    
+    // Second check the disk cache...
+    UIImage *diskImage = [UIImage decodedImageWithImage:SDScaledImageForPath(key, [NSData dataWithContentsOfFile:[self cachePathForKey:key]])];
+    
+    if (diskImage)
+    {
+        CGFloat cost = diskImage.size.height * diskImage.size.width * diskImage.scale;
+        [self.memCache setObject:diskImage forKey:key cost:cost];
+    }
+    
+    return diskImage;
+}
+
 - (void)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock
 {
     if (!doneBlock) return;


### PR DESCRIPTION
Hi, there are cases people just want to load images synchronously without using blocks,
so I added `-imageFromDiskCacheForKey:` method instead of using asynchronous `-queryDiskCacheForKey:done:`.

It'lll be glad if you can merge this commit to your master branch :)
