### PR TITLE
Check if placeholder is empty

### DIFF
--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -47,7 +47,7 @@ static char operationKey;
 {
     [self cancelCurrentImageLoad];
 
-    self.image = placeholder;
+    if (placeholder) self.image = placeholder;
     
     if (url)
     {


### PR DESCRIPTION
In case there is already an image set on the imageview (before `setImageWithURL:` is called),  i think it would be better if this image doesn't get nil, when there is no placeholder. 
