### PR TITLE
Added method to SDWebImageManager to check if an image exists in either ...

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -190,6 +190,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 /**
  * Check if image has already been cached
  */
+- (BOOL)cachedImageExistsForURL:(NSURL *)url;
 - (BOOL)diskImageExistsForURL:(NSURL *)url;
 
 @end

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -60,6 +60,12 @@
     }
 }
 
+- (BOOL)cachedImageExistsForURL:(NSURL *)url {
+    NSString *key = [self cacheKeyForURL:url];
+    if ([self.imageCache imageFromMemoryCacheForKey:key] != nil) return YES;
+    return [self.imageCache diskImageExistsWithKey:key];
+}
+
 - (BOOL)diskImageExistsForURL:(NSURL *)url {
     NSString *key = [self cacheKeyForURL:url];
     return [self.imageCache diskImageExistsWithKey:key];


### PR DESCRIPTION
Currently SDWebImageManager contains the method `-diskImageExistsForURL:` which checks whether a given image exists in the disk cache synchronously.

However, it is often useful in custom code to check to see whether a given image exists in _either_ the disk _or_ the memory cache before starting a `downloadWithUrl:` operation.

This is as simple as calling `[manager.imageCache imageFromMemoryCacheForKey:key]` and checking for a nil result, but doing this outside `SDWebImageManager` requires bypassing any cacheKeyFilters in the instance, and parsing the URL manually into a key.

Therefore, I've added a very small utility function that checks for the presence of the image in the disk _or_ memory cache, mirroring the existing `-diskImageExistsForURL:` function exactly, but adding an additional check of the memory cache.

Please let me know if you think there are better ways to do this, or there is a reason why there was no combined check utility method previously, but it was a small and useful modification which I found useful, so thought I'd submit a pull request in case it was helpful.
