### PR TITLE
Fix a potential issue (#365). If the UIImage passed as param is nil, this inline function will return a non-nil instance of UIImage

### DIFF
--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -23,7 +23,7 @@ inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image) {
         return [UIImage animatedImageWithImages:scaledImages duration:image.duration];
     }
     else {
-        if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
+        if (image && [[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
             CGFloat scale = 1.0;
             if (key.length >= 8) {
                 // Search @2x. at the end of the string, before a 3 to 4 extension length (only if key len is 8 or more @2x. + 4 len ext)


### PR DESCRIPTION
See #365 for details
