### PR TITLE
Fix memory cache image cost miscalculation for 4.x

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -37,6 +37,18 @@
 		00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A721BC4880E00A5A117 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0A21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0B21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0C21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0D21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0E21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA0F21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E9EFA1021983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
+		0E9EFA1121983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
+		0E9EFA1221983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
+		0E9EFA1321983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
+		0E9EFA1421983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
+		0E9EFA1521983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */; };
 		320224BB203979BA00E9F285 /* SDAnimatedImageRep.h in Headers */ = {isa = PBXBuildFile; fileRef = 320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320224BC203979BA00E9F285 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
 		321DB3612011D4D70015D2CB /* NSButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1289,6 +1301,8 @@
 
 /* Begin PBXFileReference section */
 		00733A4C1BC487C000A5A117 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+CacheMemoryCost.h"; sourceTree = "<group>"; };
+		0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+CacheMemoryCost.m"; sourceTree = "<group>"; };
 		320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDAnimatedImageRep.h; sourceTree = "<group>"; };
 		320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDAnimatedImageRep.m; sourceTree = "<group>"; };
 		321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSButton+WebCache.h"; path = "SDWebImage/NSButton+WebCache.h"; sourceTree = "<group>"; };
@@ -1790,6 +1804,8 @@
 				321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */,
 				AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */,
 				AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */,
+				0E9EFA0821983283005D7892 /* UIImage+CacheMemoryCost.h */,
+				0E9EFA0921983283005D7892 /* UIImage+CacheMemoryCost.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -2018,6 +2034,7 @@
 				4369C27A1D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				80377DCC1F2F66A700F89830 /* lossless_common.h in Headers */,
 				321E60971F38E8ED00405457 /* SDWebImageImageIOCoder.h in Headers */,
+				0E9EFA0D21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				43A918671D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				431739571CDFC8B70008FEB9 /* encode.h in Headers */,
 				00733A6F1BC4880E00A5A117 /* UIImage+WebP.h in Headers */,
@@ -2109,6 +2126,7 @@
 				4314D16D1D0E0E3B004B36C9 /* SDImageCache.h in Headers */,
 				4314D16F1D0E0E3B004B36C9 /* NSData+ImageContentType.h in Headers */,
 				80377C121F2F666300F89830 /* bit_reader_inl_utils.h in Headers */,
+				0E9EFA0B21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				4314D1701D0E0E3B004B36C9 /* mux.h in Headers */,
 				321E60871F38E8C800405457 /* SDWebImageCoder.h in Headers */,
 				80377EA21F2F66D400F89830 /* vp8i_dec.h in Headers */,
@@ -2175,6 +2193,7 @@
 				431BB6DC1D06D2C1006A3455 /* UIButton+WebCache.h in Headers */,
 				431BB6E11D06D2C1006A3455 /* SDWebImage.h in Headers */,
 				80377E311F2F66A800F89830 /* yuv.h in Headers */,
+				0E9EFA0E21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				80377ECA1F2F66D500F89830 /* common_dec.h in Headers */,
 				80377C771F2F666400F89830 /* thread_utils.h in Headers */,
 				80377E1F1F2F66A800F89830 /* mips_macro.h in Headers */,
@@ -2264,6 +2283,7 @@
 				4397D2C81D0DDD8C00BB2784 /* SDWebImageCompat.h in Headers */,
 				4397D2CB1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.h in Headers */,
 				4397D2CC1D0DDD8C00BB2784 /* mux.h in Headers */,
+				0E9EFA0F21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				80377C911F2F666400F89830 /* thread_utils.h in Headers */,
 				4397D2D01D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.h in Headers */,
 				4397D2D11D0DDD8C00BB2784 /* decode.h in Headers */,
@@ -2334,6 +2354,7 @@
 				80377D871F2F66A700F89830 /* lossless_common.h in Headers */,
 				321E60961F38E8ED00405457 /* SDWebImageImageIOCoder.h in Headers */,
 				4A2CAE041AB4BB5400B6BC39 /* SDWebImage.h in Headers */,
+				0E9EFA0C21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				431739511CDFC8B70008FEB9 /* format_constants.h in Headers */,
 				43A918661D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				323F8B701F38EF770092B609 /* delta_palettization_enc.h in Headers */,
@@ -2429,6 +2450,7 @@
 				80377D0B1F2F66A100F89830 /* mips_macro.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
 				4369C2771D9807EC007E863A /* UIView+WebCache.h in Headers */,
+				0E9EFA0A21983283005D7892 /* UIImage+CacheMemoryCost.h in Headers */,
 				80377CEF1F2F66A100F89830 /* dsp.h in Headers */,
 				80377C011F2F665300F89830 /* filters_utils.h in Headers */,
 				5376131C155AD0D5005750A4 /* SDWebImageManager.h in Headers */,
@@ -2698,6 +2720,7 @@
 				323F8BBD1F38EF770092B609 /* predictor_enc.c in Sources */,
 				3290FA0D1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
 				80377DBD1F2F66A700F89830 /* dec.c in Sources */,
+				0E9EFA1321983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				00733A561BC4880000A5A117 /* SDWebImageDownloaderOperation.m in Sources */,
 				80377DE71F2F66A700F89830 /* upsampling.c in Sources */,
 				321E60C71F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
@@ -2972,6 +2995,7 @@
 				321E60B71F38E90100405457 /* SDWebImageWebPCoder.m in Sources */,
 				80377D5D1F2F66A700F89830 /* upsampling.c in Sources */,
 				80377D251F2F66A700F89830 /* argb.c in Sources */,
+				0E9EFA1121983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				80377D281F2F66A700F89830 /* cost_mips32.c in Sources */,
 				323F8BF11F38EF770092B609 /* anim_encode.c in Sources */,
 				4314D1551D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.m in Sources */,
@@ -3116,6 +3140,7 @@
 				321E60BA1F38E90100405457 /* SDWebImageWebPCoder.m in Sources */,
 				80377E2C1F2F66A800F89830 /* upsampling.c in Sources */,
 				80377DF41F2F66A800F89830 /* argb.c in Sources */,
+				0E9EFA1421983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				80377DF71F2F66A800F89830 /* cost_mips32.c in Sources */,
 				323F8BF41F38EF770092B609 /* anim_encode.c in Sources */,
 				80377C6E1F2F666400F89830 /* quant_levels_dec_utils.c in Sources */,
@@ -3134,6 +3159,7 @@
 				80377E511F2F66A800F89830 /* filters_mips_dsp_r2.c in Sources */,
 				80377E371F2F66A800F89830 /* argb_mips_dsp_r2.c in Sources */,
 				80377E471F2F66A800F89830 /* dec.c in Sources */,
+				0E9EFA1521983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				80377C921F2F666400F89830 /* utils.c in Sources */,
 				4397D27E1D0DDD8C00BB2784 /* UIImage+GIF.m in Sources */,
 				321E60911F38E8C800405457 /* SDWebImageCoder.m in Sources */,
@@ -3282,6 +3308,7 @@
 				323F8BBC1F38EF770092B609 /* predictor_enc.c in Sources */,
 				3290FA0C1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
 				80377D781F2F66A700F89830 /* dec.c in Sources */,
+				0E9EFA1221983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				80377DA21F2F66A700F89830 /* upsampling.c in Sources */,
 				80377C401F2F666300F89830 /* rescaler_utils.c in Sources */,
 				321E60C61F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
@@ -3430,6 +3457,7 @@
 				323F8BBA1F38EF770092B609 /* predictor_enc.c in Sources */,
 				3290FA0A1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
 				80377CEE1F2F66A100F89830 /* dec.c in Sources */,
+				0E9EFA1021983283005D7892 /* UIImage+CacheMemoryCost.m in Sources */,
 				80377D181F2F66A100F89830 /* upsampling.c in Sources */,
 				80377C0C1F2F665300F89830 /* rescaler_utils.c in Sources */,
 				321E60C41F38E91700405457 /* UIImage+ForceDecode.m in Sources */,

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -15,6 +15,13 @@
 #import "NSData+ImageContentType.h"
 #import "UIImageView+WebCache.h"
 #import "UIImage+MultiFormat.h"
+#import "UIImage+CacheMemoryCost.h"
+
+static inline NSUInteger SDWebImageCalculateFLAnimatedImageMemoryCost(FLAnimatedImage *image) {
+    UIImage *posterImage = image.posterImage;
+    // Calculate pixels value, we use pixels as cost to store into memory cache, so we also use image.data's bytes length divide 4.
+    return image.frameCacheSizeCurrent * posterImage.size.height * posterImage.size.width * posterImage.scale * posterImage.scale + image.data.length / 4;
+}
 
 static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageView *imageView, NSData *imageData) {
     if ([NSData sd_imageFormatForImageData:imageData] != SDImageFormatGIF) {
@@ -150,6 +157,15 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                            if (animatedImage) {
                                if (strongSelf.sd_cacheFLAnimatedImage) {
                                    image.sd_FLAnimatedImage = animatedImage;
+                                   image.sd_memoryCost = SDWebImageCalculateFLAnimatedImageMemoryCost(animatedImage);
+                                   NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
+                                   UIImage *cachedImage = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:key];
+                                   // If image can be find in memory cache, we update the cost value of cost.
+                                   if (cachedImage) {
+                                       [[SDImageCache sharedImageCache] removeImageForKey:key fromDisk:NO withCompletion:^{
+                                           [[SDImageCache sharedImageCache] storeImage:image forKey:key toDisk:NO completion:nil];
+                                       }];
+                                   }
                                }
                                strongSelf.image = animatedImage.posterImage;
                                strongSelf.animatedImage = animatedImage;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -175,13 +175,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                            image.sd_FLAnimatedImage = animatedImage;
                                            image.sd_memoryCost = SDWebImageCalculateFLAnimatedImageMemoryCost(animatedImage);
                                            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
-                                           UIImage *cachedImage = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:key];
-                                           // If image can be find in memory cache, we update the cost value of cost.
-                                           if (cachedImage) {
-                                               [[SDImageCache sharedImageCache] removeImageForKey:key fromDisk:NO withCompletion:^{
-                                                   [[SDImageCache sharedImageCache] storeImage:image forKey:key toDisk:NO completion:nil];
-                                               }];
-                                           }
+                                           [[SDImageCache sharedImageCache] updateImageMemoryCostWithKey:key];
                                        }
                                        sstrongSelf.image = animatedImage.posterImage;
                                        sstrongSelf.animatedImage = animatedImage;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -15,13 +15,6 @@
 #import "NSData+ImageContentType.h"
 #import "UIImageView+WebCache.h"
 #import "UIImage+MultiFormat.h"
-#import "UIImage+CacheMemoryCost.h"
-
-static inline NSUInteger SDWebImageCalculateFLAnimatedImageMemoryCost(FLAnimatedImage *image) {
-    UIImage *posterImage = image.posterImage;
-    // Calculate pixels value, we use pixels as cost to store into memory cache, so we also use image.data's bytes length divide 4.
-    return image.frameCacheSizeCurrent * posterImage.size.height * posterImage.size.width * posterImage.scale * posterImage.scale + image.data.length / 4;
-}
 
 static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageView *imageView, NSData *imageData) {
     if ([NSData sd_imageFormatForImageData:imageData] != SDImageFormatGIF) {
@@ -152,7 +145,6 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                dispatch_group_leave(group);
                                return;
                            }
-
                            __weak typeof(strongSelf) wweakSelf = strongSelf;
                            // Hack, mark we need should use dispatch group notify for completedBlock
                            objc_setAssociatedObject(group, &SDWebImageInternalSetImageGroupKey, @(YES), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -173,9 +165,6 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                    if (animatedImage) {
                                        if (sstrongSelf.sd_cacheFLAnimatedImage) {
                                            image.sd_FLAnimatedImage = animatedImage;
-                                           image.sd_memoryCost = SDWebImageCalculateFLAnimatedImageMemoryCost(animatedImage);
-                                           NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
-                                           [[SDImageCache sharedImageCache] updateImageMemoryCostWithKey:key];
                                        }
                                        sstrongSelf.image = animatedImage.posterImage;
                                        sstrongSelf.animatedImage = animatedImage;

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -160,6 +160,17 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  */
 - (void)storeImageDataToDisk:(nullable NSData *)imageData forKey:(nullable NSString *)key;
 
+#pragma mark - Update Ops
+
+/**
+ * Update image memory cost if image already be stored in memory.
+ *
+ *
+ * @param key        The unique image cache key, usually it's image absolute URL
+ * @note After image be stored in memory cache, if image's memory size changes, such as set a large memory associated object to it, or subclass `UIImage` which has its own large memory properties, you can use this to update memory cost which can make memory cache handle `maxMemoryCost` correctly
+ */
+- (void)updateImageMemoryCostWithKey:(nullable NSString *)key;
+
 #pragma mark - Query and Retrieve Ops
 
 /**

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -18,7 +18,8 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 #if SD_MAC
     return image.size.height * image.size.width;
 #elif SD_UIKIT || SD_WATCH
-    return image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
+    NSUInteger imageSize = image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
+    return image.images ? (imageSize * image.images.count) : imageSize;
 #endif
 }
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -18,7 +18,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 #if SD_MAC
     return image.size.height * image.size.width;
 #elif SD_UIKIT || SD_WATCH
-    return image.size.height * image.size.width * image.scale * image.scale;
+    return image.size.height * image.size.width * image.scale * image.scale * CGImageGetBitsPerPixel(image.CGImage) / 8;
 #endif
 }
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -357,6 +357,18 @@
     }
 }
 
+#pragma mark - Update Ops
+
+- (void)updateImageMemoryCostWithKey:(NSString *)key {
+    UIImage *cachedImage = [self imageFromMemoryCacheForKey:key];
+    // If image can be find in memory cache, we update the cost value of cost.
+    if (cachedImage) {
+        [self removeImageForKey:key fromDisk:NO withCompletion:^{
+            [self storeImage:cachedImage forKey:key toDisk:NO completion:nil];
+        }];
+    }
+}
+
 #pragma mark - Query and Retrieve Ops
 
 - (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock {

--- a/SDWebImage/UIImage+CacheMemoryCost.h
+++ b/SDWebImage/UIImage+CacheMemoryCost.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (CacheMemoryCost)
+
+/**
+ * The image memory cost calculation, this property would be used in memory cache of `SDImageCache`.
+ * The default value is pixels of `image` or `images`.
+ * If you set some associated object to `UIImage`, you can set the custom value to indicate the memory cost.
+ * If you set a new value after `UIImage` be cached to memory cache, you need to reinsert into cache with new value cost by yourself.
+ */
+@property (assign, nonatomic) NSUInteger sd_memoryCost;
+
+@end

--- a/SDWebImage/UIImage+CacheMemoryCost.h
+++ b/SDWebImage/UIImage+CacheMemoryCost.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import <UIKit/UIKit.h>
+#import "SDWebImageCompat.h"
 
 @interface UIImage (CacheMemoryCost)
 

--- a/SDWebImage/UIImage+CacheMemoryCost.m
+++ b/SDWebImage/UIImage+CacheMemoryCost.m
@@ -7,7 +7,6 @@
  */
 
 #import "UIImage+CacheMemoryCost.h"
-#import "SDWebImageCompat.h"
 #import "objc/runtime.h"
 
 FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {

--- a/SDWebImage/UIImage+CacheMemoryCost.m
+++ b/SDWebImage/UIImage+CacheMemoryCost.m
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "UIImage+CacheMemoryCost.h"
+#import "SDWebImageCompat.h"
+#import "objc/runtime.h"
+
+FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
+#if SD_MAC
+    return image.size.height * image.size.width;
+#elif SD_UIKIT || SD_WATCH
+    NSUInteger imageSize = image.size.height * image.size.width * image.scale * image.scale;
+    return image.images ? (imageSize * image.images.count) : imageSize;
+#endif
+}
+
+@implementation UIImage (CacheMemoryCost)
+
+- (NSUInteger)sd_memoryCost {
+    NSNumber *memoryCost = objc_getAssociatedObject(self, _cmd);
+    if (memoryCost == nil) {
+        memoryCost = @(SDCacheCostForImage(self));
+    }
+    return [memoryCost unsignedIntegerValue];
+}
+
+- (void)setSd_memoryCost:(NSUInteger)sd_memoryCost {
+    objc_setAssociatedObject(self, @selector(sd_memoryCost), @(sd_memoryCost), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -32,6 +32,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDWebImagePrefetcher.h>
 #import <SDWebImage/UIView+WebCacheOperation.h>
 #import <SDWebImage/UIImage+MultiFormat.h>
+#import <SDWebImage/UIImage+CacheMemoryCost.h>
 #import <SDWebImage/SDWebImageOperation.h>
 #import <SDWebImage/SDWebImageDownloader.h>
 #import <SDWebImage/SDWebImageTransition.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Same as #2485 , sync to `4.x`.

