### PR TITLE
SDWebImagePrefetcher should only perform `NSLog` statements if `SD_VERBOSE` is defined

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -63,11 +63,15 @@
 
         if (image)
         {
+#ifdef SD_VERBOSE
             NSLog(@"Prefetched %d out of %d", self.finishedCount, self.prefetchURLs.count);
+#endif
         }
         else
         {
+#ifdef SD_VERBOSE
             NSLog(@"Prefetched %d out of %d (Failed)", self.finishedCount, [self.prefetchURLs count]);
+#endif
 
             // Add last failed
             self.skippedCount++;
@@ -91,8 +95,10 @@
 
 - (void)reportStatus
 {
+#ifdef SD_VERBOSE
     NSUInteger total = [self.prefetchURLs count];
     NSLog(@"Finished prefetching (%d successful, %d skipped, timeElasped %.2f)", total - self.skippedCount, self.skippedCount, CFAbsoluteTimeGetCurrent() - self.startedTime);
+#endif
 }
 
 - (void)prefetchURLs:(NSArray *)urls


### PR DESCRIPTION
Right now, `SDWebImagePrefetcher` is very verbose. I'd suggest removing the `NSLog` statements altogether, or perhaps use some compile-time constant (like you did for `SD_WEBP`) like I did in this pull request. I changed this so  the `NSLog` statements are only invoked if `SD_VERBOSE` is defined. Otherwise, the `NSLog` statements are omitted.
