### PR TITLE
Add SDWebImageCompat.m to MKAnnotation lib target.

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
 		A18A6CCA172DC28500419892 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
 		AE26408A18CF4DA2009733D3 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
+		AE8864EB1924FADB007C36C4 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = 5DA509F2187B68E7002FEB5C /* random.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -742,6 +743,7 @@
 				53EDFCA117625C1100698166 /* vp8.c in Sources */,
 				53EDFCA917625C5B00698166 /* huffman.c in Sources */,
 				53EDFCAC17625C8700698166 /* frame.c in Sources */,
+				AE8864EB1924FADB007C36C4 /* random.c in Sources */,
 				53EDFCAF17625CA600698166 /* alpha.c in Sources */,
 				53EDFCB517625CD800698166 /* quant_levels_dec.c in Sources */,
 				53EDFCBC17625D1900698166 /* dec.c in Sources */,


### PR DESCRIPTION
Fixes build when using `SDWebImage+MKAnnotation` static lib in project under iOS 7.1 and Xcode 5.1.
