### PR TITLE
Canceling the SDWebImageOperation will also cancel the disk cache query operation

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -98,7 +98,7 @@ typedef enum SDImageCacheType SDImageCacheType;
  *
  * @param key The unique key used to store the wanted image
  */
-- (void)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock;
+- (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock;
 
 /**
  * Query the memory cache synchronously.

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -251,14 +251,16 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     return SDScaledImageForKey(key, image);
 }
 
-- (void)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock
+- (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(void (^)(UIImage *image, SDImageCacheType cacheType))doneBlock
 {
-    if (!doneBlock) return;
+    NSOperation *operation = NSOperation.new;
+    
+    if (!doneBlock) return nil;
 
     if (!key)
     {
         doneBlock(nil, SDImageCacheTypeNone);
-        return;
+        return nil;
     }
 
     // First check the in-memory cache...
@@ -266,11 +268,16 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     if (image)
     {
         doneBlock(image, SDImageCacheTypeMemory);
-        return;
+        return nil;
     }
 
     dispatch_async(self.ioQueue, ^
     {
+        if (operation.isCancelled)
+        {
+            return;
+        }
+        
         @autoreleasepool
         {
             UIImage *diskImage = [self diskImageForKey:key];
@@ -286,6 +293,8 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
             });
         }
     });
+    
+    return operation;
 }
 
 - (void)removeImageForKey:(NSString *)key


### PR DESCRIPTION
I noticed that with particularly large images, pulling the disk image from cache and decoding it was taking a considerable amount of time, and in cases where large images were used in UITableViews, these queries were stacking up and causing memory pressure and terminated apps.

I added an NSOperation as a sentinel that the parent (SDWebImageManager) could mark as cancelled, so these stacked queries would not execute.
