### PR TITLE
fix alpha pngs turning into white pngs

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -160,7 +160,7 @@
 
                             if (transformedImage && finished)
                             {
-                                NSData *dataToStore = isImageGIF ? data : nil;
+                                NSData *dataToStore = [transformedImage isEqual:downloadedImage] ? data : nil;
                                 [self.imageCache storeImage:transformedImage imageData:dataToStore forKey:key toDisk:cacheOnDisk];
                             }
                         });


### PR DESCRIPTION
Issue #26 still occurs when your delegate responds to imageManager:transformDownloadedImage:withURL:.

This commit fixes it, but only if your transform method doesn't touch any pngs with alpha.
