### PR TITLE
Added PNG detection to be able to determine at runtime if a downloaded image should be saved as PNG or as JPEG

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -90,13 +90,14 @@ typedef enum SDImageCacheType SDImageCacheType;
  * Store an image into memory and optionally disk cache at the given key.
  *
  * @param image The image to store
+ * @param recalculate BOOL indicates if imageData can be used or a new data should be constructed from the UIImage
  * @param data The image data as returned by the server, this representation will be used for disk storage
  *             instead of converting the given image object into a storable/compressed image format in order
  *             to save quality and CPU
  * @param key The unique image cache key, usually it's image absolute URL
  * @param toDisk Store the image to disk cache if YES
  */
-- (void)storeImage:(UIImage *)image imageData:(NSData *)data forKey:(NSString *)key toDisk:(BOOL)toDisk;
+- (void)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk;
 
 /**
  * Query the disk cache asynchronously.

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -199,8 +199,8 @@
 
                             if (transformedImage && finished)
                             {
-                                NSData *dataToStore = [transformedImage isEqual:downloadedImage] ? data : nil;
-                                [self.imageCache storeImage:transformedImage imageData:dataToStore forKey:key toDisk:cacheOnDisk];
+                                BOOL imageWasTransformed = ![transformedImage isEqual:downloadedImage];
+                                [self.imageCache storeImage:transformedImage recalculateFromImage:imageWasTransformed imageData:data forKey:key toDisk:cacheOnDisk];
                             }
                         });
                     }
@@ -213,7 +213,7 @@
 
                         if (downloadedImage && finished)
                         {
-                            [self.imageCache storeImage:downloadedImage imageData:data forKey:key toDisk:cacheOnDisk];
+                            [self.imageCache storeImage:downloadedImage recalculateFromImage:NO imageData:data forKey:key toDisk:cacheOnDisk];
                         }
                     }
                 }


### PR DESCRIPTION
After properly reviewing the code, I noticed the change is not as big as I initially thought:
- the case where we need to extract a NSData from UIImage is only when an image was downloaded and via the `SDWebImageManagerDelegate` method `- (UIImage *)imageManager:(SDWebImageManager *)imageManager transformDownloadedImage:(UIImage *)image withURL:(NSURL *)imageURL`, the image was changed. 
- otherwise, we either use the NSData that was received from the network or, if `- (void)storeImage:(UIImage *)image forKey:(NSString *)key` or `- (void)storeImage:(UIImage *)image forKey:(NSString *)key toDisk:(BOOL)toDisk` are called, the imageData is nil so we can't determine if the file is PNG or JPEG.

For my project, the case I described first applies, since we are transforming the data after it arrives. And we do have JPEG images that would have been saved as PNG.
