### PR TITLE
Compare requested url with returned

### DIFF
--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -52,8 +52,7 @@ static char imageURLKey;
             if (!wself) return;
             
             NSURL *lastURL = [wself sd_imageURL];
-            BOOL isMatch = [[lastURL absoluteString] isEqualToString:[imageURL absoluteString]];
-            if (!isMatch) {
+            if (![lastURL isEqual:imageURL]) {
                 dispatch_main_async_safe(^{
                     NSError *urlError = [NSError errorWithDomain:@"SDWebImageErrorDomain" code:-1 userInfo:@{NSLocalizedDescriptionKey : @"URL request/response mismatch"}];
                     if (completedBlock) {


### PR DESCRIPTION
To avoid the issue of loading the wrong image into a UIImageView, as seen on fast table scrolling and similar scenarios, we match the requested URL with the returned URL. In case of mismatch, we back out.

The benefit of this change is to put the responsibility of loading the correct image URL on the library and not the user - the details of URL matching should not be the user's responsibility. The library should only load the last requested URL's content into the UIImageView.
