### PR TITLE
Fix SDWebImageManager transformDownloadedImage

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -154,7 +154,7 @@
 
                             if (transformedImage && finished)
                             {
-                                [self.imageCache storeImage:transformedImage imageData:data forKey:key toDisk:cacheOnDisk];
+                                [self.imageCache storeImage:transformedImage imageData:nil forKey:key toDisk:cacheOnDisk];
                             }
                         });
                     }


### PR DESCRIPTION
The data of the transformed image should be cached instead of the of the downloaded one.
Passing nil to storeImage will generate data, so no need to duplicate code here.
