### PR TITLE
Switch to built in XCTest async

### DIFF
--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -3,7 +3,6 @@ workspace '../SDWebImage'
 
 def import_pods
   pod 'Expecta'                       # A Matcher Framework for Objective-C/Cocoa
-  pod 'XCTestAsync'                   # Extension to XCTest for asynchronous testing
   pod 'SDWebImage', :path => '../'
 end
 

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -10,7 +10,6 @@
 
 
 #import <XCTest/XCTest.h>
-#import <XCTestAsync/XCTestAsync.h>
 #import <Expecta.h>
 
 #import "SDImageCache.h"

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -10,7 +10,6 @@
 
 
 #import <XCTest/XCTest.h>
-#import <XCTestAsync/XCTestAsync.h>
 #import <Expecta.h>
 
 #import "SDWebImageManager.h"
@@ -37,20 +36,25 @@ static int64_t kAsyncTestTimeout = 5;
 }
 
 - (void)testThatDownloadInvokesCompletionBlockWithCorrectParamsAsync {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image download completes"];
+
     NSURL *originalImageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/656/177/44771656:jpeg_preview_small.jpg?20120509154705"];
     
     [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         expect(image).toNot.beNil();
         expect(error).to.beNil();
         expect(originalImageURL).to.equal(imageURL);
-        
-        XCAsyncSuccess();
+
+        [expectation fulfill];
+        expectation = nil;
     }];
-    
-    XCAsyncFailAfter(kAsyncTestTimeout, @"Download image timed out");
+
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
 
 - (void)testThatDownloadWithIncorrectURLInvokesCompletionBlockWithAnErrorAsync {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image download completes"];
+
     NSURL *originalImageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/656/177/44771656:jpeg_preview_small.png"];
     
     [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
@@ -58,10 +62,11 @@ static int64_t kAsyncTestTimeout = 5;
         expect(error).toNot.beNil();
         expect(originalImageURL).to.equal(imageURL);
         
-        XCAsyncSuccess();
+        [expectation fulfill];
+        expectation = nil;
     }];
     
-    XCAsyncFailAfter(kAsyncTestTimeout, @"Download image timed out");
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
 
 @end

--- a/Tests/Tests/UIImageMultiFormatTests.m
+++ b/Tests/Tests/UIImageMultiFormatTests.m
@@ -10,7 +10,6 @@
 
 
 #import <XCTest/XCTest.h>
-#import <XCTestAsync/XCTestAsync.h>
 #import <Expecta.h>
 
 #import "UIImage+MultiFormat.h"


### PR DESCRIPTION
XCTest now has built in async support. Let's use that instead of XCTestAsync.
