### PR TITLE
Increased default maxConcurrentOperationCount, fixes #527

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -65,7 +65,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     if ((self = [super init])) {
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
-        _downloadQueue.maxConcurrentOperationCount = 2;
+        _downloadQueue.maxConcurrentOperationCount = 6;
         _URLCallbacks = [NSMutableDictionary new];
         _HTTPHeaders = [NSMutableDictionary dictionaryWithObject:@"image/webp,image/*;q=0.8" forKey:@"Accept"];
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderBarrierQueue", DISPATCH_QUEUE_CONCURRENT);


### PR DESCRIPTION
The default maxConcurrentOperationCount is set way too low in the image downloader (see issue #527). By increasing it, table/collection view performance is drastically improved. Especially when downloading images of mixed file sizes, as in the demo project.
