### PR TITLE
Fix getter names. Fixes commit: 097b502eae

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -176,7 +176,7 @@
     [self didChangeValueForKey:@"isFinished"];
 }
 
-- (BOOL)finished
+- (BOOL)isFinished
 {
     return _finished;
 }
@@ -187,7 +187,7 @@
     [self didChangeValueForKey:@"isExecuting"];
 }
 
-- (BOOL)executing
+- (BOOL)isExecuting
 {
     return _executing;
 }


### PR DESCRIPTION
The getters of the properties “executing” and
“finished” both use custom getter names.

097b502eae implemented the wrong getter names
without the “is” prefix.
