### PR TITLE
New option SDWebImageRefreshCached

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -13,7 +13,8 @@
 typedef enum
 {
     SDWebImageDownloaderLowPriority = 1 << 0,
-    SDWebImageDownloaderProgressiveDownload = 1 << 1
+    SDWebImageDownloaderProgressiveDownload = 1 << 1,
+    SDWebImageDownloaderEnableNSURLCache = 1 << 2
 } SDWebImageDownloaderOptions;
 
 typedef enum

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -120,7 +120,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     [self addProgressCallback:progressBlock andCompletedBlock:completedBlock forURL:url createCallback:^
     {
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests
-        NSMutableURLRequest *request = [NSMutableURLRequest.alloc initWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:15];
+        NSMutableURLRequest *request = [NSMutableURLRequest.alloc initWithURL:url cachePolicy:(options & SDWebImageDownloaderEnableNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData) timeoutInterval:15];
         request.HTTPShouldHandleCookies = NO;
         request.HTTPShouldUsePipelining = YES;
         request.allHTTPHeaderFields = wself.HTTPHeaders;

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -31,7 +31,14 @@ typedef enum
      * This flag enables progressive download, the image is displayed progressively during download as a browser would do.
      * By default, the image is only displayed once completely downloaded.
      */
-    SDWebImageProgressiveDownload = 1 << 3
+    SDWebImageProgressiveDownload = 1 << 3,
+    /**
+     * Even if the image is cached, fetch the URL again anyway. When set, NSURLCache is enabled in the downloader.
+     * NSURLCache will handle the protocol caching logic while SDWebImage remains useful for offline images.
+     * This option helps deal with images changing behind the same request URL, e.g. Facebook graph api profile pics.
+     * If a cached image exists, the completion block is called once with the cached image and again with the final image.
+     */
+    SDWebImageRefreshCached = 1 << 4
 } SDWebImageOptions;
 
 typedef void(^SDWebImageCompletedBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType);


### PR DESCRIPTION
Even if the image is cached, fetch the URL again anyway. When set,
NSURLCache is enabled in the downloader via the new option
SDWebImageDownloaderEnableNSURLCache.

NSURLCache will handle the protocol caching while SDWebImage remains
useful for offline images.

This option helps deal with images changing behind the same request URL,
e.g. Facebook graph api profile pics where the request URL
https://graph.facebook.com/[userid]/picture returns a redirect to the
actual profile image.

If a cached image exists, the completion block is called once with the
cached image and again with the final image.
