### PR TITLE
Prevent warnings on iOS

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -30,9 +30,13 @@
 #endif
 
 #if OS_OBJECT_USE_OBJC
+    #undef SDDispatchQueueRelease
+    #undef SDDispatchQueueSetterSementics
     #define SDDispatchQueueRelease(q)
     #define SDDispatchQueueSetterSementics strong
 #else
+    #undef SDDispatchQueueRelease
+    #undef SDDispatchQueueSetterSementics
     #define SDDispatchQueueRelease(q) (dispatch_release(q))
     #define SDDispatchQueueSetterSementics assign
 #endif


### PR DESCRIPTION
Undefine macros before define to prevent warning on iOS
