### PR TITLE
Allow setting a custom memory cost limit for the in-memory NSCache. 

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -35,7 +35,7 @@ typedef enum SDImageCacheType SDImageCacheType;
 /**
  * The maximum "total cost" of the in-memory image cache. The cost function is the number of pixels held in memory.
  */
-@property (assign, nonatomic) NSInteger maxMemoryCost;
+@property (assign, nonatomic) NSUInteger maxMemoryCost;
 
 /**
  * The maximum length of time to keep an image in the cache, in seconds

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -338,9 +338,14 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     }
 }
 
-- (void)setMaxMemoryCost:(NSInteger)maxMemoryCost
+- (void)setMaxMemoryCost:(NSUInteger)maxMemoryCost
 {
     self.memCache.totalCostLimit = maxMemoryCost;
+}
+
+- (NSUInteger)maxMemoryCost
+{
+    return self.memCache.totalCostLimit;
 }
 
 - (void)clearMemory


### PR DESCRIPTION
This can help to keep memory down before memory warnings are sent by the device.

Thanks! 
