### PR TITLE
fix duplicate symbols when using with webp via pods

### DIFF
--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -58,8 +58,11 @@ static void FreeImageData(void *info, const void *data, size_t size)
 
 @end
 
+#if !COCOAPODS
 // Functions to resolve some undefined symbols when using WebP and force_load flag
 void WebPInitPremultiplyNEON(void) {}
 void WebPInitUpsamplersNEON(void) {}
 void VP8DspInitNEON(void) {}
+#endif
+
 #endif


### PR DESCRIPTION
When build SDWebImage with webp support, it will fail due to "duplicate symbols".
