### PR TITLE
-getSize now returns an `unsigned long long`.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -134,7 +134,7 @@ typedef enum SDImageCacheType SDImageCacheType;
 /**
  * Get the size used by the disk cache
  */
-- (int)getSize;
+- (unsigned long long)getSize;
 
 /**
  * Get the number of images in the disk cache

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -284,9 +284,9 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     });
 }
 
--(int)getSize
+-(unsigned long long)getSize
 {
-    int size = 0;
+    unsigned long long size = 0;
     NSDirectoryEnumerator *fileEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:self.diskCachePath];
     for (NSString *fileName in fileEnumerator)
     {


### PR DESCRIPTION
This type now matches the type and width of the value returned by the
`fileSize` accessor of the `NSDictionary (NSFileAttributes)` category
(which is what is used when accumulating the total cache size).
