### PR TITLE
Update url after framework transferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [4.4.2 - 4.4 patch, on July 18th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.4.2)
-See [all tickets marked for the 4.4.2 release](https://github.com/rs/SDWebImage/milestone/27)
+## [4.4.2 - 4.4 patch, on July 18th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.4.2)
+See [all tickets marked for the 4.4.2 release](https://github.com/SDWebImage/SDWebImage/milestone/27)
 
 #### Features
 - Ability to change the clear cache option `SDImageCacheConfig.diskCacheExpireType` #2357
@@ -14,8 +14,8 @@ See [all tickets marked for the 4.4.2 release](https://github.com/rs/SDWebImage/
 - Check for nullable key when cancel image load operation #2386
 - Replace `__bridge_transfer` with `__bridge` when convert from `CFStringRef` to `NSString` #2394
 
-## [4.4.1 - 4.4 patch, on June 7th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.4.1)
-See [all tickets marked for the 4.4.1 release](https://github.com/rs/SDWebImage/milestone/26)
+## [4.4.1 - 4.4 patch, on June 7th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.4.1)
+See [all tickets marked for the 4.4.1 release](https://github.com/SDWebImage/SDWebImage/milestone/26)
 	
 #### Fixes
 - Coder
@@ -23,8 +23,8 @@ See [all tickets marked for the 4.4.1 release](https://github.com/rs/SDWebImage/
 - Downloader
 	- Fix that the downloader operation may not call the completion block when requesting the same image url in race condition #2346 #2344
 
-## [4.4.0 - watchOS View Category, on May 31st, 2018](https://github.com/rs/SDWebImage/releases/tag/4.4.0)
-See [all tickets marked for the 4.4.0 release](https://github.com/rs/SDWebImage/milestone/25)
+## [4.4.0 - watchOS View Category, on May 31st, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.4.0)
+See [all tickets marked for the 4.4.0 release](https://github.com/SDWebImage/SDWebImage/milestone/25)
 
 #### Features
 - View Category
@@ -56,8 +56,8 @@ See [all tickets marked for the 4.4.0 release](https://github.com/rs/SDWebImage/
 #### Docs
 - Fix function storeImageDataToDisk description #2301
 
-## [4.3.3 - Cache Serializer, on Mar 12th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.3.3)
-See [all tickets marked for the 4.3.3 release](https://github.com/rs/SDWebImage/milestone/24)
+## [4.3.3 - Cache Serializer, on Mar 12th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.3.3)
+See [all tickets marked for the 4.3.3 release](https://github.com/SDWebImage/SDWebImage/milestone/24)
 
 #### Features
 - Manager
@@ -69,8 +69,8 @@ See [all tickets marked for the 4.3.3 release](https://github.com/rs/SDWebImage/
 	- Enable CLANG\_WARN\_OBJC\_IMPLICIT\_RETAIN\_SELF and fix warning #2242
 
 
-## [4.3.2 - 4.3 Patch, on Feb 28th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.3.2)
-See [all tickets marked for the 4.3.2 release](https://github.com/rs/SDWebImage/milestone/23)
+## [4.3.2 - 4.3 Patch, on Feb 28th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.3.2)
+See [all tickets marked for the 4.3.2 release](https://github.com/SDWebImage/SDWebImage/milestone/23)
 
 #### Fixes
 - Download Operation
@@ -80,8 +80,8 @@ See [all tickets marked for the 4.3.2 release](https://github.com/rs/SDWebImage/
 - Downloader
 	- Follow Apple's doc, add NSOperation only after all configuration done #2232
 
-## [4.3.1 - 4.3 Patch, on Feb 25th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.3.1)
-See [all tickets marked for the 4.3.1 release](https://github.com/rs/SDWebImage/milestone/22)
+## [4.3.1 - 4.3 Patch, on Feb 25th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.3.1)
+See [all tickets marked for the 4.3.1 release](https://github.com/SDWebImage/SDWebImage/milestone/22)
 
 #### Fixes
 - Cache
@@ -106,8 +106,8 @@ See [all tickets marked for the 4.3.1 release](https://github.com/rs/SDWebImage/
 	- Fix CLANG\_WARN\_OBJC\_IMPLICIT\_RETAIN\_SELF warning #2225 
 
 
-## [4.3.0 - Image Progress & Transition, on Jan 31th, 2018](https://github.com/rs/SDWebImage/releases/tag/4.3.0)
-See [all tickets marked for the 4.3.0 release](https://github.com/rs/SDWebImage/milestone/21)
+## [4.3.0 - Image Progress & Transition, on Jan 31th, 2018](https://github.com/SDWebImage/SDWebImage/releases/tag/4.3.0)
+See [all tickets marked for the 4.3.0 release](https://github.com/SDWebImage/SDWebImage/milestone/21)
 
 #### Features
 - View Category
@@ -151,8 +151,8 @@ See [all tickets marked for the 4.3.0 release](https://github.com/rs/SDWebImage/
 - Project
 	- Update the spec file to define the dependency version for libwebp #2169
 
-## [4.2.3 - 4.2 Patch, on Nov 30th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.2.3)
-See [all tickets marked for the 4.2.3 release](https://github.com/rs/SDWebImage/milestone/20)
+## [4.2.3 - 4.2 Patch, on Nov 30th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.2.3)
+See [all tickets marked for the 4.2.3 release](https://github.com/SDWebImage/SDWebImage/milestone/20)
 
 #### Features
 - Add a public API to allow user to invalidate URLSession used in SDWebImageDownloader to avoid memory leak on non-singleton instance #2116
@@ -170,8 +170,8 @@ See [all tickets marked for the 4.2.3 release](https://github.com/rs/SDWebImage/
 - Adopt the current requirement, change ImageIO coder's canDecodeFromHEIC to actual implementation #2146 #2138
 - When store image with no data for SDImageCache, check whether it contains alpha to use PNG or JPEG format #2136
 
-## [4.2.2 - 4.2 Patch, on Nov 7th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.2.2)
-See [all tickets marked for the 4.2.2 release](https://github.com/rs/SDWebImage/milestone/19)
+## [4.2.2 - 4.2 Patch, on Nov 7th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.2.2)
+See [all tickets marked for the 4.2.2 release](https://github.com/SDWebImage/SDWebImage/milestone/19)
 
 #### Features
 - Update our iOS demo to modern way, add a `UIProgressView` to show image download progress #2096
@@ -180,8 +180,8 @@ See [all tickets marked for the 4.2.2 release](https://github.com/rs/SDWebImage/
 - Fix that completion block and set image block are called asynchronously for `UIView+WebCache` #2093 #2097 #2092
 - Fix WebP progressive decoding may do extra calculate #2095
 
-## [4.2.1 - 4.2 Patch, on Oct 31st, 2017](https://github.com/rs/SDWebImage/releases/tag/4.2.1)
-See [all tickets marked for the 4.2.1 release](https://github.com/rs/SDWebImage/milestone/18)
+## [4.2.1 - 4.2 Patch, on Oct 31st, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.2.1)
+See [all tickets marked for the 4.2.1 release](https://github.com/SDWebImage/SDWebImage/milestone/18)
 
 #### Features
 - Feature refactor built-in coders and support animated webp on macOS #2082 (reusable code into `SDWebImageCoderHelper`; `SDWebImageFrame` abstracts animated images frames)
@@ -189,8 +189,8 @@ See [all tickets marked for the 4.2.1 release](https://github.com/rs/SDWebImage/
 #### Fixes
 - Fixed EXIF orientation method will crash on iOS 7 because it’s an iOS 8 above API #2082
 
-## [4.2.0 - Pluginable coders, on Oct 30th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.2.0)
-See [all tickets marked for the 4.2.0 release](https://github.com/rs/SDWebImage/milestone/16)
+## [4.2.0 - Pluginable coders, on Oct 30th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.2.0)
+See [all tickets marked for the 4.2.0 release](https://github.com/SDWebImage/SDWebImage/milestone/16)
 
 #### Features
 - Refactor decoding code and provide decoding plugin #1991
@@ -214,8 +214,8 @@ See [all tickets marked for the 4.2.0 release](https://github.com/rs/SDWebImage/
 #### Docs
 - Updated diagrams
 
-## [4.1.2 - 4.1 patch, on Oct 9th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.1.2)
-See [all tickets marked for the 4.1.2 release](https://github.com/rs/SDWebImage/milestone/17)
+## [4.1.2 - 4.1 patch, on Oct 9th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.1.2)
+See [all tickets marked for the 4.1.2 release](https://github.com/SDWebImage/SDWebImage/milestone/17)
 
 #### Fixes
 
@@ -223,8 +223,8 @@ See [all tickets marked for the 4.1.2 release](https://github.com/rs/SDWebImage/
 - Static `WebP` decoding little enhancement. Do not need create `WebP` iterator for static images #2050
 - Change `finished` check from `equal` to `equal or greater than` to protect accident condition #2051
 
-## [4.1.1 - 4.1 patch, on Oct 6th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.1.1)
-See [all tickets marked for the 4.1.1 release](https://github.com/rs/SDWebImage/milestone/14)
+## [4.1.1 - 4.1 patch, on Oct 6th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.1.1)
+See [all tickets marked for the 4.1.1 release](https://github.com/SDWebImage/SDWebImage/milestone/14)
 
 #### Fixes
 
@@ -251,8 +251,8 @@ See [all tickets marked for the 4.1.1 release](https://github.com/rs/SDWebImage/
 
 - Updated *Manual Installation* section #2030 fixes #2012
 
-## [4.1.0 - Swift API cleanup, on Jul 31st, 2017](https://github.com/rs/SDWebImage/releases/tag/4.1.0)
-See [all tickets marked for the 4.1.0 release](https://github.com/rs/SDWebImage/milestone/13)
+## [4.1.0 - Swift API cleanup, on Jul 31st, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.1.0)
+See [all tickets marked for the 4.1.0 release](https://github.com/SDWebImage/SDWebImage/milestone/13)
 
 #### Features
 
@@ -281,14 +281,14 @@ See [all tickets marked for the 4.1.0 release](https://github.com/rs/SDWebImage/
 
 - #1778 #1779 #1788 #1799 b1c3bb7 (replaces #1806) 0df32ea #1847 5eb83c3 (replaces #1828) #1946 #1966
 
-## [4.0.0 - New platforms (Mac OS X and watchOS) + refactoring, on Jan 28th, 2017](https://github.com/rs/SDWebImage/releases/tag/4.0.0)
+## [4.0.0 - New platforms (Mac OS X and watchOS) + refactoring, on Jan 28th, 2017](https://github.com/SDWebImage/SDWebImage/releases/tag/4.0.0)
 
-See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/milestone/3)
+See [all tickets marked for the 4.0.0 release](https://github.com/SDWebImage/SDWebImage/milestone/3)
 Versions 4.0.0-beta and 4.0.0-beta 2 list all the changes. 
 
-## [4.0.0 beta 2 - New platforms (Mac OS X and watchOS) + refactoring, on Oct 6th, 2016](https://github.com/rs/SDWebImage/releases/tag/4.0.0-beta2)
+## [4.0.0 beta 2 - New platforms (Mac OS X and watchOS) + refactoring, on Oct 6th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/4.0.0-beta2)
 
-See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/milestone/3)
+See [all tickets marked for the 4.0.0 release](https://github.com/SDWebImage/SDWebImage/milestone/3)
 
 #### Features
 
@@ -298,9 +298,9 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
 
 - Fixed #1668 CGContextDrawImage: invalid context 0x0 - b366d84
 
-## [4.0.0 beta - New platforms (Mac OS X and watchOS) + refactoring, on Oct 5th, 2016](https://github.com/rs/SDWebImage/releases/tag/4.0.0-beta)
+## [4.0.0 beta - New platforms (Mac OS X and watchOS) + refactoring, on Oct 5th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/4.0.0-beta)
 
-See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/milestone/3)
+See [all tickets marked for the 4.0.0 release](https://github.com/SDWebImage/SDWebImage/milestone/3)
 
 #### Infrastructure:
 
@@ -318,7 +318,7 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
     - `SDWebImage TV Demo`
     - `SDWebImage Watch Demo`
 - bumped `libwep` version to `0.5.1`
-- improved unit testing code coverage (*35%* -> **77%**) and integrated [CodeCov](https://codecov.io/gh/rs/SDWebImage)
+- improved unit testing code coverage (*35%* -> **77%**) and integrated [CodeCov](https://codecov.io/gh/SDWebImage/SDWebImage)
 
 #### Backwards incompatible changes
 
@@ -400,20 +400,20 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
 - Fixed #1089 by updating the docs on the calling queue for the `progressBlock` (background queue)
 - Fixed a compilation issue on `FLAnimatedImageView+WebCache` - #1687
 
-## [3.8.2 Patch release for 3.8.0 on Sep 5th, 2016](https://github.com/rs/SDWebImage/releases/tag/3.8.2)
+## [3.8.2 Patch release for 3.8.0 on Sep 5th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.8.2)
 
 #### Fixes:
 
 - Fixed #1608 #1623 #1644 Crash in `[NSURLCache cachedResponseForRequest:]` -  the fix is actually avoiding to access `NSURLCache` which appears to generate a race condition. We only call it if necesarry (`SDWebImageRefreshCached` is used and the image cannot be cached by the system when it's too big or behind authentication)
 
-## [3.8.1 Patch release for 3.8.0 on Jun 7th, 2016](https://github.com/rs/SDWebImage/releases/tag/3.8.1)
+## [3.8.1 Patch release for 3.8.0 on Jun 7th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.8.1)
 
 #### Fixes:
 
 - SDWebImage 3.8.0 get wrong image #1589 - the issue was caused by the changes in 3.8.0 (Removed the URL query params from the filename (key) fb0cdb6d 1bf62d4 #1584 - fixes #1433 #1553 #1583 #1585) - Reverted. 
 - Note: The solution for those issues (i.e. #1433 #1553) is to set the `SDWebImageManager` `cacheKeyFilter` block and do their own calculations there.
 
-## [3.8.0 Minor release - Replaces NSURLConnection (deprecated) with NSURLSession - on Jun 6th, 2016](https://github.com/rs/SDWebImage/releases/tag/3.8.0)
+## [3.8.0 Minor release - Replaces NSURLConnection (deprecated) with NSURLSession - on Jun 6th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.8.0)
 
 #### Infrastructure:
 
@@ -430,7 +430,7 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
 - Fixed the WebP build with the official 1.0.0 CocoaPods release f1a471e - fixes #1444
 - Updated doc: `removeImageForKey:` not synchronous e6e5c51 - fixes #1379 #1415
 
-## [3.7.6 Patch release for 3.7.0 on May 8th, 2016](https://github.com/rs/SDWebImage/releases/tag/3.7.6)
+## [3.7.6 Patch release for 3.7.0 on May 8th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.6)
 
 #### Infrastructure:
 - Changed the **libwebp git url** so that people from China can access it - #1390 (from `https://chromium.googlesource.com/webm/libwebp` to `https://github.com/webmproject/libwebp`)
@@ -450,11 +450,11 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
 - Protect against malformed frame for GIFs - #1447
 - updated doc: #1462 #1466 #1486 #1532 #1461 
 
-## [3.7.5 Patch release for 3.7.0 on Jan 21st, 2016](https://github.com/rs/SDWebImage/releases/tag/3.7.5)
+## [3.7.5 Patch release for 3.7.0 on Jan 21st, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.5)
 - fixed #1425 and #1426 - Continuation of Fix #1366, addresses #1350 and reverts a part of #1221 - from commit 6406d8e, the wrong usage of `dispatch_apply`
 - fixed #1422 - Added a fallback for #976 so that if there are images saved with the old format (no extension), they can still be loaded
 
-## [3.7.4 Patch release for 3.7.0 with tvOS support on Jan 8th, 2016](https://github.com/rs/SDWebImage/releases/tag/3.7.4)
+## [3.7.4 Patch release for 3.7.0 with tvOS support on Jan 8th, 2016](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.4)
 
 #### Updates
 - bumped `libwep` version to `0.4.4`
@@ -491,134 +491,134 @@ See [all tickets marked for the 4.0.0 release](https://github.com/rs/SDWebImage/
 - Remove logging from the image prefetcher - #1276
 - Fix typos #1256 #1257 #1258 #1331 #1290
 
-## [3.7.3 Patch release for 3.7.0 with iOS8+ framework and Carthage on Jun 13th, 2015](https://github.com/rs/SDWebImage/releases/tag/3.7.3)
+## [3.7.3 Patch release for 3.7.0 with iOS8+ framework and Carthage on Jun 13th, 2015](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.3)
 
-- Adds support for **iOS 8+ Framework and Carthage** [#1071](https://github.com/rs/SDWebImage/pull/1071) [#1081](https://github.com/rs/SDWebImage/pull/1081) [#1101](https://github.com/rs/SDWebImage/pull/1101) 
+- Adds support for **iOS 8+ Framework and Carthage** [#1071](https://github.com/SDWebImage/SDWebImage/pull/1071) [#1081](https://github.com/SDWebImage/SDWebImage/pull/1081) [#1101](https://github.com/SDWebImage/SDWebImage/pull/1101) 
 
-- [Refactor] Use `NSMutableSet` for failed URLs' storage instead of array [#1076](https://github.com/rs/SDWebImage/pull/1076) 
-- Make a constant for the error domain [#1011](https://github.com/rs/SDWebImage/pull/1011) 
-- Improve operation behavior [#988](https://github.com/rs/SDWebImage/pull/988) 
-- Bug fix: `Collection <__NSArrayM: > was mutated while being enumerated` [#985](https://github.com/rs/SDWebImage/pull/985) 
-- added `SDWebImageAvoidAutoSetImage` option to avoid automatic image addition in `UIImageView` and let developer to do it himself [#1188](https://github.com/rs/SDWebImage/pull/1188) 
-- Added support for custom disk cache folder with fall back for caches directory [#1153](https://github.com/rs/SDWebImage/pull/1153) 
-- Added some files to the workspace so they are easier to edit [8431481](https://github.com/rs/SDWebImage/commit/8431481)
-- Doc update [72ed897](https://github.com/rs/SDWebImage/commit/72ed897) [7f99c01](https://github.com/rs/SDWebImage/commit/7f99c01) [#1016](https://github.com/rs/SDWebImage/pull/1016) [#1038](https://github.com/rs/SDWebImage/pull/1038) [#1045](https://github.com/rs/SDWebImage/pull/1045)
-- [Memory Issue] Clear `SDWebImagePrefetcher` `progressBlock` when it has completed [#1017](https://github.com/rs/SDWebImage/pull/1017) 
-- avoid warning `<Error>: ImageIO: CGImageSourceCreateWithData data parameter is nil` if `imageData` is nil [88ee3c6](https://github.com/rs/SDWebImage/commit/88ee3c6) [#1018](https://github.com/rs/SDWebImage/pull/1018) 
-- allow override `diskCachePath` [#1041](https://github.com/rs/SDWebImage/pull/1041) 
-- Use `__typeof(self)` when assigning `weak` reference for block [#1054](https://github.com/rs/SDWebImage/pull/1054) 
-- [Refactor] Implement cache cost calculation as a inline function [#1075](https://github.com/rs/SDWebImage/pull/1075) 
-- @3x support [9620fff](https://github.com/rs/SDWebImage/commit/9620fff) [#1005](https://github.com/rs/SDWebImage/pull/1005) 
-- Fix parenthesis to avoid crashes [#1104](https://github.com/rs/SDWebImage/pull/1104) 
-- Add `NSCache` countLimit property [#1140](https://github.com/rs/SDWebImage/pull/1140) 
-- `failedURLs` can be removed at the appropriate time [#1111](https://github.com/rs/SDWebImage/pull/1111) 
-- Purge `NSCache` on system memory notifications [#1143](https://github.com/rs/SDWebImage/pull/1143) 
-- Determines at runtime is `UIApplication` is available as per [#1082](https://github.com/rs/SDWebImage/issues/1082) [#1085](https://github.com/rs/SDWebImage/pull/1085) 
-- Fixes http://git.chromium.org/webm/libwebp.git/info/refs not valid [#1175](https://github.com/rs/SDWebImage/pull/1175) + Reverted [#1193](https://github.com/rs/SDWebImage/pull/1193) + [#1177](https://github.com/rs/SDWebImage/pull/1177) 
-- 404 image url was causing the test to fail [0e761f4](https://github.com/rs/SDWebImage/commit/0e761f4)
-- Fix for transparency being lost in transformed images. [#1121](https://github.com/rs/SDWebImage/pull/1121) 
-- Add handling for additional error codes that shouldn't be considered a permanent failure [#1159](https://github.com/rs/SDWebImage/pull/1159) 
-- add webp accepted content type only if `WebP` enabled [#1178](https://github.com/rs/SDWebImage/pull/1178) 
-- fix `ImageIO: CGImageSourceCreateWithData` data parameter is nil [#1167](https://github.com/rs/SDWebImage/pull/1167) 
-- Applied patch for issue [#1074](https://github.com/rs/SDWebImage/issues/1074) SDWebImage residing in swift module breaks the debugger [#1138](https://github.com/rs/SDWebImage/pull/1138)
-- Fixed URLs with trailing parameters get assigned an incorrect image scale value [#1157](https://github.com/rs/SDWebImage/issues/1157) [#1158](https://github.com/rs/SDWebImage/pull/1158) 
-- Add newline to avoid compiler warning in `WebImage.h` [#1199](https://github.com/rs/SDWebImage/pull/1199) 
+- [Refactor] Use `NSMutableSet` for failed URLs' storage instead of array [#1076](https://github.com/SDWebImage/SDWebImage/pull/1076) 
+- Make a constant for the error domain [#1011](https://github.com/SDWebImage/SDWebImage/pull/1011) 
+- Improve operation behavior [#988](https://github.com/SDWebImage/SDWebImage/pull/988) 
+- Bug fix: `Collection <__NSArrayM: > was mutated while being enumerated` [#985](https://github.com/SDWebImage/SDWebImage/pull/985) 
+- added `SDWebImageAvoidAutoSetImage` option to avoid automatic image addition in `UIImageView` and let developer to do it himself [#1188](https://github.com/SDWebImage/SDWebImage/pull/1188) 
+- Added support for custom disk cache folder with fall back for caches directory [#1153](https://github.com/SDWebImage/SDWebImage/pull/1153) 
+- Added some files to the workspace so they are easier to edit [8431481](https://github.com/SDWebImage/SDWebImage/commit/8431481)
+- Doc update [72ed897](https://github.com/SDWebImage/SDWebImage/commit/72ed897) [7f99c01](https://github.com/SDWebImage/SDWebImage/commit/7f99c01) [#1016](https://github.com/SDWebImage/SDWebImage/pull/1016) [#1038](https://github.com/SDWebImage/SDWebImage/pull/1038) [#1045](https://github.com/SDWebImage/SDWebImage/pull/1045)
+- [Memory Issue] Clear `SDWebImagePrefetcher` `progressBlock` when it has completed [#1017](https://github.com/SDWebImage/SDWebImage/pull/1017) 
+- avoid warning `<Error>: ImageIO: CGImageSourceCreateWithData data parameter is nil` if `imageData` is nil [88ee3c6](https://github.com/SDWebImage/SDWebImage/commit/88ee3c6) [#1018](https://github.com/SDWebImage/SDWebImage/pull/1018) 
+- allow override `diskCachePath` [#1041](https://github.com/SDWebImage/SDWebImage/pull/1041) 
+- Use `__typeof(self)` when assigning `weak` reference for block [#1054](https://github.com/SDWebImage/SDWebImage/pull/1054) 
+- [Refactor] Implement cache cost calculation as a inline function [#1075](https://github.com/SDWebImage/SDWebImage/pull/1075) 
+- @3x support [9620fff](https://github.com/SDWebImage/SDWebImage/commit/9620fff) [#1005](https://github.com/SDWebImage/SDWebImage/pull/1005) 
+- Fix parenthesis to avoid crashes [#1104](https://github.com/SDWebImage/SDWebImage/pull/1104) 
+- Add `NSCache` countLimit property [#1140](https://github.com/SDWebImage/SDWebImage/pull/1140) 
+- `failedURLs` can be removed at the appropriate time [#1111](https://github.com/SDWebImage/SDWebImage/pull/1111) 
+- Purge `NSCache` on system memory notifications [#1143](https://github.com/SDWebImage/SDWebImage/pull/1143) 
+- Determines at runtime is `UIApplication` is available as per [#1082](https://github.com/SDWebImage/SDWebImage/issues/1082) [#1085](https://github.com/SDWebImage/SDWebImage/pull/1085) 
+- Fixes http://git.chromium.org/webm/libwebp.git/info/refs not valid [#1175](https://github.com/SDWebImage/SDWebImage/pull/1175) + Reverted [#1193](https://github.com/SDWebImage/SDWebImage/pull/1193) + [#1177](https://github.com/SDWebImage/SDWebImage/pull/1177) 
+- 404 image url was causing the test to fail [0e761f4](https://github.com/SDWebImage/SDWebImage/commit/0e761f4)
+- Fix for transparency being lost in transformed images. [#1121](https://github.com/SDWebImage/SDWebImage/pull/1121) 
+- Add handling for additional error codes that shouldn't be considered a permanent failure [#1159](https://github.com/SDWebImage/SDWebImage/pull/1159) 
+- add webp accepted content type only if `WebP` enabled [#1178](https://github.com/SDWebImage/SDWebImage/pull/1178) 
+- fix `ImageIO: CGImageSourceCreateWithData` data parameter is nil [#1167](https://github.com/SDWebImage/SDWebImage/pull/1167) 
+- Applied patch for issue [#1074](https://github.com/SDWebImage/SDWebImage/issues/1074) SDWebImage residing in swift module breaks the debugger [#1138](https://github.com/SDWebImage/SDWebImage/pull/1138)
+- Fixed URLs with trailing parameters get assigned an incorrect image scale value [#1157](https://github.com/SDWebImage/SDWebImage/issues/1157) [#1158](https://github.com/SDWebImage/SDWebImage/pull/1158) 
+- Add newline to avoid compiler warning in `WebImage.h` [#1199](https://github.com/SDWebImage/SDWebImage/pull/1199) 
 
-## [3.7.2 Updated patch release for 3.7.0 on Mar 17th, 2015](https://github.com/rs/SDWebImage/releases/tag/3.7.2)
+## [3.7.2 Updated patch release for 3.7.0 on Mar 17th, 2015](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.2)
 
 #### Updates
 - bumped `libwep` version to `0.4.3`
 
 #### Features:
-- implement `SDWebImageDownloaderAllowInvalidSSLCertificates` option - [#937](https://github.com/rs/SDWebImage/pull/937) 
-- flag to transform animated images (`SDWebImageTransformAnimatedImage`) - [#703](https://github.com/rs/SDWebImage/pull/703) 
-- allows user to override default `SDWebImageDownloaderOperation` - [#876](https://github.com/rs/SDWebImage/pull/876) 
-- adds option to decompress images and select prefetcher queue - [#996](https://github.com/rs/SDWebImage/pull/996)  
+- implement `SDWebImageDownloaderAllowInvalidSSLCertificates` option - [#937](https://github.com/SDWebImage/SDWebImage/pull/937) 
+- flag to transform animated images (`SDWebImageTransformAnimatedImage`) - [#703](https://github.com/SDWebImage/SDWebImage/pull/703) 
+- allows user to override default `SDWebImageDownloaderOperation` - [#876](https://github.com/SDWebImage/SDWebImage/pull/876) 
+- adds option to decompress images and select prefetcher queue - [#996](https://github.com/SDWebImage/SDWebImage/pull/996)  
 
 #### Fixes:
-- fixed [#809](https://github.com/rs/SDWebImage/issues/809) `cancelAll` crash - [#838](https://github.com/rs/SDWebImage/pull/838) 
-- fixed [#900](https://github.com/rs/SDWebImage/issues/900) by adding a new flag `SD_LOG_NONE` that allows silencing the SD logs from the Prefetcher
-- fixed [#895](https://github.com/rs/SDWebImage/issues/895) unsafe setImage in `setImageWithURL:` - [#896](https://github.com/rs/SDWebImage/pull/896) 
-- fix `NSNotificationCenter` dispatch on subthreads - [#987](https://github.com/rs/SDWebImage/pull/987) 
-- fix `SDWebImageDownloader` threading issue - [#104](https://github.com/rs/SDWebImage/pull/104)6 
-- fixed duplicate failed urls are added into `failedURLs` - [#994](https://github.com/rs/SDWebImage/pull/994) 
-- increased default `maxConcurrentOperationCount`, fixes [#527](https://github.com/rs/SDWebImage/issues/527) - [#897](https://github.com/rs/SDWebImage/pull/897) 
-- handle empty urls `NSArray` - [#929](https://github.com/rs/SDWebImage/pull/929) 
-- decoding webp, depends on source image data alpha status - [#936](https://github.com/rs/SDWebImage/pull/936) 
-- fix [#610](https://github.com/rs/SDWebImage/issues/610) display progressive jpeg issue - [#840](https://github.com/rs/SDWebImage/pull/840) 
-- the code from `SDWebImageDownloaderOperation connection:didFailWithError:` should match the code from `connectionDidFinishLoading:`. This fixes [#872](https://github.com/rs/SDWebImage/issues/872) - [7f39e5e](https://github.com/rs/SDWebImage/commit/7f39e5e)
-- `304 - Not Modified` HTTP status code handling - [#942](https://github.com/rs/SDWebImage/pull/942) 
-- cost compute fix - [#941](https://github.com/rs/SDWebImage/pull/941) 
-- initialise `kPNGSignatureData` data - [#981](https://github.com/rs/SDWebImage/pull/981) 
+- fixed [#809](https://github.com/SDWebImage/SDWebImage/issues/809) `cancelAll` crash - [#838](https://github.com/SDWebImage/SDWebImage/pull/838) 
+- fixed [#900](https://github.com/SDWebImage/SDWebImage/issues/900) by adding a new flag `SD_LOG_NONE` that allows silencing the SD logs from the Prefetcher
+- fixed [#895](https://github.com/SDWebImage/SDWebImage/issues/895) unsafe setImage in `setImageWithURL:` - [#896](https://github.com/SDWebImage/SDWebImage/pull/896) 
+- fix `NSNotificationCenter` dispatch on subthreads - [#987](https://github.com/SDWebImage/SDWebImage/pull/987) 
+- fix `SDWebImageDownloader` threading issue - [#104](https://github.com/SDWebImage/SDWebImage/pull/104)6 
+- fixed duplicate failed urls are added into `failedURLs` - [#994](https://github.com/SDWebImage/SDWebImage/pull/994) 
+- increased default `maxConcurrentOperationCount`, fixes [#527](https://github.com/SDWebImage/SDWebImage/issues/527) - [#897](https://github.com/SDWebImage/SDWebImage/pull/897) 
+- handle empty urls `NSArray` - [#929](https://github.com/SDWebImage/SDWebImage/pull/929) 
+- decoding webp, depends on source image data alpha status - [#936](https://github.com/SDWebImage/SDWebImage/pull/936) 
+- fix [#610](https://github.com/SDWebImage/SDWebImage/issues/610) display progressive jpeg issue - [#840](https://github.com/SDWebImage/SDWebImage/pull/840) 
+- the code from `SDWebImageDownloaderOperation connection:didFailWithError:` should match the code from `connectionDidFinishLoading:`. This fixes [#872](https://github.com/SDWebImage/SDWebImage/issues/872) - [7f39e5e](https://github.com/SDWebImage/SDWebImage/commit/7f39e5e)
+- `304 - Not Modified` HTTP status code handling - [#942](https://github.com/SDWebImage/SDWebImage/pull/942) 
+- cost compute fix - [#941](https://github.com/SDWebImage/SDWebImage/pull/941) 
+- initialise `kPNGSignatureData` data - [#981](https://github.com/SDWebImage/SDWebImage/pull/981) 
 
 #### Documentation
 - documentation updated
 
-## [3.7.1 Patch release for 3.7.0 on Jul 23rd, 2014](https://github.com/rs/SDWebImage/releases/tag/3.7.1)
+## [3.7.1 Patch release for 3.7.0 on Jul 23rd, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.1)
 
-- fixed `sd_imageOrientationFromImageData:` crash if imageSource is nil - [#819](https://github.com/rs/SDWebImage/pull/819) [#813](https://github.com/rs/SDWebImage/pull/813) [#808](https://github.com/rs/SDWebImage/issues/808) [#828](https://github.com/rs/SDWebImage/issues/828) - temporary fix
-- fixed `SDWebImageCombinedOperation cancel` crash (also visible as `SDWebImageManager cancelAll`) - [28109c4](https://github.com/rs/SDWebImage/commit/28109c4) [#798](https://github.com/rs/SDWebImage/issues/798) [#809](https://github.com/rs/SDWebImage/issues/809) 
-- fixed duplicate symbols when using with webp via pods - [#795](https://github.com/rs/SDWebImage/pull/795) 
-- fixed missing `mark` from `pragma mark` - [#827](https://github.com/rs/SDWebImage/pull/827) 
+- fixed `sd_imageOrientationFromImageData:` crash if imageSource is nil - [#819](https://github.com/SDWebImage/SDWebImage/pull/819) [#813](https://github.com/SDWebImage/SDWebImage/pull/813) [#808](https://github.com/SDWebImage/SDWebImage/issues/808) [#828](https://github.com/SDWebImage/SDWebImage/issues/828) - temporary fix
+- fixed `SDWebImageCombinedOperation cancel` crash (also visible as `SDWebImageManager cancelAll`) - [28109c4](https://github.com/SDWebImage/SDWebImage/commit/28109c4) [#798](https://github.com/SDWebImage/SDWebImage/issues/798) [#809](https://github.com/SDWebImage/SDWebImage/issues/809) 
+- fixed duplicate symbols when using with webp via pods - [#795](https://github.com/SDWebImage/SDWebImage/pull/795) 
+- fixed missing `mark` from `pragma mark` - [#827](https://github.com/SDWebImage/SDWebImage/pull/827) 
 
-## [3.7.0 Xcode6, arm64, highlight UIImageView, imageURL ref, NTLM, ... on Jul 14th, 2014](https://github.com/rs/SDWebImage/releases/tag/3.7.0)
+## [3.7.0 Xcode6, arm64, highlight UIImageView, imageURL ref, NTLM, ... on Jul 14th, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.7.0)
 
 ## Features
-- Add category for imageView's highlighted state `UIImageView+HighlightedWebCache` - [#646](https://github.com/rs/SDWebImage/pull/646) [#765](https://github.com/rs/SDWebImage/pull/765)
-- Keep a reference to the image URL - [#560](https://github.com/rs/SDWebImage/pull/560)
-- Pass imageURL in completedBlock - [#770](https://github.com/rs/SDWebImage/pull/770)
-- Implemented NTLM auth support. Replaced deprecated auth challenge methods from `NSURLConnectionDelegate` - [#711](https://github.com/rs/SDWebImage/pull/711) [50c4d1d](https://github.com/rs/SDWebImage/commit/50c4d1d)
-- Ability to suspend image downloaders `SDWebImageDownloader setSuspended:` - [#734](https://github.com/rs/SDWebImage/pull/734)
-- Delay the loading of the placeholder image until after load - [#701](https://github.com/rs/SDWebImage/pull/701)
-- Ability to save images to cache directly - [#714](https://github.com/rs/SDWebImage/pull/714)
-- Support for image orientation - [#764](https://github.com/rs/SDWebImage/pull/764)
-- Added async `SDImageCache removeImageForKey:withCompletion:` - [#732](https://github.com/rs/SDWebImage/pull/732) [cd4b925](https://github.com/rs/SDWebImage/commit/cd4b925)
-- Exposed cache paths - [#339](https://github.com/rs/SDWebImage/issues/339)
-- Exposed `SDWebImageManager cacheKeyForURL:` - [5fd21e5](https://github.com/rs/SDWebImage/commit/5fd21e5)
-- Exposing `SDWebImageManager` instance from the `SDWebImagePrefetcher` class - [6c409cd](https://github.com/rs/SDWebImage/commit/6c409cd)
-- `SDWebImageManager` uses the shared instance of `SDWebImageDownloader` - [0772019](https://github.com/rs/SDWebImage/commit/0772019)
-- Refactor the cancel logic - [#771](https://github.com/rs/SDWebImage/pull/771) [6d01e80](https://github.com/rs/SDWebImage/commit/6d01e80) [23874cd](https://github.com/rs/SDWebImage/commit/23874cd) [a6f11b3](https://github.com/rs/SDWebImage/commit/a6f11b3)
-- Added method `SDWebImageManager cachedImageExistsForURL:` to check if an image exists in either the disk OR the memory cache - [#644](https://github.com/rs/SDWebImage/pull/644)
-- Added option to use the cached image instead of the placeholder for `UIImageView`. Replaces [#541](https://github.com/rs/SDWebImage/pull/541) - [#599](https://github.com/rs/SDWebImage/issues/599) [30f6726](https://github.com/rs/SDWebImage/commit/30f6726)
+- Add category for imageView's highlighted state `UIImageView+HighlightedWebCache` - [#646](https://github.com/SDWebImage/SDWebImage/pull/646) [#765](https://github.com/SDWebImage/SDWebImage/pull/765)
+- Keep a reference to the image URL - [#560](https://github.com/SDWebImage/SDWebImage/pull/560)
+- Pass imageURL in completedBlock - [#770](https://github.com/SDWebImage/SDWebImage/pull/770)
+- Implemented NTLM auth support. Replaced deprecated auth challenge methods from `NSURLConnectionDelegate` - [#711](https://github.com/SDWebImage/SDWebImage/pull/711) [50c4d1d](https://github.com/SDWebImage/SDWebImage/commit/50c4d1d)
+- Ability to suspend image downloaders `SDWebImageDownloader setSuspended:` - [#734](https://github.com/SDWebImage/SDWebImage/pull/734)
+- Delay the loading of the placeholder image until after load - [#701](https://github.com/SDWebImage/SDWebImage/pull/701)
+- Ability to save images to cache directly - [#714](https://github.com/SDWebImage/SDWebImage/pull/714)
+- Support for image orientation - [#764](https://github.com/SDWebImage/SDWebImage/pull/764)
+- Added async `SDImageCache removeImageForKey:withCompletion:` - [#732](https://github.com/SDWebImage/SDWebImage/pull/732) [cd4b925](https://github.com/SDWebImage/SDWebImage/commit/cd4b925)
+- Exposed cache paths - [#339](https://github.com/SDWebImage/SDWebImage/issues/339)
+- Exposed `SDWebImageManager cacheKeyForURL:` - [5fd21e5](https://github.com/SDWebImage/SDWebImage/commit/5fd21e5)
+- Exposing `SDWebImageManager` instance from the `SDWebImagePrefetcher` class - [6c409cd](https://github.com/SDWebImage/SDWebImage/commit/6c409cd)
+- `SDWebImageManager` uses the shared instance of `SDWebImageDownloader` - [0772019](https://github.com/SDWebImage/SDWebImage/commit/0772019)
+- Refactor the cancel logic - [#771](https://github.com/SDWebImage/SDWebImage/pull/771) [6d01e80](https://github.com/SDWebImage/SDWebImage/commit/6d01e80) [23874cd](https://github.com/SDWebImage/SDWebImage/commit/23874cd) [a6f11b3](https://github.com/SDWebImage/SDWebImage/commit/a6f11b3)
+- Added method `SDWebImageManager cachedImageExistsForURL:` to check if an image exists in either the disk OR the memory cache - [#644](https://github.com/SDWebImage/SDWebImage/pull/644)
+- Added option to use the cached image instead of the placeholder for `UIImageView`. Replaces [#541](https://github.com/SDWebImage/SDWebImage/pull/541) - [#599](https://github.com/SDWebImage/SDWebImage/issues/599) [30f6726](https://github.com/SDWebImage/SDWebImage/commit/30f6726)
 - Created workspace + added unit tests target
-- Updated documentation - [#476](https://github.com/rs/SDWebImage/issues/476) [#384](https://github.com/rs/SDWebImage/issues/384) [#526](https://github.com/rs/SDWebImage/issues/526) [#376](https://github.com/rs/SDWebImage/pull/376) [a8f5627](https://github.com/rs/SDWebImage/commit/a8f5627)
+- Updated documentation - [#476](https://github.com/SDWebImage/SDWebImage/issues/476) [#384](https://github.com/SDWebImage/SDWebImage/issues/384) [#526](https://github.com/SDWebImage/SDWebImage/issues/526) [#376](https://github.com/SDWebImage/SDWebImage/pull/376) [a8f5627](https://github.com/SDWebImage/SDWebImage/commit/a8f5627)
 
 ## Bugfixes
-- Fixed Xcode 6 builds - [#741](https://github.com/rs/SDWebImage/pull/741) [0b47342](https://github.com/rs/SDWebImage/commit/0b47342)
-- Fixed `diskImageExistsWithKey:` deadlock - [#625](https://github.com/rs/SDWebImage/issues/625) [6e4fbaf](https://github.com/rs/SDWebImage/commit/6e4fbaf)
+- Fixed Xcode 6 builds - [#741](https://github.com/SDWebImage/SDWebImage/pull/741) [0b47342](https://github.com/SDWebImage/SDWebImage/commit/0b47342)
+- Fixed `diskImageExistsWithKey:` deadlock - [#625](https://github.com/SDWebImage/SDWebImage/issues/625) [6e4fbaf](https://github.com/SDWebImage/SDWebImage/commit/6e4fbaf)
 For consistency, added async methods in `SDWebImageManager` `cachedImageExistsForURL:completion:` and `diskImageExistsForURL:completion:`
-- Fixed race condition that causes cancellation of one download operation to stop a run loop that is now used for another download operation. Race is introduced through `performSelector:onThread:withObject:waitUntilDone:` - [#698](https://github.com/rs/SDWebImage/pull/698)
-- Fixed race condition between operation cancelation and loading finish - [39db378](https://github.com/rs/SDWebImage/commit/39db378) [#621](https://github.com/rs/SDWebImage/pull/621) [#783](https://github.com/rs/SDWebImage/pull/783)
-- Fixed race condition in SDWebImageManager if one operation is cancelled - [f080e38](https://github.com/rs/SDWebImage/commit/f080e38) [#699](https://github.com/rs/SDWebImage/pull/699)
-- Fixed issue where cancelled operations aren't removed from `runningOperations` - [#68](https://github.com/rs/SDWebImage/issues/68)
-- Should not add url to failedURLs when timeout, cancel and so on - [#766](https://github.com/rs/SDWebImage/pull/766) [#707](https://github.com/rs/SDWebImage/issues/707)
-- Fixed potential *object mutated while being enumerated* crash - [#727](https://github.com/rs/SDWebImage/pull/727) [#728](https://github.com/rs/SDWebImage/pull/728) (revert a threading fix from [#727](https://github.com/rs/SDWebImage/pull/727))
-- Fixed `NSURLConnection` response statusCode not valid (e.g. 404), downloader never stops its runloop and hangs the operation queue - [#735](https://github.com/rs/SDWebImage/pull/735)
-- Fixed `SDWebImageRefreshCached` bug for large images - [#744](https://github.com/rs/SDWebImage/pull/744)
-- Added proper handling for `SDWebImageDownloaderLowPriority` - [#713](https://github.com/rs/SDWebImage/issues/713) [#745](https://github.com/rs/SDWebImage/issues/745)
-- Fixed fixing potential bug when sending a nil url for UIButton+WebCache - [#761](https://github.com/rs/SDWebImage/issues/761) [#763](https://github.com/rs/SDWebImage/pull/763)
-- Fixed issue [#529](https://github.com/rs/SDWebImage/pull/529) - if the `cacheKeyFilter` was set, this was ignored when computing the `scaledImageForKey`. For most of the developers that did not set `cacheKeyFilter`, the code will work exactly the same - [eb91fdd](https://github.com/rs/SDWebImage/commit/eb91fdd)
-- Returning error in setImage completedBlock if the url was nil. Added `dispatch_main_async_safe` macro - [#505](https://github.com/rs/SDWebImage/issues/505) [af3e4f8](https://github.com/rs/SDWebImage/commit/af3e4f8)
-- Avoid premature completion of prefetcher if request fails - [#751](https://github.com/rs/SDWebImage/pull/751)
-- Return nil from `SDScaledImageForKey` if the input image is nil - [#365](https://github.com/rs/SDWebImage/issues/365) [#750](https://github.com/rs/SDWebImage/pull/750)
-- Do not load placeholder image if `SDWebImageDelayPlaceholder` option specified - [#780](https://github.com/rs/SDWebImage/pull/780)
-- Make sure we call the `startPrefetchingAtIndex:` method from main queue - [#694](https://github.com/rs/SDWebImage/pull/694)
-- Save image in cache before calling completion block - [#700](https://github.com/rs/SDWebImage/pull/700)
-- Fixed arm64 warnings - [#685](https://github.com/rs/SDWebImage/pull/685) [#720](https://github.com/rs/SDWebImage/pull/720) [#721](https://github.com/rs/SDWebImage/pull/721) [#687](https://github.com/rs/SDWebImage/pull/687)
-- Improved logging - [#721](https://github.com/rs/SDWebImage/pull/721)
+- Fixed race condition that causes cancellation of one download operation to stop a run loop that is now used for another download operation. Race is introduced through `performSelector:onThread:withObject:waitUntilDone:` - [#698](https://github.com/SDWebImage/SDWebImage/pull/698)
+- Fixed race condition between operation cancelation and loading finish - [39db378](https://github.com/SDWebImage/SDWebImage/commit/39db378) [#621](https://github.com/SDWebImage/SDWebImage/pull/621) [#783](https://github.com/SDWebImage/SDWebImage/pull/783)
+- Fixed race condition in SDWebImageManager if one operation is cancelled - [f080e38](https://github.com/SDWebImage/SDWebImage/commit/f080e38) [#699](https://github.com/SDWebImage/SDWebImage/pull/699)
+- Fixed issue where cancelled operations aren't removed from `runningOperations` - [#68](https://github.com/SDWebImage/SDWebImage/issues/68)
+- Should not add url to failedURLs when timeout, cancel and so on - [#766](https://github.com/SDWebImage/SDWebImage/pull/766) [#707](https://github.com/SDWebImage/SDWebImage/issues/707)
+- Fixed potential *object mutated while being enumerated* crash - [#727](https://github.com/SDWebImage/SDWebImage/pull/727) [#728](https://github.com/SDWebImage/SDWebImage/pull/728) (revert a threading fix from [#727](https://github.com/SDWebImage/SDWebImage/pull/727))
+- Fixed `NSURLConnection` response statusCode not valid (e.g. 404), downloader never stops its runloop and hangs the operation queue - [#735](https://github.com/SDWebImage/SDWebImage/pull/735)
+- Fixed `SDWebImageRefreshCached` bug for large images - [#744](https://github.com/SDWebImage/SDWebImage/pull/744)
+- Added proper handling for `SDWebImageDownloaderLowPriority` - [#713](https://github.com/SDWebImage/SDWebImage/issues/713) [#745](https://github.com/SDWebImage/SDWebImage/issues/745)
+- Fixed fixing potential bug when sending a nil url for UIButton+WebCache - [#761](https://github.com/SDWebImage/SDWebImage/issues/761) [#763](https://github.com/SDWebImage/SDWebImage/pull/763)
+- Fixed issue [#529](https://github.com/SDWebImage/SDWebImage/pull/529) - if the `cacheKeyFilter` was set, this was ignored when computing the `scaledImageForKey`. For most of the developers that did not set `cacheKeyFilter`, the code will work exactly the same - [eb91fdd](https://github.com/SDWebImage/SDWebImage/commit/eb91fdd)
+- Returning error in setImage completedBlock if the url was nil. Added `dispatch_main_async_safe` macro - [#505](https://github.com/SDWebImage/SDWebImage/issues/505) [af3e4f8](https://github.com/SDWebImage/SDWebImage/commit/af3e4f8)
+- Avoid premature completion of prefetcher if request fails - [#751](https://github.com/SDWebImage/SDWebImage/pull/751)
+- Return nil from `SDScaledImageForKey` if the input image is nil - [#365](https://github.com/SDWebImage/SDWebImage/issues/365) [#750](https://github.com/SDWebImage/SDWebImage/pull/750)
+- Do not load placeholder image if `SDWebImageDelayPlaceholder` option specified - [#780](https://github.com/SDWebImage/SDWebImage/pull/780)
+- Make sure we call the `startPrefetchingAtIndex:` method from main queue - [#694](https://github.com/SDWebImage/SDWebImage/pull/694)
+- Save image in cache before calling completion block - [#700](https://github.com/SDWebImage/SDWebImage/pull/700)
+- Fixed arm64 warnings - [#685](https://github.com/SDWebImage/SDWebImage/pull/685) [#720](https://github.com/SDWebImage/SDWebImage/pull/720) [#721](https://github.com/SDWebImage/SDWebImage/pull/721) [#687](https://github.com/SDWebImage/SDWebImage/pull/687)
+- Improved logging - [#721](https://github.com/SDWebImage/SDWebImage/pull/721)
 - Added `SDWebImageCompat.m` to `SDWebImage+MKAnnotation` target
 
-## [3.6 Fix and cleanup on Mar 24th, 2014](https://github.com/rs/SDWebImage/releases/tag/3.6)
+## [3.6 Fix and cleanup on Mar 24th, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.6)
 
-## [3.5.4 ARM64 Support on Feb 24th, 2014](https://github.com/rs/SDWebImage/releases/tag/3.5.4)
+## [3.5.4 ARM64 Support on Feb 24th, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.5.4)
 
-## [3.5.3 on Jan 7th, 2014](https://github.com/rs/SDWebImage/releases/tag/3.5.3)
+## [3.5.3 on Jan 7th, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.5.3)
 
-## [3.5.2 on Jan 2nd, 2014](https://github.com/rs/SDWebImage/releases/tag/3.5.2)
+## [3.5.2 on Jan 2nd, 2014](https://github.com/SDWebImage/SDWebImage/releases/tag/3.5.2)
 
-## [3.5.1 on Dec 3rd, 2013](https://github.com/rs/SDWebImage/releases/tag/3.5.1)
+## [3.5.1 on Dec 3rd, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.5.1)
 
-## [3.5 WebP Target, iOS 7, Fixes on Oct 4th, 2013](https://github.com/rs/SDWebImage/releases/tag/3.5)
+## [3.5 WebP Target, iOS 7, Fixes on Oct 4th, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.5)
 
 - Fix iOS 7 related issues
 - Move `WebP` support to a dedicated target
@@ -626,68 +626,68 @@ For consistency, added async methods in `SDWebImageManager` `cachedImageExistsFo
 - Fix timeout issue
 - Add some methods that allow to check if an image exists on disk without taking it off disk and decompressing it first
 
-## [3.4 Animated image category, bug fixes on Aug 13th, 2013](https://github.com/rs/SDWebImage/releases/tag/3.4)
+## [3.4 Animated image category, bug fixes on Aug 13th, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.4)
 
 - Add `calculateSizeWithCompletionBlock`
 - Add multiple download of images for animationImages property of `UIImageView`
-- Add background task for disk cleanup [#306](https://github.com/rs/SDWebImage/issues/306) 
-- Fix dead thread issue on iOS 5 [#444](https://github.com/rs/SDWebImage/pull/444), [#399](https://github.com/rs/SDWebImage/issues/399), [#466](https://github.com/rs/SDWebImage/issues/466)
-- Make IO operations cancelable to fix perf issue with heavy images [#462](https://github.com/rs/SDWebImage/issues/462) 
-- Fix crash `Collection <__NSArrayM: ...> was mutated while being enumerated.` [#471](https://github.com/rs/SDWebImage/pull/471) 
+- Add background task for disk cleanup [#306](https://github.com/SDWebImage/SDWebImage/issues/306) 
+- Fix dead thread issue on iOS 5 [#444](https://github.com/SDWebImage/SDWebImage/pull/444), [#399](https://github.com/SDWebImage/SDWebImage/issues/399), [#466](https://github.com/SDWebImage/SDWebImage/issues/466)
+- Make IO operations cancelable to fix perf issue with heavy images [#462](https://github.com/SDWebImage/SDWebImage/issues/462) 
+- Fix crash `Collection <__NSArrayM: ...> was mutated while being enumerated.` [#471](https://github.com/SDWebImage/SDWebImage/pull/471) 
 
-## [3.3 WebP, Animated GIF and more on Jun 14th, 2013](https://github.com/rs/SDWebImage/releases/tag/3.3)
+## [3.3 WebP, Animated GIF and more on Jun 14th, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.3)
 
-- WebP image format support [#410](https://github.com/rs/SDWebImage/issues/410)
-- Animated GIF support [#375](https://github.com/rs/SDWebImage/pull/375)
-- Custom image cache search paths [#156](https://github.com/rs/SDWebImage/pull/156)
+- WebP image format support [#410](https://github.com/SDWebImage/SDWebImage/issues/410)
+- Animated GIF support [#375](https://github.com/SDWebImage/SDWebImage/pull/375)
+- Custom image cache search paths [#156](https://github.com/SDWebImage/SDWebImage/pull/156)
 - Bug fixes
 
-## [3.2 Bug fixes on Mar 13th, 2013](https://github.com/rs/SDWebImage/releases/tag/3.2)
+## [3.2 Bug fixes on Mar 13th, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.2)
 
-- `SDWebImageRefreshCached` download option [#326](https://github.com/rs/SDWebImage/pull/326)
-- New `SDWebImageManager` delegate methods [ebd63a88c1](https://github.com/rs/SDWebImage/commit/ebd63a88c116ac7acfbeded5c84d0fffa2443438)
-- Fix long standing issue with alpha en JPEGs [#299](https://github.com/rs/SDWebImage/pull/299)
-- Add synchronous disk-cache loading method [#297](https://github.com/rs/SDWebImage/pull/297)
+- `SDWebImageRefreshCached` download option [#326](https://github.com/SDWebImage/SDWebImage/pull/326)
+- New `SDWebImageManager` delegate methods [ebd63a88c1](https://github.com/SDWebImage/SDWebImage/commit/ebd63a88c116ac7acfbeded5c84d0fffa2443438)
+- Fix long standing issue with alpha en JPEGs [#299](https://github.com/SDWebImage/SDWebImage/pull/299)
+- Add synchronous disk-cache loading method [#297](https://github.com/SDWebImage/SDWebImage/pull/297)
 - Fix `SDWebImageCacheMemoryOnly` flag
 - Bug fixes
 
-## [3.1 Bug fixes on Jan 21st, 2013](https://github.com/rs/SDWebImage/releases/tag/3.1)
+## [3.1 Bug fixes on Jan 21st, 2013](https://github.com/SDWebImage/SDWebImage/releases/tag/3.1)
 
-## [3.0 Complete rewrite on Nov 29th, 2012](https://github.com/rs/SDWebImage/releases/tag/3.0)
+## [3.0 Complete rewrite on Nov 29th, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/3.0)
 
 - Complete rewrite of the library using `GCD`, `ARC`, `NSCache` and blocks
 - Drop compatibility with iOS 3 and 4
 
-## [2.7.4 Bug fixes on Nov 14th, 2012](https://github.com/rs/SDWebImage/releases/tag/2.7.4)
+## [2.7.4 Bug fixes on Nov 14th, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.7.4)
 
-## [2.7.3 on Nov 3rd, 2012](https://github.com/rs/SDWebImage/releases/tag/2.7.3)
+## [2.7.3 on Nov 3rd, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.7.3)
 
-## [2.7.2 on Oct 23rd, 2012](https://github.com/rs/SDWebImage/releases/tag/2.7.2)
+## [2.7.2 on Oct 23rd, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.7.2)
 
-## [2.7.1 on Oct 19th, 2012](https://github.com/rs/SDWebImage/releases/tag/2.7.1)
+## [2.7.1 on Oct 19th, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.7.1)
 
-## [2.7 on Sep 8th, 2012](https://github.com/rs/SDWebImage/releases/tag/2.7)
+## [2.7 on Sep 8th, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.7)
 
-## [2.6 on May 4th, 2012](https://github.com/rs/SDWebImage/releases/tag/2.6)
+## [2.6 on May 4th, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.6)
 
-## [2.5 on Mar 22nd, 2012](https://github.com/rs/SDWebImage/releases/tag/2.5)
+## [2.5 on Mar 22nd, 2012](https://github.com/SDWebImage/SDWebImage/releases/tag/2.5)
 
-## [2.4 on Oct 1st, 2011](https://github.com/rs/SDWebImage/releases/tag/2.4)
+## [2.4 on Oct 1st, 2011](https://github.com/SDWebImage/SDWebImage/releases/tag/2.4)
 
-## [2.3 on Sep 16th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.3)
+## [2.3 on Sep 16th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.3)
 
-## [2.2 on Aug 29th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.2)
+## [2.2 on Aug 29th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.2)
 
-## [2.1.0 on Jun 12th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.1.0)
+## [2.1.0 on Jun 12th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.1.0)
 
-## [2.1 on Jun 12th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.1)
+## [2.1 on Jun 12th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.1)
 
-## [2.0.0 on Jun 9th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.0.0)
+## [2.0.0 on Jun 9th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.0.0)
 
-## [2.0 on Jun 9th, 2010](https://github.com/rs/SDWebImage/releases/tag/2.0)
+## [2.0 on Jun 9th, 2010](https://github.com/SDWebImage/SDWebImage/releases/tag/2.0)
 
-## [1.0.0 on Dec 31st, 2009](https://github.com/rs/SDWebImage/releases/tag/1.0.0)
+## [1.0.0 on Dec 31st, 2009](https://github.com/SDWebImage/SDWebImage/releases/tag/1.0.0)
 
-## [1.0 on Dec 31st, 2009](https://github.com/rs/SDWebImage/releases/tag/1.0)
+## [1.0 on Dec 31st, 2009](https://github.com/SDWebImage/SDWebImage/releases/tag/1.0)
 
 

--- a/Docs/ManualInstallation.md
+++ b/Docs/ManualInstallation.md
@@ -2,7 +2,7 @@
 
 In order to gain access to all the files from the repository, you should clone it.
 ```
-git clone --recursive https://github.com/rs/SDWebImage.git
+git clone --recursive https://github.com/SDWebImage/SDWebImage.git
 ```
 
 ... TO BE CHECKED AND DESCRIBED IN DETAIL

--- a/Docs/SDWebImage-4.0-Migration-guide.md
+++ b/Docs/SDWebImage-4.0-Migration-guide.md
@@ -14,7 +14,7 @@ This guide is provided in order to ease the transition of existing applications 
 SDWebImage 4.0 officially supports iOS 7 and later, Mac OS X 10.8 and later, watchOS 2 and later and tvOS 9 and later.
 It needs Xcode 7.3 or later to be able to build everything properly.
 
-For targeting previous versions of the SDKs, check [README - Backwards compatibility](https://github.com/rs/SDWebImage#backwards-compatibility)
+For targeting previous versions of the SDKs, check [README - Backwards compatibility](https://github.com/SDWebImage/SDWebImage#backwards-compatibility)
 .
 
 ### Migration

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Pod Version](http://img.shields.io/cocoapods/v/SDWebImage.svg?style=flat)](http://cocoadocs.org/docsets/SDWebImage/)
 [![Pod Platform](http://img.shields.io/cocoapods/p/SDWebImage.svg?style=flat)](http://cocoadocs.org/docsets/SDWebImage/)
 [![Pod License](http://img.shields.io/cocoapods/l/SDWebImage.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/rs/SDWebImage)
-[![codecov](https://codecov.io/gh/rs/SDWebImage/branch/master/graph/badge.svg)](https://codecov.io/gh/rs/SDWebImage)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/SDWebImage/SDWebImage)
+[![codecov](https://codecov.io/gh/SDWebImage/SDWebImage/branch/master/graph/badge.svg)](https://codecov.io/gh/SDWebImage/SDWebImage)
 
 This library provides an async image downloader with cache support. For convenience, we added categories for UI elements like `UIImageView`, `UIButton`, `MKAnnotationView`.
 
@@ -39,22 +39,22 @@ This library provides an async image downloader with cache support. For convenie
 
 #### Backwards compatibility
 
-- For iOS 5 and 6, use [any 3.x version up to 3.7.6](https://github.com/rs/SDWebImage/tree/3.7.6)
-- For iOS < 5.0, please use the last [2.0 version](https://github.com/rs/SDWebImage/tree/2.0-compat).
+- For iOS 5 and 6, use [any 3.x version up to 3.7.6](https://github.com/SDWebImage/SDWebImage/tree/3.7.6)
+- For iOS < 5.0, please use the last [2.0 version](https://github.com/SDWebImage/SDWebImage/tree/2.0-compat).
 
 ## Getting Started
 
 - Read this Readme doc
-- Read the [How to use section](https://github.com/rs/SDWebImage#how-to-use)
+- Read the [How to use section](https://github.com/SDWebImage/SDWebImage#how-to-use)
 - Read the [Documentation @ CocoaDocs](http://cocoadocs.org/docsets/SDWebImage/)
 - Try the example by downloading the project from Github or even easier using CocoaPods try `pod try SDWebImage`
-- Read the [Installation Guide](https://github.com/rs/SDWebImage/wiki/Installation-Guide)
+- Read the [Installation Guide](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide)
 - Read the [SDWebImage 4.0 Migration Guide](Docs/SDWebImage-4.0-Migration-guide.md) to get an idea of the changes from 3.x to 4.x
-- Read the [Common Problems](https://github.com/rs/SDWebImage/wiki/Common-Problems) to find the solution for common problems 
-- Go to the [Wiki Page](https://github.com/rs/SDWebImage/wiki) for more information such as [Advanced Usage](https://github.com/rs/SDWebImage/wiki/Advanced-Usage)
+- Read the [Common Problems](https://github.com/SDWebImage/SDWebImage/wiki/Common-Problems) to find the solution for common problems 
+- Go to the [Wiki Page](https://github.com/SDWebImage/SDWebImage/wiki) for more information such as [Advanced Usage](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage)
 
 ## Who Uses It
-- Find out [who uses SDWebImage](https://github.com/rs/SDWebImage/wiki/Who-Uses-SDWebImage) and add your app to the list.
+- Find out [who uses SDWebImage](https://github.com/SDWebImage/SDWebImage/wiki/Who-Uses-SDWebImage) and add your app to the list.
 
 ## Communication
 
@@ -90,7 +90,7 @@ imageView.sd_setImage(with: URL(string: "http://www.domain.com/path/to/image.jpg
 - Starting with the 4.0 version, we rely on [FLAnimatedImage](https://github.com/Flipboard/FLAnimatedImage) to take care of our animated images. 
 - If you use cocoapods, add `pod 'SDWebImage/GIF'` to your podfile.
 - To use it, simply make sure you use `FLAnimatedImageView` instead of `UIImageView`.
-- **Note**: there is a backwards compatible feature, so if you are still trying to load a GIF into a `UIImageView`, it will only show the 1st frame as a static image by default. However, you can enable the full GIF support by using the built-in GIF coder. See [GIF coder](https://github.com/rs/SDWebImage/wiki/Advanced-Usage#gif-coder)
+- **Note**: there is a backwards compatible feature, so if you are still trying to load a GIF into a `UIImageView`, it will only show the 1st frame as a static image by default. However, you can enable the full GIF support by using the built-in GIF coder. See [GIF coder](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#gif-coder)
 - **Important**: FLAnimatedImage only works on the iOS platform. For macOS, use `NSImageView` with `animates` set to `YES` to show the entire animated images and `NO` to only show the 1st frame. For all the other platforms (tvOS, watchOS) we will fallback to the backwards compatibility feature described above 
 
 ## Installation
@@ -133,7 +133,7 @@ To install with carthage, follow the instruction on [Carthage](https://github.co
 
 #### Cartfile
 ```
-github "rs/SDWebImage"
+github "SDWebImage/SDWebImage"
 ```
 
 ### Installation by cloning the repository
@@ -164,7 +164,7 @@ community can help you solve it.
 
 ## Licenses
 
-All source code is licensed under the [MIT License](https://raw.github.com/rs/SDWebImage/master/LICENSE).
+All source code is licensed under the [MIT License](https://raw.github.com/SDWebImage/SDWebImage/master/LICENSE).
 
 ## Architecture
 

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
 
   s.license = 'MIT'
   s.summary = 'Asynchronous image downloader with cache support with an UIImageView category.'
-  s.homepage = 'https://github.com/rs/SDWebImage'
+  s.homepage = 'https://github.com/SDWebImage/SDWebImage'
   s.author = { 'Olivier Poitrey' => 'rs@dailymotion.com' }
-  s.source = { :git => 'https://github.com/rs/SDWebImage.git', :tag => s.version.to_s }
+  s.source = { :git => 'https://github.com/SDWebImage/SDWebImage.git', :tag => s.version.to_s }
 
   s.description = 'This library provides a category for UIImageView with support for remote '      \
                   'images coming from the web. It provides an UIImageView category adding web '    \

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -127,7 +127,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                            FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
                            if (associatedAnimatedImage) {
                                // Asscociated animated image exist
-                               // FLAnimatedImage framework contains a bug that cause GIF been rotated if previous rendered image orientation is not Up. We have to call `setImage:` with non-nil image to reset the state. See `https://github.com/rs/SDWebImage/issues/2402`
+                               // FLAnimatedImage framework contains a bug that cause GIF been rotated if previous rendered image orientation is not Up. We have to call `setImage:` with non-nil image to reset the state. See `https://github.com/SDWebImage/SDWebImage/issues/2402`
                                strongSelf.image = associatedAnimatedImage.posterImage;
                                strongSelf.animatedImage = associatedAnimatedImage;
                                return;

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -390,7 +390,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     }
     BOOL exists = [self.fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
     
-    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+    // fallback because of https://github.com/SDWebImage/SDWebImage/pull/976 that added the extension to the disk file name
     // checking the key with and without the extension
     if (!exists) {
         exists = [self.fileManager fileExistsAtPath:[self defaultCachePathForKey:key].stringByDeletingPathExtension];
@@ -444,7 +444,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         return data;
     }
 
-    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+    // fallback because of https://github.com/SDWebImage/SDWebImage/pull/976 that added the extension to the disk file name
     // checking the key with and without the extension
     data = [NSData dataWithContentsOfFile:defaultPath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
@@ -459,7 +459,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             return imageData;
         }
 
-        // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+        // fallback because of https://github.com/SDWebImage/SDWebImage/pull/976 that added the extension to the disk file name
         // checking the key with and without the extension
         imageData = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
         if (imageData) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Update urls based on [88d3e28](https://github.com/SDWebImage/SDWebImage/commit/f9d05d921e71827f48b63cf38e28a8b1111bf6c7)
