### PR TITLE
Fix the accident changes of Swift API naming for `sd_imageDataAsFormat:`

### DIFF
--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -52,7 +52,7 @@
  @param imageFormat The specify image format
  @return The encoded data. If can't encode, return nil
  */
-- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat;
+- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat NS_SWIFT_NAME(sd_imageData(as:));
 
 /**
  Encode the current image to data with the specify image format and compression quality
@@ -61,7 +61,7 @@
  @param compressionQuality The quality of the resulting image data. Value between 0.0-1.0. Some coders may not support compression quality.
  @return The encoded data. If can't encode, return nil
  */
-- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality;
+- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality NS_SWIFT_NAME(sd_imageData(as:compressionQuality:));
 
 /**
  Encode the current image to data with the specify image format and compression quality, allow specify animate/static control
@@ -71,6 +71,6 @@
  @param firstFrameOnly Even if the image is animated image, encode the first frame only as static image.
  @return The encoded data. If can't encode, return nil
  */
-- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality firstFrameOnly:(BOOL)firstFrameOnly;
+- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality firstFrameOnly:(BOOL)firstFrameOnly NS_SWIFT_NAME(sd_imageData(as:compressionQuality:firstFrameOnly:));
 
 @end


### PR DESCRIPTION
We should keep previous naming `sd_imageData(as:)` from 4.x, it should not be a API break changes.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2400 #2413 

### Pull Request Description

It seems that since we change `SDImageFormat` from enum to `NS_TYPED_EXTENSIBLE_ENUM`, cause some Swift API naming changed by accident. These current API naming is OK.

In #2413 I fix some, but today when I try to migrate a 4.x project into 5.x, I found that this API was also been changed by accident. We should recovery them with correct API for Swift user before 5.0.0 release.

+ `sd_imageData(as imageFormat: SDImageFormat) -> Data?` => `sd_imageData(asFormat imageFormat: SDImageFormat) -> Data?`

