### PR TITLE
Added Stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,28 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - important
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+  If this is still an issue, please make sure it is up to date and if so,
+  add a comment that this is still an issue to keep it open.
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 60
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+     recent activity. It will be closed if no further activity occurs.
+     If this is still applicable, please make sure it is up to date and if so,
+     add a comment that this is still an issue to keep it open.
+     Thank you for your contributions.


### PR DESCRIPTION
- Stale bot is already installed
- This PR will enable it
- Proposed config: 
  - issues
    - 30 days of inactivity mark as `Stale`, another 7 without response and the bot will auto-close. 
  - prs
    - 60 days of inactivity mark as `Stale`, another 7 without response and the bot will auto-close. 
  - marking an issue/pr with `important` label will make the bot skip it
- Note: any change like comment, label, ... will make the bot remove `Stale` label and give us another 30 days

CC @SDWebImage/collaborators 