### PR TITLE
Xcode10 needs pods to have deployment_target>=3.0

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.watchos.deployment_target = '3.0'
 
   s.license = 'MIT'
   s.summary = 'Asynchronous image downloader with cache support with an UIImageView category.'


### PR DESCRIPTION
Without this you cannot upload to app store.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

I had problems to upload a binary to AppStore. The problem was that SDWebImage for WatchOS has deployment target of watchOS 2.0, but Apple requires all the framework to have deployment target of watchOS 3.0+.