### PR TITLE
Fix completionBlock setter semantics

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -17,7 +17,7 @@
 @property (assign, nonatomic) NSUInteger skippedCount;
 @property (assign, nonatomic) NSUInteger finishedCount;
 @property (assign, nonatomic) NSTimeInterval startedTime;
-@property (SDDispatchQueueSetterSementics, nonatomic) void (^completionBlock)(NSUInteger, NSUInteger);
+@property (copy, nonatomic) void (^completionBlock)(NSUInteger, NSUInteger);
 
 @end
 


### PR DESCRIPTION
Using `SDDispatchQueueSetterSementics`, which might be `assign` for a block is a terrible idea.
