### PR TITLE
Added C# bindings for use with Xamarin.iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+*.a
+SDWebImageBinding/SDWebImage/bin
+SDWebImageBinding/SDWebImage/obj
+
 # Xcode
 build/*
 *.pbxuser

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+XBUILD=/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+PROJECT_ROOT=.
+PROJECT=$(PROJECT_ROOT)/SDWebImage.xcodeproj
+TARGET=SDWebImage
+
+all: libSDWebImage.a
+
+libSDWebImage-i386.a:
+	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -configuration Release clean build
+	-mv $(PROJECT_ROOT)/build/Release-iphonesimulator/lib$(TARGET).a $@
+
+libSDWebImage-armv7.a:
+	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphoneos -arch armv7 -configuration Release clean build
+	-mv $(PROJECT_ROOT)/build/Release-iphoneos/lib$(TARGET).a $@
+
+libSDWebImage-armv7s.a:
+	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphoneos -arch armv7s -configuration Release clean build
+	-mv $(PROJECT_ROOT)/build/Release-iphoneos/lib$(TARGET).a $@
+
+libSDWebImage.a: libSDWebImage-i386.a libSDWebImage-armv7.a libSDWebImage-armv7s.a
+	lipo -create -output $@ $^
+
+clean:
+	-rm -f *.a *.dll

--- a/SDWebImageBinding/SDWebImage/ApiDefinition.cs
+++ b/SDWebImageBinding/SDWebImage/ApiDefinition.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Drawing;
+using MonoTouch.ObjCRuntime;
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace SDWebImage 
+{
+	public delegate void SDWebImageDownloaderCompletedBlock (UIImage image, NSData data, NSError error, bool finished);
+	public delegate void SDWebImageDownloaderProgressBlock (int receivedSize, long expectedSize);
+	public delegate void SDWebImageCompletedBlock (UIImage image, NSError error, SDImageCacheType cacheType);
+	public delegate void SDWebImageCompletedWithFinishedBlock (UIImage image, NSError error, SDImageCacheType cacheType, bool finished);
+
+	public delegate void SDWebImageDoneBlock (UIImage image, SDImageCacheType cacheType);
+	public delegate void SDImageCacheCompletionBlock(int fileCount, ulong totalSize);
+	public delegate void SDWebImagePrefetcherCompletionBlock(int finishedCount, int skippedCount);
+	public delegate string SDWebImageManagerCacheKeyFilterBlock(NSUrl url);
+	public delegate void SDWebImageDownloaderOperationCancelBlock();
+
+	[Model, BaseType (typeof (NSObject))]
+	public partial interface SDWebImageOperation 
+	{
+		[Export ("cancel")]
+		void Cancel ();
+	}
+
+	[BaseType (typeof (NSObject))]
+	public partial interface SDWebImageDownloader 
+	{
+		[Export ("maxConcurrentDownloads")]
+		int MaxConcurrentDownloads { get; set; }
+
+		[Export ("executionOrder")]
+		SDWebImageDownloaderExecutionOrder ExecutionOrder { get; set; }
+
+		[Static, Export ("sharedDownloader")]
+		SDWebImageDownloader SharedDownloader { get; }
+
+		[Export ("setValue:forHTTPHeaderField:")]
+		void SetValue (string value, string field);
+
+		[Export ("valueForHTTPHeaderField:")]
+		string ValueForHTTPHeaderField (string field);
+
+		[Export ("downloadImageWithURL:options:progress:completed:")]
+		SDWebImageOperation DownloadImageWithURL (NSUrl url, SDWebImageDownloaderOptions options, SDWebImageDownloaderProgressBlock progressBlock, SDWebImageDownloaderCompletedBlock completedBlock);
+	}
+
+	[BaseType (typeof (NSObject))]
+	public partial interface SDImageCache 
+	{
+		[Export ("maxCacheAge")]
+		int MaxCacheAge { get; set; }
+
+		[Export ("maxCacheSize")]
+		ulong MaxCacheSize { get; set; }
+
+		[Static, Export ("sharedImageCache")]
+		SDImageCache SharedImageCache { get; }
+
+		[Export ("initWithNamespace:")]
+		IntPtr Constructor (string ns);
+
+		[Export ("addReadOnlyCachePath:")]
+		void AddReadOnlyCachePath (string path);
+
+		[Export ("storeImage:forKey:")]
+		void StoreImage (UIImage image, string key);
+
+		[Export ("storeImage:forKey:toDisk:")]
+		void StoreImage (UIImage image, string key, bool toDisk);
+
+		[Export ("storeImage:imageData:forKey:toDisk:")]
+		void StoreImage (UIImage image, NSData data, string key, bool toDisk);
+
+		[Export ("queryDiskCacheForKey:done:")]
+		NSOperation QueryDiskCacheForKey (string key, SDWebImageDoneBlock doneBlock);
+
+		[Export ("imageFromMemoryCacheForKey:")]
+		UIImage ImageFromMemoryCacheForKey (string key);
+
+		[Export ("imageFromDiskCacheForKey:")]
+		UIImage ImageFromDiskCacheForKey (string key);
+
+		[Export ("removeImageForKey:")]
+		void RemoveImageForKey (string key);
+
+		[Export ("removeImageForKey:fromDisk:")]
+		void RemoveImageForKey (string key, bool fromDisk);
+
+		[Export ("clearMemory")]
+		void ClearMemory ();
+
+		[Export ("clearDisk")]
+		void ClearDisk ();
+
+		[Export ("cleanDisk")]
+		void CleanDisk ();
+
+		[Export ("getSize")]
+		ulong Size { get; }
+
+		[Export ("getDiskCount")]
+		int DiskCount { get; }
+
+		[Export ("calculateSizeWithCompletionBlock:")]
+		void CalculateSizeWithCompletionBlock (SDImageCacheCompletionBlock completionBlock);
+	}
+
+	[Model, BaseType (typeof (NSObject))]
+	public partial interface SDWebImageManagerDelegate 
+	{
+		[Export ("imageManager:shouldDownloadImageForURL:")]
+		bool ShouldDownloadImageForURL (SDWebImageManager imageManager, NSUrl imageURL);
+
+		[Export ("imageManager:transformDownloadedImage:withURL:")]
+		UIImage TransformDownloadedImage (SDWebImageManager imageManager, UIImage image, NSUrl imageURL);
+	}
+
+	[BaseType (typeof (NSObject))]
+	public partial interface SDWebImageManager 
+	{
+		[Export ("delegate", ArgumentSemantic.Assign)]
+		SDWebImageManagerDelegate Delegate { get; set; }
+
+		[Export ("imageCache", ArgumentSemantic.Retain)]
+		SDImageCache ImageCache { get; }
+
+		[Export ("imageDownloader", ArgumentSemantic.Retain)]
+		SDWebImageDownloader ImageDownloader { get; }
+
+		[Export ("cacheKeyFilter", ArgumentSemantic.Retain)]
+		SDWebImageManagerCacheKeyFilterBlock CacheKeyFilter { get; set; }
+
+		[Static, Export ("sharedManager")]
+		SDWebImageManager SharedManager { get; }
+
+		[Export ("downloadWithURL:options:progress:completed:")]
+		SDWebImageOperation DownloadWithURL (NSUrl url, SDWebImageOptions options, SDWebImageDownloaderProgressBlock progressBlock, SDWebImageCompletedWithFinishedBlock completedBlock);
+
+		[Export ("cancelAll")]
+		void CancelAll ();
+
+		[Export ("isRunning")]
+		bool IsRunning { get; }
+	}
+
+	[Category, BaseType (typeof (UIImage))]
+	public partial interface ForceDecode_UIImage
+	{
+		[Static, Export ("decodedImageWithImage:")]
+		UIImage DecodedImageWithImage (UIImage image);
+	}
+
+	[BaseType (typeof (NSOperation))]
+	public partial interface SDWebImageDownloaderOperation : SDWebImageOperation 
+	{
+		[Export ("request", ArgumentSemantic.Retain)]
+		NSUrlRequest Request { get; }
+
+		[Export ("options")]
+		SDWebImageDownloaderOptions Options { get; }
+
+		[Export ("initWithRequest:options:progress:completed:cancelled:")]
+		IntPtr Constructor (NSUrlRequest request, SDWebImageDownloaderOptions options, SDWebImageDownloaderProgressBlock progressBlock, SDWebImageDownloaderCompletedBlock completedBlock, SDWebImageDownloaderOperationCancelBlock cancelBlock);
+	}
+
+	[BaseType (typeof (NSObject))]
+	public partial interface SDWebImagePrefetcher
+	{
+		[Export ("maxConcurrentDownloads")]
+		uint MaxConcurrentDownloads { get; set; }
+
+		[Export ("options")]
+		SDWebImageOptions Options { get; set; }
+
+		[Static, Export ("sharedImagePrefetcher")]
+		SDWebImagePrefetcher SharedImagePrefetcher { get; }
+
+		[Export ("prefetchURLs:")]
+		void PrefetchURLs (NSUrl [] urls);
+
+		[Export ("prefetchURLs:completed:")]
+		void PrefetchURLs (NSUrl [] urls, SDWebImagePrefetcherCompletionBlock completionBlock);
+
+		[Export ("cancelPrefetching")]
+		void CancelPrefetching ();
+	}
+	
+	[Category, BaseType (typeof (UIButton))]
+	public partial interface WebCache_UIButton 
+	{
+		[Export ("setImageWithURL:forState:")]
+		void SetImageWithURL (NSUrl url, UIControlState state);
+
+		[Export ("setImageWithURL:forState:placeholderImage:")]
+		void SetImageWithURL (NSUrl url, UIControlState state, UIImage placeholder);
+
+		[Export ("setImageWithURL:forState:placeholderImage:options:")]
+		void SetImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageOptions options);
+
+		[Export ("setImageWithURL:forState:completed:")]
+		void SetImageWithURL (NSUrl url, UIControlState state, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setImageWithURL:forState:placeholderImage:completed:")]
+		void SetImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setImageWithURL:forState:placeholderImage:options:completed:")]
+		void SetImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageOptions options, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setBackgroundImageWithURL:forState:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state);
+
+		[Export ("setBackgroundImageWithURL:forState:placeholderImage:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state, UIImage placeholder);
+
+		[Export ("setBackgroundImageWithURL:forState:placeholderImage:options:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageOptions options);
+
+		[Export ("setBackgroundImageWithURL:forState:completed:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setBackgroundImageWithURL:forState:placeholderImage:completed:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setBackgroundImageWithURL:forState:placeholderImage:options:completed:")]
+		void SetBackgroundImageWithURL (NSUrl url, UIControlState state, UIImage placeholder, SDWebImageOptions options, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("cancelCurrentImageLoad")]
+		void CancelCurrentImageLoad ();
+	}
+
+	[Category, BaseType (typeof (NSData))]
+	public partial interface GIF_NSData 
+	{
+		[Static, Export ("sd_isGIF")]
+		bool Sd_isGIF ();
+	}
+
+	[Category, BaseType (typeof (UIImage))]
+	public partial interface GIF_UIImage 
+	{
+		[Static, Export ("sd_animatedGIFNamed:")]
+		UIImage Sd_animatedGIFNamed (string name);
+
+		[Static, Export ("sd_animatedGIFWithData:")]
+		UIImage Sd_animatedGIFWithData (NSData data);
+
+		[Export ("sd_animatedImageByScalingAndCroppingToSize:")]
+		UIImage Sd_animatedImageByScalingAndCroppingToSize (SizeF size);
+	}
+
+	[Category, BaseType (typeof (UIImage))]
+	public partial interface MultiFormat_UIImage 
+	{
+		[Static, Export ("sd_imageWithData:")]
+		UIImage Sd_imageWithData (NSData data);
+	}
+
+	[Category, BaseType (typeof (UIImageView))]
+	public partial interface WebCache_UIImageView 
+	{
+		[Export ("setImageWithURL:")]
+		void SetImageWithURL (NSUrl url);
+
+		[Export ("setImageWithURL:placeholderImage:")]
+		void SetImageWithURL (NSUrl url, UIImage placeholder);
+
+		[Export ("setImageWithURL:placeholderImage:options:")]
+		void SetImageWithURL (NSUrl url, UIImage placeholder, SDWebImageOptions options);
+
+		[Export ("setImageWithURL:completed:")]
+		void SetImageWithURL (NSUrl url, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setImageWithURL:placeholderImage:completed:")]
+		void SetImageWithURL (NSUrl url, UIImage placeholder, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setImageWithURL:placeholderImage:options:completed:")]
+		void SetImageWithURL (NSUrl url, UIImage placeholder, SDWebImageOptions options, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setImageWithURL:placeholderImage:options:progress:completed:")]
+		void SetImageWithURL (NSUrl url, UIImage placeholder, SDWebImageOptions options, SDWebImageDownloaderProgressBlock progressBlock, SDWebImageCompletedBlock completedBlock);
+
+		[Export ("setAnimationImagesWithURLs:")]
+		void SetAnimationImagesWithURLs (NSUrl[] urls);
+
+		[Export ("cancelCurrentImageLoad")]
+		void CancelCurrentImageLoad ();
+
+		[Export ("cancelCurrentArrayLoad")]
+		void CancelCurrentArrayLoad ();
+	}
+}
+

--- a/SDWebImageBinding/SDWebImage/SDWebImage.csproj
+++ b/SDWebImageBinding/SDWebImage/SDWebImage.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{D1657AD6-A89D-4E33-AC91-E38348088316}</ProjectGuid>
+    <ProjectTypeGuids>{F5B4F3BC-B597-4E2B-B552-EF5D8A32436F};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SDWebImage</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>SDWebImage</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="monotouch" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Xamarin.ObjcBinding.CSharp.targets" />
+  <ItemGroup>
+    <ObjcBindingNativeLibrary Include="..\..\libSDWebImage.a">
+      <Link>libSDWebImage.a</Link>
+    </ObjcBindingNativeLibrary>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="libSDWebImage.linkwith.cs">
+      <DependentUpon>libSDWebImage.a</DependentUpon>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/SDWebImageBinding/SDWebImage/StructsAndEnums.cs
+++ b/SDWebImageBinding/SDWebImage/StructsAndEnums.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace SDWebImage
+{
+	public enum SDWebImageDownloaderOptions 
+	{
+		LowPriority = 1 << 0,
+		ProgressiveDownload = 1 << 1,
+		UseNSURLCache = 1 << 2,
+		IgnoreCachedResponse = 1 << 3
+	}
+
+	public enum SDWebImageDownloaderExecutionOrder
+	{
+		FIFOExecutionOrder,
+		LIFOExecutionOrder
+	}
+
+	public enum SDWebImageOptions
+	{
+		RetryFailed = 1 << 0,
+		LowPriority = 1 << 1,
+		CacheMemoryOnly = 1 << 2,
+		ProgressiveDownload = 1 << 3,
+		RefreshCached = 1 << 4
+	}
+
+	public enum SDImageCacheType
+	{
+		None = 0,
+		Disk,
+		Memory
+	}
+}
+

--- a/SDWebImageBinding/SDWebImage/libSDWebImage.linkwith.cs
+++ b/SDWebImageBinding/SDWebImage/libSDWebImage.linkwith.cs
@@ -1,0 +1,4 @@
+using System;
+using MonoTouch.ObjCRuntime;
+
+[assembly: LinkWith ("libSDWebImage.a", LinkTarget.Simulator | LinkTarget.ArmV7 | LinkTarget.ArmV7s, ForceLoad = true)]

--- a/SDWebImageBinding/SDWebImageBinding.sln
+++ b/SDWebImageBinding/SDWebImageBinding.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SDWebImage", "SDWebImage\SDWebImage.csproj", "{D1657AD6-A89D-4E33-AC91-E38348088316}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1657AD6-A89D-4E33-AC91-E38348088316}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1657AD6-A89D-4E33-AC91-E38348088316}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1657AD6-A89D-4E33-AC91-E38348088316}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1657AD6-A89D-4E33-AC91-E38348088316}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = SDWebImage\SDWebImage.csproj
+	EndGlobalSection
+EndGlobal

--- a/SDWebImageBinding/SDWebImageBinding.userprefs
+++ b/SDWebImageBinding/SDWebImageBinding.userprefs
@@ -1,0 +1,33 @@
+﻿<Properties>
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="SDWebImage/libSDWebImage.linkwith.cs">
+    <Files>
+      <File FileName="SDWebImage/ApiDefinition.cs" Line="142" Column="21" />
+      <File FileName="SDWebImage/StructsAndEnums.cs" Line="3" Column="21" />
+      <File FileName="SDWebImage/libSDWebImage.linkwith.cs" Line="5" Column="1" />
+    </Files>
+    <Pads>
+      <Pad Id="ProjectPad">
+        <State expanded="True">
+          <Node name="SDWebImage" expanded="True">
+            <Node name="References" expanded="True" />
+            <Node name="libSDWebImage.linkwith.cs" selected="True" />
+          </Node>
+        </State>
+      </Pad>
+      <Pad Id="ClassPad">
+        <State expanded="True" selected="True" />
+      </Pad>
+      <Pad Id="MonoDevelop.Debugger.WatchPad">
+        <State />
+      </Pad>
+      <Pad Id="ConnectionManagerPad">
+        <State selected="True" />
+      </Pad>
+    </Pads>
+  </MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>


### PR DESCRIPTION
I've created C# bindings as I'm using Xamarin.iOS for a new project. Consider these changes public domain so feel free to license as you wish.

To build the universal static lib, run "make all", then build the C# dll in Xamarin studio or with xbuild.
