### PR TITLE
guarding against image source == NULL

### DIFF
--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -47,20 +47,22 @@
 +(UIImageOrientation)sd_imageOrientationFromImageData:(NSData *)imageData {
     UIImageOrientation result = UIImageOrientationUp;
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
-    CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-    if (properties) {
-        CFTypeRef val;
-        int exifOrientation;
-        val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
-        if (val) {
-            CFNumberGetValue(val, kCFNumberIntType, &exifOrientation);
-            result = [self sd_exifOrientationToiOSOrientation:exifOrientation];
-        } // else - if it's not set it remains at up
-        CFRelease((CFTypeRef) properties);
-    } else {
-        //NSLog(@"NO PROPERTIES, FAIL");
+    if (imageSource) {
+        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
+        if (properties) {
+            CFTypeRef val;
+            int exifOrientation;
+            val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
+            if (val) {
+                CFNumberGetValue(val, kCFNumberIntType, &exifOrientation);
+                result = [self sd_exifOrientationToiOSOrientation:exifOrientation];
+            } // else - if it's not set it remains at up
+            CFRelease((CFTypeRef) properties);
+        } else {
+            //NSLog(@"NO PROPERTIES, FAIL");
+        }
+        CFRelease(imageSource);
     }
-    CFRelease(imageSource);
     return result;
 }
 


### PR DESCRIPTION
Changed this code to do nothing when image source = Null, which should prevent the crash one user saw with CFRelease.
