### PR TITLE
Use 'default_subspec' and separate the WebP support to its sub-spec

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -29,11 +29,13 @@ Pod::Spec.new do |s|
   s.subspec 'MapKit' do |mk|
     mk.source_files = 'SDWebImage/MKAnnotationView+WebCache.*'
     mk.framework = 'MapKit'
+    mk.dependency 'SDWebImage/Core'
   end
 
   s.subspec 'WebP' do |webp|
     webp.source_files = 'SDWebImage/UIImage+WebP.{h,m}'
     webp.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1' }
+    webp.dependency 'SDWebImage/Core'
     webp.dependency 'libwebp'
   end
 end


### PR DESCRIPTION
This removes unnecessary dependency to 'libwebp' for users who don't need WebP support.
