### PR TITLE
Set the image property of UIImageView on the main thread

### DIFF
--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -54,17 +54,20 @@ static char operationKey;
         __weak UIImageView *wself = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished)
         {
-            __strong UIImageView *sself = wself;
-            if (!sself) return;
-            if (image)
-            {
-                sself.image = image;
-                [sself setNeedsLayout];
-            }
-            if (completedBlock && finished)
-            {
-                completedBlock(image, error, cacheType);
-            }
+            if (!wself) return;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                __strong UIImageView *sself = wself;
+                if (!sself) return;
+                if (image)
+                {
+                    sself.image = image;
+                    [sself setNeedsLayout];
+                }
+                if (completedBlock && finished)
+                {
+                    completedBlock(image, error, cacheType);
+                }
+            });
         }];
         objc_setAssociatedObject(self, &operationKey, operation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }


### PR DESCRIPTION
This sets the image property of the UIImageView on the main thread. This handles it in a different way than pull request #398 in that the completedBlock of downloadWithURL does not always need to be on the main thread, but actually setting the image view property does need to be on the main thread.
