### PR TITLE
Update argument list for example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
                  {
                      // progression tracking code
                  }
-                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType)
+                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished)
                  {
                      if (image)
                      {


### PR DESCRIPTION
It looks like the argument list for the `completed` block callback was updated sometime after the documentation was written (`BOOL finished` was added).
