### PR TITLE
Fix misnamed parameters in comment documentation

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -136,7 +136,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Remove the image from memory and disk cache synchronously
  *
  * @param key             The unique image cache key
- * @param completionBlock An block that should be executed after the image has been removed (optional)
+ * @param completion      An block that should be executed after the image has been removed (optional)
  */
 - (void)removeImageForKey:(NSString *)key withCompletion:(SDWebImageNoParamsBlock)completion;
 
@@ -153,7 +153,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  *
  * @param key             The unique image cache key
  * @param fromDisk        Also remove cache entry from disk if YES
- * @param completionBlock An block that should be executed after the image has been removed (optional)
+ * @param completion      An block that should be executed after the image has been removed (optional)
  */
 - (void)removeImageForKey:(NSString *)key fromDisk:(BOOL)fromDisk withCompletion:(SDWebImageNoParamsBlock)completion;
 
@@ -164,7 +164,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 
 /**
  * Clear all disk cached images. Non-blocking method - returns immediately.
- * @param completionBlock An block that should be executed after cache expiration completes (optional)
+ * @param completion    An block that should be executed after cache expiration completes (optional)
  */
 - (void)clearDiskOnCompletion:(SDWebImageNoParamsBlock)completion;
 


### PR DESCRIPTION
These misnamed parameters were showing warnings in projects with `-Wdocumentation` enabled.
