### PR TITLE
Race in SDWebImageManager; occasional wrong image.

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -136,6 +136,7 @@
             }
             id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 if (weakOperation.isCancelled) {
+                    // Do nothing if the operation has been cancelled.
                 }
                 else if (error) {
                     dispatch_main_sync_safe(^{


### PR DESCRIPTION
Do not execute completion block if we've been cancelled. dispatch_main_sync_safe() does not guarantee that no other code runs until our block is executed, so the operation may have been cancelled in-between. If we call the completion block after cancellation, there's a race between this load and the subsequent image load in a table view cell, for instance.
