### PR TITLE
Revert the hack code for FLAnimatedImage compatible, because of the FLAnimatedImage initializer method block main queue.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -113,6 +113,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                    options:(SDWebImageOptions)options
                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
+    dispatch_group_t group = dispatch_group_create();
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
@@ -121,6 +122,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                        setImageBlock:^(UIImage *image, NSData *imageData) {
                            __strong typeof(weakSelf)strongSelf = weakSelf;
                            if (!strongSelf) {
+                               dispatch_group_leave(group);
                                return;
                            }
                            // Step 1. Check memory cache (associate object)
@@ -130,6 +132,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                // FLAnimatedImage framework contains a bug that cause GIF been rotated if previous rendered image orientation is not Up. We have to call `setImage:` with non-nil image to reset the state. See `https://github.com/rs/SDWebImage/issues/2402`
                                strongSelf.image = associatedAnimatedImage.posterImage;
                                strongSelf.animatedImage = associatedAnimatedImage;
+                               dispatch_group_leave(group);
                                return;
                            }
                            // Step 2. Check if original compressed image data is "GIF"
@@ -137,29 +140,39 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                            if (!isGIF) {
                                strongSelf.image = image;
                                strongSelf.animatedImage = nil;
+                               dispatch_group_leave(group);
                                return;
                            }
-                           // Step 3. Check if data exist or query disk cache
-                           if (!imageData) {
-                               NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
-                               imageData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
-                           }
-                           // Step 4. Create FLAnimatedImage
-                           FLAnimatedImage *animatedImage = SDWebImageCreateFLAnimatedImage(strongSelf, imageData);
-                           // Step 5. Set animatedImage or normal image
-                           if (animatedImage) {
-                               if (strongSelf.sd_cacheFLAnimatedImage) {
-                                   image.sd_FLAnimatedImage = animatedImage;
+                           // Hack, mark we need should use dispatch group notify for completedBlock
+                           objc_setAssociatedObject(group, &SDWebImageInternalSetImageGroupKey, @(YES), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                           dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                               // Step 3. Check if data exist or query disk cache
+                               __block NSData *gifData = imageData;
+                               if (!gifData) {
+                                   NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
+                                   gifData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
                                }
-                               strongSelf.image = animatedImage.posterImage;
-                               strongSelf.animatedImage = animatedImage;
-                           } else {
-                               strongSelf.image = image;
-                               strongSelf.animatedImage = nil;
-                           }
+                               // Step 4. Create FLAnimatedImage
+                               FLAnimatedImage *animatedImage = SDWebImageCreateFLAnimatedImage(strongSelf, gifData);
+                               dispatch_async(dispatch_get_main_queue(), ^{
+                                   // Step 5. Set animatedImage or normal image
+                                   if (animatedImage) {
+                                       if (strongSelf.sd_cacheFLAnimatedImage) {
+                                           image.sd_FLAnimatedImage = animatedImage;
+                                       }
+                                       strongSelf.image = animatedImage.posterImage;
+                                       strongSelf.animatedImage = animatedImage;
+                                   } else {
+                                       strongSelf.image = image;
+                                       strongSelf.animatedImage = nil;
+                                   }
+                                   dispatch_group_leave(group);
+                               });
+                           });
                        }
                             progress:progressBlock
-                           completed:completedBlock];
+                           completed:completedBlock
+                             context:@{SDWebImageInternalSetImageGroupKey : group}];
 }
 
 @end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -137,7 +137,9 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                            }
                            // Step 2. Check if original compressed image data is "GIF"
                            BOOL isGIF = (image.sd_imageFormat == SDImageFormatGIF || [NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF);
-                           if (!isGIF) {
+                           // Check if placeholder, which does not trigger a backup disk cache query
+                           BOOL isPlaceholder = (image == placeholder);
+                           if (!isGIF || isPlaceholder) {
                                strongSelf.image = image;
                                strongSelf.animatedImage = nil;
                                dispatch_group_leave(group);

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -13,7 +13,7 @@
 /**
  A Dispatch group to maintain setImageBlock and completionBlock. This key should be used only internally and may be changed in the future. (dispatch_group_t)
  */
-FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey __deprecated_msg("Key Deprecated. Does nothing. This key should be used only internally");
+FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
 /**
  A SDWebImageManager instance to control the image download and cache process using in UIImageView+WebCache category and likes. If not provided, use the shared manager (SDWebImageManager)
  */


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2404

### Pull Request Description

Since we still need the FLAnimatedImage hack code, because the user complain about the first time create`FLAnimatedImage` instance will block the main queue. And the solution is #2404 to create it on the global queue.

Because this is a compatible hack code, I think we should not introduce too much of thing for this. I provide a much simple solution, but make it works the same effect without any performance lost and still use the GCD, which is much stable.

PS: To say, I think this performance issue should be reported to the https://github.com/Flipboard/FLAnimatedImage team, to allow user to skip that for-in loop using `CGImageSoureCreateImageAtIndex`, which will cause a full decoding process and consume CPU. The correct way of checking, you can use `CGImageSourceCopyPropertiesAtIndex ` or `CGImageSourceCreateThumbnailAtIndex`, which don't do a full resolution bitmap decoding and reduce much of cost. Anyway, it's just my opinion.