### PR TITLE
New name for SDWebImageDownloaderQueueMode type, typo fixing, strong cycle fixing.

### DIFF
--- a/Examples/SDWebImage Demo/DetailViewController.m
+++ b/Examples/SDWebImage Demo/DetailViewController.m
@@ -34,12 +34,13 @@
     if (self.imageURL)
     {
         __block UIActivityIndicatorView *activityIndicator;
+        __weak UIImageView *weakImageView = self.imageView;
         [self.imageView setImageWithURL:self.imageURL placeholderImage:nil options:SDWebImageProgressiveDownload progress:^(NSUInteger receivedSize, long long expectedSize)
         {
             if (!activityIndicator)
             {
-                [self.imageView addSubview:activityIndicator = [UIActivityIndicatorView.alloc initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray]];
-                activityIndicator.center = self.imageView.center;
+                [weakImageView addSubview:activityIndicator = [UIActivityIndicatorView.alloc initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray]];
+                activityIndicator.center = weakImageView.center;
                 [activityIndicator startAnimating];
             }
         }

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -333,7 +333,7 @@
                     nil];
     }
     [SDWebImageManager.sharedManager.imageDownloader setValue:@"SDWebImage Demo" forHTTPHeaderField:@"AppName"];
-    SDWebImageManager.sharedManager.imageDownloader.queueMode = SDWebImageDownloaderLIFOQueueMode;
+    SDWebImageManager.sharedManager.imageDownloader.executionOrder = SDWebImageDownloaderLIFOExecutionOrder;
     return self;
 }
 

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -20,7 +20,7 @@ enum SDImageCacheType
      */
     SDImageCacheTypeDisk,
     /**
-     * The image was obtained from the disk cache.
+     * The image was obtained from the memory cache.
      */
     SDImageCacheTypeMemory
 };

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -28,9 +28,15 @@ typedef enum
 
 typedef enum
 {
-    SDWebImageDownloaderFILOQueueMode,
-    SDWebImageDownloaderLIFOQueueMode
-} SDWebImageDownloaderQueueMode;
+    SDWebImageDownloaderFIFOExecutionOrder,
+    /**
+     * Default value. All download operations will execute in queue style (first-in-first-out).
+     */
+    SDWebImageDownloaderLIFOExecutionOrder
+    /**
+     * All download operations will execute in stack style (last-in-first-out).
+     */
+} SDWebImageDownloaderExecutionOrder;
 
 extern NSString *const SDWebImageDownloadStartNotification;
 extern NSString *const SDWebImageDownloadStopNotification;
@@ -46,9 +52,9 @@ typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, 
 @property (assign, nonatomic) NSInteger maxConcurrentDownloads;
 
 /**
- * Changes download operations unqueue mode. Default value is `SDWebImageDownloaderFILOQueueMode`.
+ * Changes download operations execution order. Default value is `SDWebImageDownloaderFIFOExecutionOrder`.
  */
-@property (assign, nonatomic) SDWebImageDownloaderQueueMode queueMode;
+@property (assign, nonatomic) SDWebImageDownloaderExecutionOrder executionOrder;
 
 + (SDWebImageDownloader *)sharedDownloader;
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -67,7 +67,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
 {
     if ((self = [super init]))
     {
-        _queueMode = SDWebImageDownloaderFILOQueueMode;
+        _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = NSOperationQueue.new;
         _downloadQueue.maxConcurrentOperationCount = 2;
         _URLCallbacks = NSMutableDictionary.new;
@@ -158,9 +158,9 @@ static NSString *const kCompletedCallbackKey = @"completed";
             [sself removeCallbacksForURL:url];
         }];
         [wself.downloadQueue addOperation:operation];
-        if (wself.queueMode == SDWebImageDownloaderLIFOQueueMode)
+        if (wself.executionOrder == SDWebImageDownloaderLIFOExecutionOrder)
         {
-            // Emulate LIFO queue mode by systematically adding new operations as last operation's dependency
+            // Emulate LIFO execution order by systematically adding new operations as last operation's dependency
             [wself.lastAddedOperation addDependency:operation];
             wself.lastAddedOperation = operation;
         }


### PR DESCRIPTION
To avoid of logical inconsistencies in naming I rename SDWebImageDownloaderQueueMode because "queue" notion is a FIFO only, but LIFO is a stack, and if we give the type a neutral name, we can avoid logical inconsistencies. Added description for renamed type, fixed typo and fixed potential strong cycle in Example.
