### PR TITLE
Add -calculateSizeWithCompletionBlock:.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -154,4 +154,9 @@ typedef enum SDImageCacheType SDImageCacheType;
  */
 - (int)getDiskCount;
 
+/**
+ * Asynchronously calculate the disk cache's size.
+ */
+- (void)calculateSizeWithCompletionBlock:(void (^)(NSUInteger fileCount, unsigned long long totalSize))completionBlock;
+
 @end

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -423,4 +423,37 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     return count;
 }
 
+- (void)calculateSizeWithCompletionBlock:(void (^)(NSUInteger fileCount, unsigned long long totalSize))completionBlock
+{
+    NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
+
+    dispatch_async(self.ioQueue, ^
+    {
+        NSUInteger fileCount = 0;
+        unsigned long long totalSize = 0;
+
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSDirectoryEnumerator *fileEnumerator = [fileManager enumeratorAtURL:diskCacheURL
+                                                  includingPropertiesForKeys:@[ NSFileSize ]
+                                                                     options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                                errorHandler:NULL];
+
+        for (NSURL *fileURL in fileEnumerator)
+        {
+            NSNumber *fileSize;
+            [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:NULL];
+            totalSize += [fileSize unsignedLongLongValue];
+            fileCount += 1;
+        }
+
+        if (completionBlock)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^
+            {
+                completionBlock(fileCount, totalSize);
+            });
+        }
+    });
+}
+
 @end


### PR DESCRIPTION
This method provides a way to asynchronously calculate the size of the
disk cache, reporting both the number of files and the total file
size.

This is useful when querying large disk caches because the file system
enumeration operation can take some time.
