### PR TITLE
Add Reference & Dependency Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Web Image
 [![Pod Platform](http://img.shields.io/cocoapods/p/SDWebImage.svg?style=flat)](http://cocoadocs.org/docsets/SDWebImage/)
 [![Pod License](http://img.shields.io/cocoapods/l/SDWebImage.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Dependency Status](https://www.versioneye.com/objective-c/sdwebimage/3.3/badge.svg?style=flat)](https://www.versioneye.com/objective-c/sdwebimage/3.3)
+[![Reference Status](https://www.versioneye.com/objective-c/sdwebimage/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/sdwebimage/references)
 
 This library provides a category for UIImageView with support for remote images coming from the web.
 


### PR DESCRIPTION
All dependencies are up-to-date. Keep up the good work. 
SDWebImage belongs to the 10 most referenced projects in CocoaPods. :+1: 
