### PR TITLE
Use ImageIO to retrieve cache from disk

### DIFF
--- a/SDWebImage/UIImage+GIF.h
+++ b/SDWebImage/UIImage+GIF.h
@@ -8,13 +8,19 @@
  */
 
 #import "SDWebImageCompat.h"
+#import <ImageIO/ImageIO.h>
 
 @interface UIImage (GIF)
 
 /**
- *  Compatibility method - creates an animated UIImage from an NSData, it will only contain the 1st frame image
+ *  Compatibility method - creates an static UIImage from an NSData, it will only contain the 1st frame image
  */
-+ (UIImage *)sd_animatedGIFWithData:(NSData *)data;
++ (UIImage *)sd_staticGIFImageWithData:(NSData *)data;
+
+/**
+ *  Compatibility method - creates an static UIImage from a CGImageSourceRef, it will only contain the 1st frame image
+ */
++ (UIImage *)sd_staticGIFImageWithCGImageSource:(CGImageSourceRef)imageSource;
 
 /**
  *  Checks if an UIImage instance is a GIF. Will use the `images` array

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -8,13 +8,12 @@
  */
 
 #import "UIImage+GIF.h"
-#import <ImageIO/ImageIO.h>
 #import "objc/runtime.h"
 #import "NSImage+WebCache.h"
 
 @implementation UIImage (GIF)
 
-+ (UIImage *)sd_animatedGIFWithData:(NSData *)data {
++ (UIImage *)sd_staticGIFImageWithData:(NSData *)data {
     if (!data) {
         return nil;
     }
@@ -28,28 +27,34 @@
     if (count <= 1) {
         staticImage = [[UIImage alloc] initWithData:data];
     } else {
-        // we will only retrieve the 1st frame. the full GIF support is available via the FLAnimatedImageView category.
-        // this here is only code to allow drawing animated images as static ones
-#if SD_WATCH
-        CGFloat scale = 1;
-        scale = [WKInterfaceDevice currentDevice].screenScale;
-#elif SD_UIKIT
-        CGFloat scale = 1;
-        scale = [UIScreen mainScreen].scale;
-#endif
-        
-        CGImageRef CGImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
-#if SD_UIKIT || SD_WATCH
-        UIImage *frameImage = [UIImage imageWithCGImage:CGImage scale:scale orientation:UIImageOrientationUp];
-        staticImage = [UIImage animatedImageWithImages:@[frameImage] duration:0.0f];
-#elif SD_MAC
-        staticImage = [[UIImage alloc] initWithCGImage:CGImage size:NSZeroSize];
-#endif
-        CGImageRelease(CGImage);
+        staticImage = [self sd_staticGIFImageWithCGImageSource:source];
     }
 
     CFRelease(source);
 
+    return staticImage;
+}
+
++ (UIImage *)sd_staticGIFImageWithCGImageSource:(CGImageSourceRef)imageSource {
+    UIImage *staticImage;
+    // we will only retrieve the 1st frame. the full GIF support is available via the FLAnimatedImageView category.
+    // this here is only code to allow drawing animated images as static ones
+#if SD_WATCH
+    CGFloat scale = 1;
+    scale = [WKInterfaceDevice currentDevice].screenScale;
+#elif SD_UIKIT
+    CGFloat scale = 1;
+    scale = [UIScreen mainScreen].scale;
+#endif
+
+    CGImageRef CGImage = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
+#if SD_UIKIT || SD_WATCH
+    UIImage *frameImage = [UIImage imageWithCGImage:CGImage scale:scale orientation:UIImageOrientationUp];
+    staticImage = [UIImage animatedImageWithImages:@[frameImage] duration:0.0f];
+#elif SD_MAC
+    staticImage = [[UIImage alloc] initWithCGImage:CGImage size:NSZeroSize];
+#endif
+    CGImageRelease(CGImage);
     return staticImage;
 }
 

--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -8,11 +8,14 @@
 
 #import "SDWebImageCompat.h"
 #import "NSData+ImageContentType.h"
+#import <ImageIO/ImageIO.h>
 
 @interface UIImage (MultiFormat)
 
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data;
 - (nullable NSData *)sd_imageData;
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat;
-
+#if SD_UIKIT || SD_WATCH
++ (UIImageOrientation)sd_imageOrientationFromCGImageSource:(nonnull CGImageSourceRef)imageSource;
+#endif
 @end


### PR DESCRIPTION
### New Pull Request Checklist
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
- [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
- [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
- [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necesarry)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)
### Pull Request Description

This fixed #386 by using ImageIO methods to retrieve data from disk cache. 

To accomplish this goal, this change rewrites the reading part in `SDImageCache`. To be specific, `sd_imageWithData` in `UIImage+MultiFormat` is no longer used when reading cache from disk. New implementation prioritizes ImageIO methods over `NSData`. This leads to somehow duplicate implementation both in `UIImage+MultiFormat` and `SDImageCache`. I don't like duplications, but I think this one actually makes sense. Because the data-to-image process _should_ be different between reading from Internet and reading from disk. This gives us more options and more potentials for optimization, such as this PR.
