### PR TITLE
Use cache key filter when scaling an image after download

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -9,6 +9,7 @@
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageDecoder.h"
 #import "UIImage+MultiFormat.h"
+#import "SDWebImageManager.h"
 #import <ImageIO/ImageIO.h>
 
 @interface SDWebImageDownloaderOperation ()
@@ -290,8 +291,8 @@
         {
             
             UIImage *image = [UIImage sd_imageWithData:self.imageData];
-            
-            image = [self scaledImageForKey:self.request.URL.absoluteString image:image];
+            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+            image = [self scaledImageForKey:key image:image];
             
             if (!image.images) // Do not force decod animated GIFs
             {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -176,4 +176,9 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  */
 - (BOOL)diskImageExistsForURL:(NSURL *)url;
 
+/**
+ *Return the cache key for a given URL
+ */
+- (NSString *)cacheKeyForURL:(NSURL *)url;
+
 @end


### PR DESCRIPTION
We were using the raw url as the key when trying to determine if an
image was an @2x image or not. This was a problem for me because I was
pulling different sized image from a server which did not append the @2x
to the larger images. I want to the cache key filter to append @2x to
the cache key.
