### PR TITLE
SDWebImageOperation - Trying to avoid crashes #341 and #364

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -160,10 +160,7 @@
             self.progressBlock(0, expected);
         }
 
-        dispatch_async(self.queue, ^
-        {
-            self.imageData = [NSMutableData.alloc initWithCapacity:expected];
-        });
+        self.imageData = [NSMutableData.alloc initWithCapacity:expected];
     }
     else
     {
@@ -182,11 +179,11 @@
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
 {
-    dispatch_async(self.queue, ^
-    {
-        [self.imageData appendData:data];
+    [self.imageData appendData:data];
 
-        if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0 && self.completedBlock)
+    if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0 && self.completedBlock)
+    {
+        dispatch_async(self.queue, ^
         {
             // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
             // Thanks to the author @Nyx0uf
@@ -254,7 +251,8 @@
             }
 
             CFRelease(imageSource);
-        }
+        });
+        
         NSUInteger received = self.imageData.length;
         dispatch_async(dispatch_get_main_queue(), ^
         {
@@ -263,7 +261,7 @@
                 self.progressBlock(received, self.expectedSize);
             }
         });
-    });
+    }
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)aConnection


### PR DESCRIPTION
This is an attempt to avoid the crashes in #341.  It won't fix the underlying issue but I hope it will avoid it in most cases.  The various crash reports indicate the underlying download operation is being freed before the async block in dataReceived is being executed.  This fix change tries to avoid every calling the async block.  

In addition I would like to remove all these async blocks on the main queue.  Besides not working (we see a ton of crashes in this code - happy to forward them all), I am using SDWebImage to download map tiles on a background thread via the use of a NSURLProtocol.  The callbacks should come back on that thread, but the async blocks make the impossible.  

Instead, it should be the responsibility of the calling code of the download operation that sets things up on the right thread/queue, not the download operation itself.  So if I want to start a download on a background thread, the callbacks should come back on that thread (obviously NRURLConnection will do the actual download on whatever thread it wants).

Happy to put a patch together if that makes sense to you.

Thanks - Charlie
