### PR TITLE
For now, just a demo of an idea regarding #2477. Using `NSOperationQueue` to run the decoding. Always have just one progressive decode op per download.

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -32,6 +32,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 @interface SDWebImageDownloader () <NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
 @property (strong, nonatomic, nonnull) NSOperationQueue *downloadQueue;
+@property (strong, nonatomic, nonnull) NSOperationQueue *decodeQueue;
 @property (weak, nonatomic, nullable) NSOperation *lastAddedOperation;
 @property (strong, nonatomic, nonnull) NSMutableDictionary<NSURL *, NSOperation<SDWebImageDownloaderOperation> *> *URLOperations;
 @property (copy, atomic, nullable) NSDictionary<NSString *, NSString *> *HTTPHeaders; // Since modify this value is rare, use immutable object can enhance performance. But should mark as atomic to keep thread-safe
@@ -91,6 +92,8 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = _config.maxConcurrentDownloads;
         _downloadQueue.name = @"com.hackemist.SDWebImageDownloader";
+        _decodeQueue = [NSOperationQueue new];
+        _decodeQueue.name = @"com.hackemist.SDWebImageDownloader.decode";
         _URLOperations = [NSMutableDictionary new];
         NSMutableDictionary<NSString *, NSString *> *headerDictionary = [NSMutableDictionary dictionary];
         NSString *userAgent = nil;
@@ -264,7 +267,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     } else {
         operationClass = [SDWebImageDownloaderOperation class];
     }
-    NSOperation<SDWebImageDownloaderOperation> *operation = [[operationClass alloc] initWithRequest:request inSession:self.session options:options context:context];
+    NSOperation<SDWebImageDownloaderOperation> *operation = [[operationClass alloc] initWithRequest:request inSession:self.session options:options decodeQueue:self.decodeQueue context:context];
     
     if ([operation respondsToSelector:@selector(setCredential:)]) {
         if (self.config.urlCredential) {

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -26,11 +26,13 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @required
 - (nonnull instancetype)initWithRequest:(nullable NSURLRequest *)request
                               inSession:(nullable NSURLSession *)session
-                                options:(SDWebImageDownloaderOptions)options;
+                                options:(SDWebImageDownloaderOptions)options
+                            decodeQueue:(nonnull NSOperationQueue *)decodeQueue;
 
 - (nonnull instancetype)initWithRequest:(nullable NSURLRequest *)request
                               inSession:(nullable NSURLSession *)session
                                 options:(SDWebImageDownloaderOptions)options
+                            decodeQueue:(nonnull NSOperationQueue *)decodeQueue
                                 context:(nullable SDWebImageContext *)context;
 
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
@@ -105,7 +107,8 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
  */
 - (nonnull instancetype)initWithRequest:(nullable NSURLRequest *)request
                               inSession:(nullable NSURLSession *)session
-                                options:(SDWebImageDownloaderOptions)options;
+                                options:(SDWebImageDownloaderOptions)options
+                            decodeQueue:(nonnull NSOperationQueue *)decodeQueue;
 
 /**
  *  Initializes a `SDWebImageDownloaderOperation` object
@@ -122,6 +125,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nonnull instancetype)initWithRequest:(nullable NSURLRequest *)request
                               inSession:(nullable NSURLSession *)session
                                 options:(SDWebImageDownloaderOptions)options
+                            decodeQueue:(nonnull NSOperationQueue *)decodeQueue
                                 context:(nullable SDWebImageContext *)context NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -189,7 +189,8 @@
     
     SDWebImageDownloaderOperation *operation = [[SDWebImageDownloaderOperation alloc] initWithRequest:request
                                                                                             inSession:nil
-                                                                                              options:0];
+                                                                                              options:0
+                                                                                          decodeQueue:[NSOperationQueue new]];
     [operation addHandlersForProgress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL *imageURL) {
         
     } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {

--- a/Tests/Tests/SDWebImageTestDownloadOperation.m
+++ b/Tests/Tests/SDWebImageTestDownloadOperation.m
@@ -52,11 +52,18 @@
     [self didChangeValueForKey:@"isExecuting"];
 }
 
-- (instancetype)initWithRequest:(NSURLRequest *)request inSession:(NSURLSession *)session options:(SDWebImageDownloaderOptions)options {
-    return [self initWithRequest:request inSession:session options:options context:nil];
+- (instancetype)initWithRequest:(NSURLRequest *)request
+                      inSession:(NSURLSession *)session
+                        options:(SDWebImageDownloaderOptions)options
+                    decodeQueue:(NSOperationQueue *)decodeQueue {
+    return [self initWithRequest:request inSession:session options:options decodeQueue:decodeQueue context:nil];
 }
 
-- (instancetype)initWithRequest:(NSURLRequest *)request inSession:(NSURLSession *)session options:(SDWebImageDownloaderOptions)options context:(SDWebImageContext *)context {
+- (instancetype)initWithRequest:(NSURLRequest *)request
+                      inSession:(NSURLSession *)session
+                        options:(SDWebImageDownloaderOptions)options
+                    decodeQueue:(NSOperationQueue *)decodeQueue
+                        context:(SDWebImageContext *)context {
     self = [super init];
     if (self) {
         self.request = request;


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

