### PR TITLE
Fix memory cache image cost miscalculation

### DIFF
--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -13,7 +13,8 @@ NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
 #if SD_MAC
     return image.size.height * image.size.width;
 #elif SD_UIKIT || SD_WATCH
-    return image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
+    NSUInteger imageSize = image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
+    return image.images ? (imageSize * image.images.count) : imageSize;
 #endif
 }
 

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -13,7 +13,7 @@ NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
 #if SD_MAC
     return image.size.height * image.size.width;
 #elif SD_UIKIT || SD_WATCH
-    return image.size.height * image.size.width * image.scale * image.scale;
+    return image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
 #endif
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

We get the wrong bytes when calculate cost. We should take `bytesPerPixel` into account (actually it's 4, but let's use `CGImageGetBitsPerPixel` to keep robust). It would leads to higher memory threshold and may causes crash IMO.
