### PR TITLE
Add HTTP header passing test to pick header for downloading request

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -59,6 +59,14 @@ typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, 
 + (SDWebImageDownloader *)sharedDownloader;
 
 /**
+ * Set filter to pick headers for downloading image HTTP request.
+ *
+ * This block will be invoked for each downloading image request, returned
+ * NSDictionary will be used as headers in corresponding HTTP request.
+ */
+@property (nonatomic, strong) NSDictionary *(^headersFilter)(NSURL *url, NSDictionary *headers);
+
+/**
  * Set a value for a HTTP header to be appended to each download HTTP request.
  *
  * @param value The value for the header field. Use `nil` value to remove the header.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -120,7 +120,14 @@ static NSString *const kCompletedCallbackKey = @"completed";
         NSMutableURLRequest *request = [NSMutableURLRequest.alloc initWithURL:url cachePolicy:(options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData) timeoutInterval:15];
         request.HTTPShouldHandleCookies = NO;
         request.HTTPShouldUsePipelining = YES;
-        request.allHTTPHeaderFields = wself.HTTPHeaders;
+        if (wself.headersFilter)
+        {
+            request.allHTTPHeaderFields = wself.headersFilter(url, [wself.HTTPHeaders copy]);
+        }
+        else
+        {
+            request.allHTTPHeaderFields = wself.HTTPHeaders;
+        }
         operation = [SDWebImageDownloaderOperation.alloc initWithRequest:request options:options progress:^(NSUInteger receivedSize, long long expectedSize)
         {
             if (!wself) return;


### PR DESCRIPTION
While developing my app using SDWebImage, I meet this problem: I have to download an image with OAuth 2 access token in HTTP header, so I use `-[SDWebImageDownloader setValue:forHTTPHeaderField:]` to set `Authorization` header, but doing this will include access token to _all_ the image downloading request which will expose access token. This PR could solve this problem by letting developer to choose which header to include for image URL. Sample code is shown below:

``` objc
SDWebImageManager.sharedManager.imageDownloader.HTTPHeadersPassingTest =
^BOOL(NSURL *url, NSString *field, NSString *value) {
    return [field isEqualToString:@"Authorization"] ? [url.host isEqual:@"foo.bar.com"] : YES;
};
```
