### PR TITLE
Allows user to override default SDWebImageDownloaderOperation

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -140,6 +140,16 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
 - (NSString *)valueForHTTPHeaderField:(NSString *)field;
 
 /**
+ * Sets a subclass of `SDWebImageDownloaderOperation` as the default
+ * `NSOperation` to be used each time SDWebImage constructs a request
+ * operation to download an image.
+ *
+ * @param operationClass The subclass of `SDWebImageDownloaderOperation` to set 
+ *        as default. Passing `nil` will revert to `SDWebImageDownloaderOperation`.
+ */
+- (void)setOperationClass:(Class)operationClass;
+
+/**
  * Creates a SDWebImageDownloader async downloader instance with a given URL
  *
  * The delegate will be informed when the image is finish downloaded or an error has happen.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -20,6 +20,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
 
 @property (strong, nonatomic) NSOperationQueue *downloadQueue;
 @property (weak, nonatomic) NSOperation *lastAddedOperation;
+@property (assign, nonatomic) Class operationClass;
 @property (strong, nonatomic) NSMutableDictionary *URLCallbacks;
 @property (strong, nonatomic) NSMutableDictionary *HTTPHeaders;
 // This queue is used to serialize the handling of the network responses of all the download operation in a single queue
@@ -63,6 +64,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
 
 - (id)init {
     if ((self = [super init])) {
+        _operationClass = [SDWebImageDownloaderOperation class];
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = 2;
@@ -104,6 +106,10 @@ static NSString *const kCompletedCallbackKey = @"completed";
     return _downloadQueue.maxConcurrentOperationCount;
 }
 
+- (void)setOperationClass:(Class)operationClass {
+    _operationClass = operationClass ?: [SDWebImageDownloaderOperation class];
+}
+
 - (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url options:(SDWebImageDownloaderOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageDownloaderCompletedBlock)completedBlock {
     __block SDWebImageDownloaderOperation *operation;
     __weak SDWebImageDownloader *wself = self;
@@ -124,34 +130,34 @@ static NSString *const kCompletedCallbackKey = @"completed";
         else {
             request.allHTTPHeaderFields = wself.HTTPHeaders;
         }
-        operation = [[SDWebImageDownloaderOperation alloc] initWithRequest:request
-                                                                   options:options
-                                                                  progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                                                                      SDWebImageDownloader *sself = wself;
-                                                                      if (!sself) return;
-                                                                      NSArray *callbacksForURL = [sself callbacksForURL:url];
-                                                                      for (NSDictionary *callbacks in callbacksForURL) {
-                                                                          SDWebImageDownloaderProgressBlock callback = callbacks[kProgressCallbackKey];
-                                                                          if (callback) callback(receivedSize, expectedSize);
-                                                                      }
-                                                                  }
-                                                                 completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
-                                                                     SDWebImageDownloader *sself = wself;
-                                                                     if (!sself) return;
-                                                                     NSArray *callbacksForURL = [sself callbacksForURL:url];
-                                                                     if (finished) {
-                                                                         [sself removeCallbacksForURL:url];
-                                                                     }
-                                                                     for (NSDictionary *callbacks in callbacksForURL) {
-                                                                         SDWebImageDownloaderCompletedBlock callback = callbacks[kCompletedCallbackKey];
-                                                                         if (callback) callback(image, data, error, finished);
-                                                                     }
-                                                                 }
-                                                                 cancelled:^{
-                                                                     SDWebImageDownloader *sself = wself;
-                                                                     if (!sself) return;
-                                                                     [sself removeCallbacksForURL:url];
-                                                                 }];
+        operation = [[wself.operationClass alloc] initWithRequest:request
+                                                          options:options
+                                                         progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                                             SDWebImageDownloader *sself = wself;
+                                                             if (!sself) return;
+                                                             NSArray *callbacksForURL = [sself callbacksForURL:url];
+                                                             for (NSDictionary *callbacks in callbacksForURL) {
+                                                                 SDWebImageDownloaderProgressBlock callback = callbacks[kProgressCallbackKey];
+                                                                 if (callback) callback(receivedSize, expectedSize);
+                                                             }
+                                                         }
+                                                        completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
+                                                            SDWebImageDownloader *sself = wself;
+                                                            if (!sself) return;
+                                                            NSArray *callbacksForURL = [sself callbacksForURL:url];
+                                                            if (finished) {
+                                                                [sself removeCallbacksForURL:url];
+                                                            }
+                                                            for (NSDictionary *callbacks in callbacksForURL) {
+                                                                SDWebImageDownloaderCompletedBlock callback = callbacks[kCompletedCallbackKey];
+                                                                if (callback) callback(image, data, error, finished);
+                                                            }
+                                                        }
+                                                        cancelled:^{
+                                                            SDWebImageDownloader *sself = wself;
+                                                            if (!sself) return;
+                                                            [sself removeCallbacksForURL:url];
+                                                        }];
         
         if (wself.username && wself.password) {
             operation.credential = [NSURLCredential credentialWithUser:wself.username password:wself.password persistence:NSURLCredentialPersistenceForSession];


### PR DESCRIPTION
Sets a subclass of `SDWebImageDownloaderOperation` as the default `NSOperation` to be used each time SDWebImage constructs a request operation to download an image.

On `setOperationClass:`, pass the subclass of `SDWebImageDownloaderOperation` to set as the default `NSOperation` class. Passing `nil` will revert to `SDWebImageDownloaderOperation`.
