### PR TITLE
Fixing sd_imageOrientationFromImageData call crashes if image is nil, re...

### DIFF
--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -47,6 +47,10 @@
 +(UIImageOrientation)sd_imageOrientationFromImageData:(NSData *)imageData {
     UIImageOrientation result = UIImageOrientationUp;
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
+    if (!imageSource) {
+        // if imageSource is nil, we do not really have an image, and CFRelease will crash
+        return UIImageOrientationUp;
+    }
     CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
     if (properties) {
         CFTypeRef val;


### PR DESCRIPTION
We have seen that SDWebImage has added support for image orientation that our apps are crashing now on line 63 of UIImage+MultiFormat.m.

I do not know why, but on some circumstances it might be that imageData is nil. If that is the case, imageSource would be imageSource pointing to 0x00000000, and CFRelease'ing it throws an exception that crashes the whole app.

My suggested fix, is to check for nil on imageSource in sd_imageOrientationFromImageData, and return UIImageOrientationUp if there is no image (UIImage+Multiformat.h)
