### PR TITLE
Fix long running requests

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -74,6 +74,11 @@
         // Note: we use a timeout to work around an issue with NSURLConnection cancel under iOS 5
         //       not waking up the runloop, leading to dead threads (see https://github.com/rs/SDWebImage/issues/466)
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 10, false);
+        if (!self.isFinished)
+        {
+            [self.connection cancel];
+            [self connection:self.connection didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:@{NSURLErrorFailingURLErrorKey: self.request.URL}]];
+        }
     }
     else
     {


### PR DESCRIPTION
Operation was not finished properly, creating dead operation which is never ended. So when queue max concurrent operation is full, queue freezes all next operations.
