### PR TITLE
Add `SDImageCacheScaleDownLargeImages` to allow cache to scale down large images if need

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -33,7 +33,12 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
      * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously.
      */
-    SDImageCacheQueryDiskSync = 1 << 1
+    SDImageCacheQueryDiskSync = 1 << 1,
+    /**
+     * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
+     * images to a size compatible with the constrained memory of devices.
+     */
+    SDImageCacheScaleDownLargeImages = 1 << 2
 };
 
 typedef void(^SDCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -440,11 +440,16 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key data:(nullable NSData *)data {
+    return [self diskImageForKey:key data:data options:0];
+}
+
+- (nullable UIImage *)diskImageForKey:(nullable NSString *)key data:(nullable NSData *)data options:(SDImageCacheOptions)options {
     if (data) {
         UIImage *image = [[SDWebImageCodersManager sharedInstance] decodedImageWithData:data];
         image = [self scaledImageForKey:key image:image];
         if (self.config.shouldDecompressImages) {
-            image = [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&data options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
+            BOOL shouldScaleDown = options & SDImageCacheScaleDownLargeImages;
+            image = [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&data options:@{SDWebImageCoderScaleDownLargeImagesKey: @(shouldScaleDown)}];
         }
         return image;
     } else {
@@ -495,7 +500,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                 cacheType = SDImageCacheTypeMemory;
             } else if (diskData) {
                 // decode image data only if in-memory cache missed
-                diskImage = [self diskImageForKey:key data:diskData];
+                diskImage = [self diskImageForKey:key data:diskData options:options];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
                     NSUInteger cost = SDCacheCostForImage(diskImage);
                     [self.memCache setObject:diskImage forKey:key cost:cost];

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -148,6 +148,7 @@
     SDImageCacheOptions cacheOptions = 0;
     if (options & SDWebImageQueryDataWhenInMemory) cacheOptions |= SDImageCacheQueryDataWhenInMemory;
     if (options & SDWebImageQueryDiskSync) cacheOptions |= SDImageCacheQueryDiskSync;
+    if (options & SDWebImageScaleDownLargeImages) cacheOptions |= SDImageCacheScaleDownLargeImages;
     
     __weak SDWebImageCombinedOperation *weakOperation = operation;
     operation.cacheOperation = [self.imageCache queryCacheOperationForKey:key options:cacheOptions done:^(UIImage *cachedImage, NSData *cachedData, SDImageCacheType cacheType) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2273

### Pull Request Description

It seems that current `SDWebImageScaleDownLargeImages` only works for image download from network. Some user want this options to works for disk cache as well. (Which may because that disk cache images are stored manually without download).

So, I can just add a option for cache as well, to use the same process for download. But without syncing the scaled down images back to disk (Which may cause many problems, such as cache invalid and duplicated scale down).

PS: To say, current scale down image processing code is not works so well. The original of that code is from [Apple's demo project](https://developer.apple.com/library/content/samplecode/LargeImageDownsizing/Introduction/Intro.html#//apple_ref/doc/uid/DTS40011173-Intro-DontLinkElementID_2). Though the algorithm using tile images to render can work theoretically. However, it's a little out of date. The best practice to do this is using Core Graphics do draw with lower sample quality, or using vImage framework to process it. But since this feature it not quite so common, we just leave it. I'll refactor it implementation maybe after 5.x release or some future days. 