### PR TITLE
Make UIKit related method calls back on the main thread

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -99,11 +99,13 @@ static char operationKey;
         __weak UIButton *wself = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished)
         {
-            __strong UIButton *sself = wself;
-            if (!sself) return;
             if (image)
             {
-                [sself setBackgroundImage:image forState:state];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    __strong UIButton *sself = wself;
+                    if (!sself) return;
+                    [sself setBackgroundImage:image forState:state];
+                });
             }
             if (completedBlock && finished)
             {

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -54,12 +54,14 @@ static char operationKey;
         __weak UIImageView *wself = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished)
         {
-            __strong UIImageView *sself = wself;
-            if (!sself) return;
             if (image)
             {
-                sself.image = image;
-                [sself setNeedsLayout];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    __strong UIImageView *sself = wself;
+                    if (!sself) return;
+                    sself.image = image;
+                    [sself setNeedsLayout];                    
+                });
             }
             if (completedBlock && finished)
             {


### PR DESCRIPTION
UIKit calls should only happen on the main thread. This pull request is almost the same as:

https://github.com/rs/SDWebImage/pull/403

except it only captures sself as a strong reference if it needs to and it also fixes the same issue in: UIButton+WebCache
