### PR TITLE
add a suspension method to image downloaders

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -148,4 +148,9 @@ typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, 
                                         progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                        completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
 
+/**
+ * Sets the download queue suspension state
+ */
+- (void)setSuspended:(BOOL)suspended;
+
 @end

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -212,4 +212,8 @@ static NSString *const kCompletedCallbackKey = @"completed";
     });
 }
 
+- (void)setSuspended:(BOOL)suspended {
+    [self.downloadQueue setSuspended:suspended];
+}
+
 @end


### PR DESCRIPTION
It is sometimes useful to pause the download queue during performance critical operations. Exposed a simple method that calls into SDWebImageDownloaders operation queue.
