### PR TITLE
Switch Downloader to use NSMapTable so we can avoid dispatch_barrier calls

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -20,7 +20,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
 
 @property (strong, nonatomic) NSOperationQueue *downloadQueue;
 @property (weak, nonatomic) NSOperation *lastAddedOperation;
-@property (strong, nonatomic) NSMutableDictionary *URLCallbacks;
+@property (strong, nonatomic) NSMapTable *URLCallbacks;
 @property (strong, nonatomic) NSMutableDictionary *HTTPHeaders;
 // This queue is used to serialize the handling of the network responses of all the download operation in a single queue
 @property (SDDispatchQueueSetterSementics, nonatomic) dispatch_queue_t barrierQueue;
@@ -66,7 +66,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = 2;
-        _URLCallbacks = [NSMutableDictionary new];
+        _URLCallbacks = [NSMapTable weakToStrongObjectsMapTable];
         _HTTPHeaders = [NSMutableDictionary dictionaryWithObject:@"image/webp,image/*;q=0.8" forKey:@"Accept"];
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
         _downloadTimeout = 15.0;
@@ -182,40 +182,32 @@ static NSString *const kCompletedCallbackKey = @"completed";
         }
         return;
     }
-
-    dispatch_barrier_sync(self.barrierQueue, ^{
-        BOOL first = NO;
-        if (!self.URLCallbacks[url]) {
-            self.URLCallbacks[url] = [NSMutableArray new];
-            first = YES;
-        }
-
-        // Handle single download of simultaneous download request for the same URL
-        NSMutableArray *callbacksForURL = self.URLCallbacks[url];
-        NSMutableDictionary *callbacks = [NSMutableDictionary new];
-        if (progressBlock) callbacks[kProgressCallbackKey] = [progressBlock copy];
-        if (completedBlock) callbacks[kCompletedCallbackKey] = [completedBlock copy];
-        [callbacksForURL addObject:callbacks];
-        self.URLCallbacks[url] = callbacksForURL;
-
-        if (first) {
-            createCallback();
-        }
-    });
+    
+    BOOL first = NO;
+    if (![self.URLCallbacks objectForKey:url]) {
+        [self.URLCallbacks setObject:[NSMutableArray new] forKey:url];
+        first = YES;
+    }
+    
+    // Handle single download of simultaneous download request for the same URL
+    NSMutableArray *callbacksForURL = [self.URLCallbacks objectForKey:url];
+    NSMutableDictionary *callbacks = [NSMutableDictionary new];
+    if (progressBlock) callbacks[kProgressCallbackKey] = [progressBlock copy];
+    if (completedBlock) callbacks[kCompletedCallbackKey] = [completedBlock copy];
+    [callbacksForURL addObject:callbacks];
+    
+    if (first) {
+        createCallback();
+    }
 }
 
 - (NSArray *)callbacksForURL:(NSURL *)url {
-    __block NSArray *callbacksForURL;
-    dispatch_sync(self.barrierQueue, ^{
-        callbacksForURL = self.URLCallbacks[url];
-    });
+    NSArray* callbacksForURL = [self.URLCallbacks objectForKey:url];
     return [callbacksForURL copy];
 }
 
 - (void)removeCallbacksForURL:(NSURL *)url {
-    dispatch_barrier_async(self.barrierQueue, ^{
-        [self.URLCallbacks removeObjectForKey:url];
-    });
+    [self.URLCallbacks removeObjectForKey:url];
 }
 
 - (void)setSuspended:(BOOL)suspended {


### PR DESCRIPTION
Using a weakToStrong NSMapTable removes the need for dispatch_barrier. This fixes #803 (and possibly some other performance issues on older devices).
