### PR TITLE
Break a retain cycle

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -160,6 +160,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
             [wself.lastAddedOperation addDependency:operation];
             wself.lastAddedOperation = operation;
         }
+        operation = nil; // break retain cycle
     }];
 
     return operation;


### PR DESCRIPTION
Breaking a retain cycle that seems to be at the root of some table scrolling lockup problems. See https://github.com/rs/SDWebImage/issues/425
