### PR TITLE
duplicate failed urls are added into failedURLs

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -194,7 +194,9 @@
 
                     if (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut) {
                         @synchronized (self.failedURLs) {
-                            [self.failedURLs addObject:url];
+                            if (![self.failedURLs containsObject:url]) {
+                                [self.failedURLs addObject:url];
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
fix bug when download image with option SDWebImageRetryFailed。
if set download image options with SDWebImageRetryFailed, then image url will stall try to download, and it always failed again, then this url is added into failedURLs, and there is no judgement to process duplicate url.
