### PR TITLE
fixed SDWebImageRefreshCached bug for large images

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -335,7 +335,11 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:SDWebImageDownloadStopNotification object:nil];
 
     SDWebImageDownloaderCompletedBlock completionBlock = self.completedBlock;
-
+    
+    if (![[NSURLCache sharedURLCache] cachedResponseForRequest:_request]) {
+        responseFromCached = NO;
+    }
+    
     if (completionBlock) {
         if (self.options & SDWebImageDownloaderIgnoreCachedResponse && responseFromCached) {
             completionBlock(nil, nil, nil, YES);


### PR DESCRIPTION
So the problem is that it thinks that the image was loaded from cache although it's actually from the remote.
connection:willCacheResponse: method of NSURLConnectionDataDelegate is not called when loading large images for the reason of that image size doesn't fit the cache size on iOS 7.
You can refer the apple documentation here.
https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLConnectionDataDelegate_protocol/Reference/Reference.html#//apple_ref/occ/intfm/NSURLConnectionDataDelegate/connection:willCacheResponse:
