### PR TITLE
Synchronize self.failedURLs

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -83,7 +83,13 @@
     __block SDWebImageCombinedOperation *operation = SDWebImageCombinedOperation.new;
     __weak SDWebImageCombinedOperation *weakOperation = operation;
     
-    if (!url || !completedBlock || (!(options & SDWebImageRetryFailed) && [self.failedURLs containsObject:url]))
+    BOOL isFailedUrl = NO;
+    @synchronized(self.failedURLs)
+    {
+        isFailedUrl = [self.failedURLs containsObject:url];
+    }
+
+    if (!url || !completedBlock || (!(options & SDWebImageRetryFailed) && isFailedUrl))
     {
         if (completedBlock) completedBlock(nil, nil, SDImageCacheTypeNone, NO);
         return operation;


### PR DESCRIPTION
Images can be downloaded in multiple threads.  If you happen to have a lot of invalid urls (which we do in our staging environment), running an app sooner or later will cause it to terminate with a   **\* Terminating app due to uncaught exception 'NSGenericException', reason: '**\* Collection <__NSArrayM: 0x1e0cc0e0> was mutated while being enumerated.'

The attached pull request attempts to fix this error.

Below is full stack trace 

<pre>
Last Exception Backtrace:
0   CoreFoundation                  0x3416229e __exceptionPreprocess + 158
1   libobjc.A.dylib                 0x3bfbb97a objc_exception_throw + 26
2   CoreFoundation                  0x34161d80 __NSFastEnumerationMutationHandler + 124
3   CoreFoundation                  0x340bdcee -[NSArray containsObject:] + 134
4   iddba                           0x0030ebae -[SDWebImageManager downloadWithURL:options:progress:completed:] (SDWebImageManager.m:81)
5   iddba                           0x00311150 -[SDWebImagePrefetcher startPrefetchingAtIndex:] (SDWebImagePrefetcher.m:59)
6   iddba                           0x00311468 __48-[SDWebImagePrefetcher startPrefetchingAtIndex:]_block_invoke (SDWebImagePrefetcher.m:78)
7   iddba                           0x0030f918 __64-[SDWebImageManager downloadWithURL:options:progress:completed:]_block_invoke_2 (SDWebImageManager.m:126)
8   iddba                           0x0030d422 __72-[SDWebImageDownloader downloadImageWithURL:options:progress:completed:]_block_invoke70 (SDWebImageDownloader.m:147)
9   iddba                           0x00314438 -[SDWebImageDownloaderOperation connection:didReceiveResponse:] (SDWebImageDownloaderOperation.m:162)
10  Foundation                      0x34a9d6f8 __65-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]_block_invoke_0 + 12
11  Foundation                      0x349dd1f4 -[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:] + 196
12  Foundation                      0x349dd110 -[NSURLConnectionInternal _withActiveConnectionAndDelegate:] + 56
13  Foundation                      0x349df1f2 _NSURLConnectionDidReceiveResponse + 78
14  CFNetwork                       0x33e3fb3c ___delegate_didReceiveResponse_block_invoke_0 + 40
15  CFNetwork                       0x33e3eb3e ___withDelegateAsync_block_invoke_0 + 50
16  CFNetwork                       0x33e66fc6 ___performAsync_block_invoke_068 + 14
17  CoreFoundation                  0x340a8748 CFArrayApplyFunction + 172
18  CFNetwork                       0x33e67426 RunloopBlockContext::perform() + 70
19  CFNetwork                       0x33dcb038 MultiplexerSource::perform() + 184
20  CoreFoundation                  0x3413767e __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 10
21  CoreFoundation                  0x34136ee4 __CFRunLoopDoSources0 + 208
22  CoreFoundation                  0x34135cb2 __CFRunLoopRun + 642
23  CoreFoundation                  0x340a8eb8 CFRunLoopRunSpecific + 352
24  CoreFoundation                  0x341079b6 CFRunLoopRun + 94
25  iddba                           0x003139ae -[SDWebImageDownloaderOperation start] (SDWebImageDownloaderOperation.m:73)
26  Foundation                      0x34a67bde __block_global_6 + 98
27  libdispatch.dylib               0x3c3d311a _dispatch_call_block_and_release + 6
28  libdispatch.dylib               0x3c3d795c _dispatch_root_queue_drain + 248
29  libdispatch.dylib               0x3c3d7abc _dispatch_worker_thread2 + 80
30  libsystem_c.dylib               0x3c407a0c _pthread_wqthread + 356
31  libsystem_c.dylib               0x3c4078a0 start_wqthread + 4
</pre>
