### PR TITLE
Import WebP category only when the macro is activated.

### DIFF
--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -8,7 +8,10 @@
 
 #import "UIImage+MultiFormat.h"
 #import "UIImage+GIF.h"
+
+#ifdef SD_WEBP
 #import "UIImage+WebP.h"
+#endif
 
 @implementation UIImage (MultiFormat)
 


### PR DESCRIPTION
Someone may not include UIImage+WebP.h/m to their project.
