### PR TITLE
Add `SDWebImageAvoidConcurrentDecode` options to allow disable the concurrent decoding in decoding queue, use the delegate queue to do decoding.

### DIFF
--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -175,7 +175,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. However, you can specify to preload all frames into memory to reduce CPU usage when the animated image is shared by lots of imageViews.
      * This will actually trigger `preloadAllAnimatedImageFrames` in the background queue(Disk Cache & Download only).
      */
-    SDWebImagePreloadAllFrames = 1 << 20
+    SDWebImagePreloadAllFrames = 1 << 20,
+    
+    /**
+     * By default, for `SDWebImageDownloader`, we decoding the image in a seperate queue after image data was downloaded. However, this will cause multiple decoding process running concurrently, each decoding need to allocate some memory buffer for bitmap and may cause memory peak or crash for really large images. Using this can disable it and use the URLSession delegate queue and decodig serially.
+     * This options is also useful if you want to do progerssive decoding for large images. Which will reduce too frequently decoding process and reduce CPU && memory usage.
+     */
+    SDWebImageAvoidConcurrentDecode = 1 << 21
 };
 
 

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -82,7 +82,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from network
      */
-    SDWebImageDownloaderPreloadAllFrames = 1 << 11
+    SDWebImageDownloaderPreloadAllFrames = 1 << 11,
+    
+    /**
+     * By default, for `SDWebImageDownloader`, we decoding the image in a seperate queue after image data was downloaded. However, this will cause multiple decoding process running concurrently, each decoding need to allocate some memory buffer for bitmap and may cause memory peak or crash for really large images. Using this can disable it and use the URLSession delegate queue and decodig serially.
+     * This options is also useful if you want to do progerssive decoding for large images. Which will reduce too frequently decoding process and reduce CPU && memory usage.
+     */
+    SDWebImageDownloaderAvoidConcurrentDecode = 1 << 12
 };
 
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadStartNotification;

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -512,6 +512,7 @@ didReceiveResponse:(NSURLResponse *)response
     if (options & SDWebImageAvoidDecodeImage) downloaderOptions |= SDWebImageDownloaderAvoidDecodeImage;
     if (options & SDWebImageDecodeFirstFrameOnly) downloaderOptions |= SDWebImageDownloaderDecodeFirstFrameOnly;
     if (options & SDWebImagePreloadAllFrames) downloaderOptions |= SDWebImageDownloaderPreloadAllFrames;
+    if (options & SDWebImageAvoidConcurrentDecode) downloaderOptions |= SDWebImageDownloaderAvoidConcurrentDecode;
     
     if (cachedImage && options & SDWebImageRefreshCached) {
         // force progressive off if image already cached but forced refreshing


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2477 

### Pull Request Description

The second solution or attempt to solve the #2477 . The first one is here #2478 

This time, we leave the choice for user. User can decide whether to use the concurrent decoding in coder queue, or use the URLSession delegate queue for sync decoding (the behavior prior to 4.2.0).

In my opinion, I don't think this is a good choice. Because even assume me as a user, I feel a little confused to decide which one to use. Because sometimes we load image from arbitrary web site and CDN images. We don't know what resolution of image will be downloaded. So it's hard to decide whether to enable this options or not.

Don't merge until we find a final resolution for that issue.

