### PR TITLE
The callbacksForURL: method in SDWebImageDownloader should return a copy of the mutable array!

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -208,7 +208,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     {
         callbacksForURL = self.URLCallbacks[url];
     });
-    return callbacksForURL;
+    return [callbacksForURL copy];
 }
 
 - (void)removeCallbacksForURL:(NSURL *)url


### PR DESCRIPTION
Since the callback array is used for fast enumeration and could be mutated via removeCallbacksForURL, a copy of the mutable array should be returned instead of the mutable array reference. It is also a recommendation since the method signature indicates the return type as NSArray.

This should fix the crash in multithread environment such as:
"Collection <__NSArrayM: 0x226d9310> was mutated while being enumerated."

This should fix the #470 issue.
