### PR TITLE
Add method - managing failedURLs

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -188,6 +188,16 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 - (BOOL)isRunning;
 
 /**
+ * Remove failed URL caused from temporary unavaiables
+ */
+- (void)removeFailedURLsWithURL:(NSURL*)url;
+
+/**
+ * Clear all failed URLs for future retry
+ */
+- (void)clearFailedURLs;
+
+/**
  * Check if image has already been cached
  */
 - (BOOL)diskImageExistsForURL:(NSURL *)url;

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -225,6 +225,18 @@
     return self.runningOperations.count > 0;
 }
 
+- (void)removeFailedURLsWithURL:(NSURL*)url {
+    @synchronized (self.failedURLs) {
+        [self.failedURLs removeObject:url];
+    }
+}
+
+- (void)clearFailedURLs {
+    @synchronized (self.failedURLs) {
+        [self.failedURLs removeAllObjects];
+    }
+}
+
 @end
 
 @implementation SDWebImageCombinedOperation


### PR DESCRIPTION
If some url has failed with temporary server error or else...
then that URL always skip until app restart. 

So, added method for remove or clearing Failed URL array.
