### PR TITLE
Fixed multiple instantiation of SDWebImageDownloader

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -42,7 +42,7 @@
     if ((self = [super init]))
     {
         _imageCache = [self createCache];
-        _imageDownloader = SDWebImageDownloader.new;
+        _imageDownloader = [SDWebImageDownloader sharedDownloader];
         _failedURLs = NSMutableArray.new;
         _runningOperations = NSMutableArray.new;
     }


### PR DESCRIPTION
Existing implementation instantiates a new copy of SDWebImageDownloader inside SDWebImageManager. So UIImage categories will eventually use the new copy of SDWebImageDownloader to download images, instead of using the global singleton. 

This makes it impossible to, for example, set custom header to the SDWebImageDownloader inside SDWebImageManager because there are no direct access to that new copy. 

A better implementation would be to reuse the global singleton via [SDWebImageDownloader sharedDownloader] so that others could set various settings to the singleton via the same method.
