### PR TITLE
Added option to not set the image in the imageView upon completion.

### DIFF
--- a/SDWebImage/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MKAnnotationView+WebCache.m
@@ -54,7 +54,7 @@ static char operationKey;
             {
                 __strong MKAnnotationView *sself = wself;
                 if (!sself) return;
-                if (image)
+                if (image && !(options & SDWebImageDontSetImageWhenFinished))
                 {
                     sself.image = image;
                 }

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -40,7 +40,11 @@ typedef enum
      *
      * Use this flag only if you can't make your URLs static with embeded cache busting parameter.
      */
-    SDWebImageRefreshCached = 1 << 4
+    SDWebImageRefreshCached = 1 << 4,
+    /**
+     * Won't set the image to the image view, only cache it and pass it to the finished callback.
+     */
+    SDWebImageDontSetImageWhenFinished = 1 << 5
 } SDWebImageOptions;
 
 typedef void(^SDWebImageCompletedBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType);

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -53,7 +53,7 @@ static char operationKey;
             {
                 __strong UIButton *sself = wself;
                 if (!sself) return;
-                if (image)
+                if (image && !(options & SDWebImageDontSetImageWhenFinished))
                 {
                     [sself setImage:image forState:state];
                 }

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -59,7 +59,7 @@ static char operationKey;
             {
                 __strong UIImageView *sself = wself;
                 if (!sself) return;
-                if (image)
+                if (image && !(options & SDWebImageDontSetImageWhenFinished))
                 {
                     sself.image = image;
                     [sself setNeedsLayout];


### PR DESCRIPTION
I was using SDWebImage as part of an `NSOperation` and I wanted to manually set the image after completion only if the operation hadn't already been cancelled.

I don't know if this is useful for anyone else, but I figured I'd share :)
