### PR TITLE
Remove synchronized lock when read cached response from NSURLCache

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -170,11 +170,11 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
         
         if (self.options & SDWebImageDownloaderIgnoreCachedResponse) {
             // Grab the cached data for later check
-            NSURLCache *URLCache = session.configuration.URLCache;
-            if (!URLCache) {
-                URLCache = [NSURLCache sharedURLCache];
+            NSURLCache *urlCache = session.configuration.URLCache;
+            if (!urlCache) {
+                urlCache = [NSURLCache sharedURLCache];
             }
-            self.cachedData = [URLCache cachedResponseForRequest:self.request].data;
+            self.cachedData = [urlCache cachedResponseForRequest:self.request].data;
         }
         
         self.dataTask = [session dataTaskWithRequest:self.request];

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -174,14 +174,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
             if (!URLCache) {
                 URLCache = [NSURLCache sharedURLCache];
             }
-            NSCachedURLResponse *cachedResponse;
-            // NSURLCache's `cachedResponseForRequest:` is not thread-safe, see https://developer.apple.com/documentation/foundation/nsurlcache#2317483
-            @synchronized (URLCache) {
-                cachedResponse = [URLCache cachedResponseForRequest:self.request];
-            }
-            if (cachedResponse) {
-                self.cachedData = cachedResponse.data;
-            }
+            self.cachedData = [URLCache cachedResponseForRequest:self.request].data;
         }
         
         self.dataTask = [session dataTaskWithRequest:self.request];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description
Refer to `Git` log, seems try to fix thread race condition, but actually, this has not any benefit for fix, the reason is read operation would not cause race condition, only if there exist write operation concurrently, only synchronize read operation is useless, we don't do write operation in our framework by ourself, only URL loading system would do it. So if we want to fix race condition, we can't use shared NSURLCache, because we can't control it, and if we use separate NSURLCache for downloader, we may still need to forbidden loading system to store response, instead, we call `storeCachedResponse:forRequest:` by ourself, so we can synchronize read and write operation.

