### PR TITLE
Canceling image loading for SDWebImageManager fires completion handler

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -107,7 +107,13 @@
 
     [self.imageCache queryDiskCacheForKey:key done:^(UIImage *image, SDImageCacheType cacheType)
     {
-        if (operation.isCancelled) return;
+        if (operation.isCancelled) {
+			NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+												 code:NSURLErrorCancelled
+											 userInfo:nil];
+			completedBlock(image, error, cacheType, YES);
+			return;
+		}
 
         if ((!image || options & SDWebImageRefreshCached) && (![self.delegate respondsToSelector:@selector(imageManager:shouldDownloadImageForURL:)] || [self.delegate imageManager:self shouldDownloadImageForURL:url]))
         {


### PR DESCRIPTION
 with error domain `NSURLErrorDomain` and code `NSURLErrorCancelled` so UI can react accordingly
When using `SDWebImage` for example to load `UIImageView`'s image I have a spinner that suppose to appear when any of images started to load and stopping when all of them finished to load
Sadly, there is no way to know when image download was canceled so I introduced following code to handle it
