### PR TITLE
Handle empty urls NSArray

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -120,10 +120,16 @@
     self.completionBlock = completionBlock;
     self.progressBlock = progressBlock;
 
-    // Starts prefetching from the very first image on the list with the max allowed concurrency
-    NSUInteger listCount = self.prefetchURLs.count;
-    for (NSUInteger i = 0; i < self.maxConcurrentDownloads && self.requestedCount < listCount; i++) {
-        [self startPrefetchingAtIndex:i];
+    if(urls.count == 0){ 
+        if(completionBlock){
+            completionBlock(0,0);
+        }
+    }else{
+        // Starts prefetching from the very first image on the list with the max allowed concurrency
+        NSUInteger listCount = self.prefetchURLs.count;
+        for (NSUInteger i = 0; i < self.maxConcurrentDownloads && self.requestedCount < listCount; i++) {
+            [self startPrefetchingAtIndex:i];
+        }
     }
 }
 


### PR DESCRIPTION
In some cases the user may end up with an empty urls NSArray, in which case the completion block is never called.
This commit handle such case to call immediately the completion block (if any)
