### PR TITLE
Failed-URL-Retries-in-SDWebImageManager

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -132,6 +132,8 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 
 @property (weak, nonatomic) id <SDWebImageManagerDelegate> delegate;
 
+//Default: 0 - add url immediatly to failed urls
+@property (assign) NSInteger maxFailedURLRetries;
 @property (strong, nonatomic, readonly) SDImageCache *imageCache;
 @property (strong, nonatomic, readonly) SDWebImageDownloader *imageDownloader;
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -22,6 +22,7 @@
 @property (strong, nonatomic, readwrite) SDImageCache *imageCache;
 @property (strong, nonatomic, readwrite) SDWebImageDownloader *imageDownloader;
 @property (strong, nonatomic) NSMutableArray *failedURLs;
+@property (strong, nonatomic) NSMutableDictionary *failedURLRequestCount;
 @property (strong, nonatomic) NSMutableArray *runningOperations;
 
 @end
@@ -43,6 +44,7 @@
         _imageDownloader = [SDWebImageDownloader new];
         _failedURLs = [NSMutableArray new];
         _runningOperations = [NSMutableArray new];
+        _failedURLRequestCount = [NSMutableDictionary new];
     }
     return self;
 }
@@ -146,8 +148,19 @@
                     });
 
                     if (error.code != NSURLErrorNotConnectedToInternet) {
-                        @synchronized (self.failedURLs) {
-                            [self.failedURLs addObject:url];
+                        BOOL retriesExeeded = NO;
+                        @synchronized (self.failedURLRequestCount) {
+                            NSNumber *count = [self.failedURLRequestCount objectForKey:url];
+                            NSInteger iCount = 1+[count integerValue];
+                            retriesExeeded = iCount > self.maxFailedURLRetries;
+                            count = [NSNumber numberWithInteger:iCount];
+                            [self.failedURLRequestCount setObject:count forKey:url];
+                        }
+                        
+                        if (retriesExeeded) {
+                            @synchronized (self.failedURLs) {
+                                [self.failedURLs addObject:url];
+                            }
                         }
                     }
                 }
@@ -162,24 +175,24 @@
                         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                             UIImage *transformedImage = [self.delegate imageManager:self transformDownloadedImage:downloadedImage withURL:url];
 
+                            dispatch_main_sync_safe(^{
+                                completedBlock(transformedImage, nil, SDImageCacheTypeNone, finished);
+                            });
+
                             if (transformedImage && finished) {
                                 BOOL imageWasTransformed = ![transformedImage isEqual:downloadedImage];
                                 [self.imageCache storeImage:transformedImage recalculateFromImage:imageWasTransformed imageData:data forKey:key toDisk:cacheOnDisk];
                             }
-
-                            dispatch_main_sync_safe(^{
-                                completedBlock(transformedImage, nil, SDImageCacheTypeNone, finished);
-                            });
                         });
                     }
                     else {
-                        if (downloadedImage && finished) {
-                            [self.imageCache storeImage:downloadedImage recalculateFromImage:NO imageData:data forKey:key toDisk:cacheOnDisk];
-                        }
-
                         dispatch_main_sync_safe(^{
                             completedBlock(downloadedImage, nil, SDImageCacheTypeNone, finished);
                         });
+
+                        if (downloadedImage && finished) {
+                            [self.imageCache storeImage:downloadedImage recalculateFromImage:NO imageData:data forKey:key toDisk:cacheOnDisk];
+                        }
                     }
                 }
 


### PR DESCRIPTION
Using the SDWebImageView category I sometimes run into the problem that a request failed, although the image link is NOT broken. 

Other people seem to be experiencing the same problem: https://github.com/rs/SDWebImage/issues/363

These small changes allow to set a variable on the image manager, which defines a number of allowed retries before the image link is marked as broken by adding it to the failedURLs-array.
