### PR TITLE
Adding a flag for Cocoa Pods users

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,13 @@ Open the "Build Settings" tab, in the "Linking" section, locate the "Other Linke
 ![Other Linker Flags](http://dl.dropbox.com/u/123346/SDWebImage/10_other_linker_flags.jpg)
 
 Alternatively, if this causes compilation problems with frameworks that extend optional libraries, such as Parse,  RestKit or opencv2, instead of the -ObjC flag use:
-
 ```
 -force_load SDWebImage.framework/Versions/Current/SDWebImage
+```
+
+If you're using Cocoa Pods and have any frameworks that extend optional libraries, such as Parsen RestKit or opencv2, instead of the -ObjC flag use:
+```
+-force_load $(TARGET_BUILD_DIR)/libPods.a
 ```
 
 ### Import headers in your source files


### PR DESCRIPTION
Using the Parse framework and SDWebImage frameworks installed via Cocoa Pods gives the same error as described in the Alternatively section of the Add Linker Flag section in this Readme.
I found a solution here : http://www.deanmao.com/2012/12/31/linker-error-using-cocoapods/
