### PR TITLE
Fix implicit atomicity declaration of the SDWebImageManager.cacheKeyFilter

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -166,7 +166,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 
  * @endcode
  */
-@property (copy) SDWebImageCacheKeyFilterBlock cacheKeyFilter;
+@property (nonatomic, copy) SDWebImageCacheKeyFilterBlock cacheKeyFilter;
 
 /**
  * Returns global SDWebImageManager instance.


### PR DESCRIPTION
The atomicity of the `cacheKeyFilter` in `SDWebImageManager` was implicitly declared `atomic`.

I declared it as `nonatomic` as that's fairly standard on iOS, and I reckon if someone needs atomic access to the filter they may need it at a larger grainularity than simply accessing the variable itself. But of course, if the intent is for this to be `atomic`, at least explicitly declare it as such.

See also `CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES`
