### PR TITLE
Replace atomic property with SD_LOCK

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -171,7 +171,7 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 /**
  * Set a value for a HTTP header to be appended to each download HTTP request.
  *
- * @param value The value for the header field. Use `nil` value to remove the header.
+ * @param value The value for the header field. Use `nil` value to remove the header field.
  * @param field The name of the header field to set.
  */
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)field;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

The change based on two reasons:
1. Use `SD_LOCK` would not causes additional performance cost, in original code, we use `atomic` property, it uses `LOCK` internal every time we call getter or setter, and we do some copy operation, it's also unnecessary.
2. Using `atomic` property has potential issue of data corruption, even if setter or getter of `HTTPHeaders` is thread safe, but three line of code below is not safe, let's assume two thread call it concurrently, both thread 1 and thread 2 already executes [1] and [2], now would call [3], if thread 1 do first, then thread 2 call later, we can see only thread 2 works to the final `HTTPHeaders`, the operation of thread 1 lost.

```objc
NSMutableDictionary *mutableHTTPHeaders = [self.HTTPHeaders mutableCopy];  [1]
[mutableHTTPHeaders setValue:value forKey:field];   [2]
self.HTTPHeaders = [mutableHTTPHeaders copy];    [3]
```
