### PR TITLE
Fix `imageIndicator` retain cycle issue, and avoid leak

### DIFF
--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -65,7 +65,6 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 #if SD_UIKIT || SD_MAC
         // check and start image indicator
         [self sd_startImageIndicator];
-        id<SDWebImageIndicator> imageIndicator = self.sd_imageIndicator;
 #endif
         
         SDWebImageManager *manager = context[SDWebImageContextCustomManager];
@@ -80,6 +79,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             imageProgress.totalUnitCount = expectedSize;
             imageProgress.completedUnitCount = receivedSize;
 #if SD_UIKIT || SD_MAC
+            id <SDWebImageIndicator> imageIndicator = sself.sd_imageIndicator;
             if ([imageIndicator respondsToSelector:@selector(updateIndicatorProgress:)]) {
                 double progress = imageProgress.fractionCompleted;
                 dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

 Fix `imageIndicator` in combinedProgressBlock has retain cycle issue.

