### PR TITLE
Remove double import for SDWebImageDecoder.h

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -9,7 +9,6 @@
 #import "SDImageCache.h"
 #import "SDWebImageDecoder.h"
 #import <CommonCrypto/CommonDigest.h>
-#import "SDWebImageDecoder.h"
 #import <mach/mach.h>
 #import <mach/mach_host.h>
 


### PR DESCRIPTION
Hello Mr. rs,
Thank you for very useuful library.

SDWebImageDecoder.h is imported twice at SDImageCache.m
