### PR TITLE
initialise kPNGSignatureData data

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -48,7 +48,6 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     static id instance;
     dispatch_once(&once, ^{
         instance = [self new];
-        kPNGSignatureData = [NSData dataWithBytes:kPNGSignatureBytes length:8];
     });
     return instance;
 }
@@ -60,6 +59,9 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 - (id)initWithNamespace:(NSString *)ns {
     if ((self = [super init])) {
         NSString *fullNamespace = [@"com.hackemist.SDWebImageCache." stringByAppendingString:ns];
+
+        // initialise PNG signature data
+        kPNGSignatureData = [NSData dataWithBytes:kPNGSignatureBytes length:8];
 
         // Create IO serial queue
         _ioQueue = dispatch_queue_create("com.hackemist.SDWebImageCache", DISPATCH_QUEUE_SERIAL);


### PR DESCRIPTION
in SDImageCache initWithNamespace method.
This ensures the kPNGSignatureData is always initialised even if we
alloc SDImageCache without using the sharedImageCache singleton
this should take care of issues [26](https://github.com/rs/SDWebImage/issues/26),[55](http://github.com/rs/SDWebImage/issues/55),[878](http://github.com/rs/SDWebImage/issues/878)
