### PR TITLE
add support for high priority download

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -37,7 +37,12 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
      * Enable to allow untrusted SSL ceriticates.
      * Useful for testing purposes. Use with caution in production.
      */
-            SDWebImageDownloaderAllowInvalidSSLCertificates = 1 << 6
+            SDWebImageDownloaderAllowInvalidSSLCertificates = 1 << 6,
+    /**
+     * 
+     */
+        SDWebImageDownloaderHighPriority = 1 << 7,
+    
 
 };
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -152,6 +152,10 @@ static NSString *const kCompletedCallbackKey = @"completed";
                                                                      SDWebImageDownloader *sself = wself;
                                                                      [sself removeCallbacksForURL:url];
                                                                  }];
+        
+        if (options & SDWebImageDownloaderHighPriority) {
+            operation.queuePriority = NSOperationQueuePriorityHigh;
+        }
 
         [wself.downloadQueue addOperation:operation];
         if (wself.executionOrder == SDWebImageDownloaderLIFOExecutionOrder) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -55,7 +55,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * Enable to allow untrusted SSL ceriticates.
      * Useful for testing purposes. Use with caution in production.
      */
-            SDWebImageAllowInvalidSSLCertificates = 1 << 7
+            SDWebImageAllowInvalidSSLCertificates = 1 << 7,
+    /**
+     * By default, image are loaded in the order they were queued. This flag move them to
+     * the front of the queue and is loaded immediately instead of waiting for the current queue to be loaded (which 
+     * could take a while).
+     */
+            SDWebImageHighPriority = 1 << 8
 };
 
 typedef void(^SDWebImageCompletedBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -127,6 +127,7 @@
             if (options & SDWebImageContinueInBackground) downloaderOptions |= SDWebImageDownloaderContinueInBackground;
             if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
             if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
+            if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
             if (image && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;


### PR DESCRIPTION
This added the option to move a request to the front of the queue. In some case you want an image to be loaded immediately instead of waiting for the current queue to finish.
