### PR TITLE
Use an empty string to if str was NULL.

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -112,6 +112,9 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 - (NSString *)cachedFileNameForKey:(NSString *)key
 {
     const char *str = [key UTF8String];
+    if (str == NULL) {
+        str = "";
+    }
     unsigned char r[CC_MD5_DIGEST_LENGTH];
     CC_MD5(str, (CC_LONG)strlen(str), r);
     NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",


### PR DESCRIPTION
I fixed 'cachedFileNameForKey:' on SDImageCache.m.
Because seg fault happened on strlen when 'key' is nil. 
