### PR TITLE
Support a maximum disk cache size in -cleanDisk.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -38,6 +38,11 @@ typedef enum SDImageCacheType SDImageCacheType;
 @property (assign, nonatomic) NSInteger maxCacheAge;
 
 /**
+ * The maximum size of the cache, in bytes.
+ */
+@property (assign, nonatomic) unsigned long long maxCacheSize;
+
+/**
  * Returns global shared cache instance
  *
  * @return SDImageCache global instance

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -255,30 +255,76 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 {
     dispatch_async(self.ioQueue, ^
     {
-        NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.maxCacheAge];
-        // convert NSString path to NSURL path
+        NSFileManager *fileManager = [NSFileManager defaultManager];
         NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
-        // build an enumerator by also prefetching file properties we want to read
-        NSDirectoryEnumerator *fileEnumerator = [[NSFileManager defaultManager] enumeratorAtURL:diskCacheURL
-                                                                     includingPropertiesForKeys:@[ NSURLIsDirectoryKey, NSURLContentModificationDateKey ]
-                                                                                        options:NSDirectoryEnumerationSkipsHiddenFiles
-                                                                                   errorHandler:NULL];
+        NSArray *resourceKeys = @[ NSURLIsDirectoryKey, NSURLContentModificationDateKey, NSURLTotalFileAllocatedSizeKey ];
+
+        // This enumerator prefetches useful properties for our cache files.
+        NSDirectoryEnumerator *fileEnumerator = [fileManager enumeratorAtURL:diskCacheURL
+                                                  includingPropertiesForKeys:resourceKeys
+                                                                     options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                                errorHandler:NULL];
+
+        NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.maxCacheAge];
+        NSMutableDictionary *cacheFiles = [NSMutableDictionary dictionary];
+        unsigned long long currentCacheSize = 0;
+
+        // Enumerate all of the files in the cache directory.  This loop has two purposes:
+        //
+        //  1. Removing files that are older than the expiration date.
+        //  2. Storing file attributes for the size-based cleanup pass.
         for (NSURL *fileURL in fileEnumerator)
         {
-            // skip folder
-            NSNumber *isDirectory;
-            [fileURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:NULL];
-            if ([isDirectory boolValue])
+            NSDictionary *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:NULL];
+
+            // Skip directories.
+            if ([resourceValues[NSURLIsDirectoryKey] boolValue])
             {
                 continue;
             }
-            
-            // compare file date with the max age
-            NSDate *fileModificationDate;
-            [fileURL getResourceValue:&fileModificationDate forKey:NSURLContentModificationDateKey error:NULL];
-            if ([[fileModificationDate laterDate:expirationDate] isEqualToDate:expirationDate])
+
+            // Remove files that are older than the expiration date;
+            NSDate *modificationDate = resourceValues[NSURLContentModificationDateKey];
+            if ([[modificationDate laterDate:expirationDate] isEqualToDate:expirationDate])
             {
-                [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+                [fileManager removeItemAtURL:fileURL error:nil];
+                continue;
+            }
+
+            // Store a reference to this file and account for its total size.
+            NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+            currentCacheSize += [totalAllocatedSize unsignedLongLongValue];
+            [cacheFiles setObject:resourceValues forKey:fileURL];
+        }
+
+        // If our remaining disk cache exceeds a configured maximum size, perform a second
+        // size-based cleanup pass.  We delete the oldest files first.
+        if (self.maxCacheSize > 0 && currentCacheSize > self.maxCacheSize)
+        {
+            // Target half of our maximum cache size for this cleanup pass.
+            const unsigned long long desiredCacheSize = self.maxCacheSize / 2;
+
+            // Sort the remaining cache files by their last modification time (oldest first).
+            NSArray *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
+                                                            usingComparator:^NSComparisonResult(id obj1, id obj2)
+            {
+                return [obj1[NSURLContentModificationDateKey] compare:obj2[NSURLContentModificationDateKey]];
+            }];
+
+            // Delete files until we fall below our desired cache size.
+            for (NSURL *fileURL in sortedFiles)
+            {
+                if ([fileManager removeItemAtURL:fileURL error:nil])
+                {
+                    NSDictionary *resourceValues = cacheFiles[fileURL];
+                    NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+                    currentCacheSize -= [totalAllocatedSize unsignedLongLongValue];
+
+                    if (currentCacheSize < desiredCacheSize)
+                    {
+                        break;
+                    }
+                }
             }
         }
     });


### PR DESCRIPTION
Previously, -cleanDisk would only remove cache files that were older
than the configured expiration date.  This allowed the disk cache to
grow significantly if a large number of resources were cached over a
short period of time.

This change adds a second (optional) size-based cleaning pass that
removes files from the disk cache until its overall size falls below
half of the configured maximum size.  Older files are deleted first.

The size-based pass is disabled by default (maxCacheSize == 0).
