### PR TITLE
Change the default priority of dataTask in SDWebImageDownloaderOperation.

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -190,6 +190,8 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
                 self.dataTask.priority = NSURLSessionTaskPriorityHigh;
             } else if (self.options & SDWebImageDownloaderLowPriority) {
                 self.dataTask.priority = NSURLSessionTaskPriorityLow;
+            } else {
+                self.dataTask.priority = NSURLSessionTaskPriorityDefault;
             }
         }
 #pragma clang diagnostic pop


### PR DESCRIPTION
The default priority of dataTask(NSURLSessionTask) is 0 at SDWebImage(4.4.2), which is low than NSURLSessionTaskPriorityLow. so change it to NSURLSessionTaskPriorityDefault(0.5).