### PR TITLE
Fixing race in SDWebImageDownloaderOperation leading to erroneous timeout.

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -129,6 +129,7 @@
 }
 
 - (void)cancelInternalAndStop {
+    if (self.isFinished) return;
     [self cancelInternal];
     CFRunLoopStop(CFRunLoopGetCurrent());
 }


### PR DESCRIPTION
In some cases, SDWebImage will erroneously report timeout for an image download. This is due to a race condition introduced through -performSelector:onThread:withObject:waitUntilDone:, which causes cancellation of a download operation to stop the run loop that is now used for _another_ download operation.
