### PR TITLE
Add url as param to progress block

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {
 extern NSString *const SDWebImageDownloadStartNotification;
 extern NSString *const SDWebImageDownloadStopNotification;
 
-typedef void(^SDWebImageDownloaderProgressBlock)(NSInteger receivedSize, NSInteger expectedSize);
+typedef void(^SDWebImageDownloaderProgressBlock)(NSInteger receivedSize, NSInteger expectedSize, NSURL *targetURL);
 
 typedef void(^SDWebImageDownloaderCompletedBlock)(UIImage *image, NSData *data, NSError *error, BOOL finished);
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -132,13 +132,13 @@ static NSString *const kCompletedCallbackKey = @"completed";
         }
         operation = [[wself.operationClass alloc] initWithRequest:request
                                                           options:options
-                                                         progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                                         progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL *targetURL) {
                                                              SDWebImageDownloader *sself = wself;
                                                              if (!sself) return;
                                                              NSArray *callbacksForURL = [sself callbacksForURL:url];
                                                              for (NSDictionary *callbacks in callbacksForURL) {
                                                                  SDWebImageDownloaderProgressBlock callback = callbacks[kProgressCallbackKey];
-                                                                 if (callback) callback(receivedSize, expectedSize);
+                                                                 if (callback) callback(receivedSize, expectedSize, targetURL);
                                                              }
                                                          }
                                                         completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -93,7 +93,7 @@
 
     if (self.connection) {
         if (self.progressBlock) {
-            self.progressBlock(0, NSURLResponseUnknownLength);
+            self.progressBlock(0, NSURLResponseUnknownLength, self.request.URL);
         }
         [[NSNotificationCenter defaultCenter] postNotificationName:SDWebImageDownloadStartNotification object:self];
 
@@ -201,7 +201,7 @@
         NSInteger expected = response.expectedContentLength > 0 ? (NSInteger)response.expectedContentLength : 0;
         self.expectedSize = expected;
         if (self.progressBlock) {
-            self.progressBlock(0, expected);
+            self.progressBlock(0, expected, self.request.URL);
         }
 
         self.imageData = [[NSMutableData alloc] initWithCapacity:expected];
@@ -303,7 +303,7 @@
     }
 
     if (self.progressBlock) {
-        self.progressBlock(self.imageData.length, self.expectedSize);
+        self.progressBlock(self.imageData.length, self.expectedSize, self.request.URL);
     }
 }
 


### PR DESCRIPTION
When tableView reuses a UITableViewCell, the progress block in every cell can't recognize the status of cells, which creates a trouble for updating every cell's progressView, so adding url as callback param can help to make a unique "id".
