### PR TITLE
Expose the graphics helper method for coder plugin author and fix scale issue

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -57,6 +57,12 @@
 		325312CA200F09910046BF1E /* SDWebImageTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 325312C6200F09910046BF1E /* SDWebImageTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		325312CE200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D0200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
+		3257EAF921898AED0097B271 /* SDImageGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257EAF721898AED0097B271 /* SDImageGraphics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257EAFA21898AED0097B271 /* SDImageGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257EAF721898AED0097B271 /* SDImageGraphics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257EAFB21898AED0097B271 /* SDImageGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257EAF721898AED0097B271 /* SDImageGraphics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257EAFC21898AED0097B271 /* SDImageGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257EAF821898AED0097B271 /* SDImageGraphics.m */; };
+		3257EAFD21898AED0097B271 /* SDImageGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257EAF821898AED0097B271 /* SDImageGraphics.m */; };
+		3257EAFE21898AED0097B271 /* SDImageGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257EAF821898AED0097B271 /* SDImageGraphics.m */; };
 		327054D4206CD8B3006EA328 /* SDImageAPNGCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 327054D2206CD8B3006EA328 /* SDImageAPNGCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327054D6206CD8B3006EA328 /* SDImageAPNGCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 327054D2206CD8B3006EA328 /* SDImageAPNGCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327054DA206CD8B3006EA328 /* SDImageAPNGCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 327054D3206CD8B3006EA328 /* SDImageAPNGCoder.m */; };
@@ -243,6 +249,8 @@
 		324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDefine.m; sourceTree = "<group>"; };
 		325312C6200F09910046BF1E /* SDWebImageTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTransition.h; sourceTree = "<group>"; };
 		325312C7200F09910046BF1E /* SDWebImageTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTransition.m; sourceTree = "<group>"; };
+		3257EAF721898AED0097B271 /* SDImageGraphics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDImageGraphics.h; sourceTree = "<group>"; };
+		3257EAF821898AED0097B271 /* SDImageGraphics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDImageGraphics.m; sourceTree = "<group>"; };
 		327054D2206CD8B3006EA328 /* SDImageAPNGCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageAPNGCoder.h; sourceTree = "<group>"; };
 		327054D3206CD8B3006EA328 /* SDImageAPNGCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageAPNGCoder.m; sourceTree = "<group>"; };
 		328BB69A2081FED200760D6C /* SDWebImageCacheKeyFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageCacheKeyFilter.h; sourceTree = "<group>"; };
@@ -369,6 +377,8 @@
 				3290FA031FA478AF0047D20C /* SDImageFrame.m */,
 				32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */,
 				32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */,
+				3257EAF721898AED0097B271 /* SDImageGraphics.h */,
+				3257EAF821898AED0097B271 /* SDImageGraphics.m */,
 			);
 			name = Decoder;
 			sourceTree = "<group>";
@@ -603,6 +613,7 @@
 			files = (
 				32D122202080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				32B9B539206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
+				3257EAFA21898AED0097B271 /* SDImageGraphics.h in Headers */,
 				328BB6AC2081FEE500760D6C /* SDWebImageCacheSerializer.h in Headers */,
 				321B378F2083290E00C0EA77 /* SDImageLoadersManager.h in Headers */,
 				329A185B1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
@@ -658,6 +669,7 @@
 			files = (
 				32CF1C071FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				32F7C0842030719600873181 /* UIImage+Transform.h in Headers */,
+				3257EAF921898AED0097B271 /* SDImageGraphics.h in Headers */,
 				53761316155AD0D5005750A4 /* SDImageCache.h in Headers */,
 				325312C8200F09910046BF1E /* SDWebImageTransition.h in Headers */,
 				32C0FDE12013426C001B8F2D /* SDWebImageIndicator.h in Headers */,
@@ -711,6 +723,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257EAFB21898AED0097B271 /* SDImageGraphics.h in Headers */,
 				806BE07E2142C65200E02143 /* SDWebImageMapKit.h in Headers */,
 				80B6DFCD2142B71600BCB334 /* MKAnnotationView+WebCache.h in Headers */,
 			);
@@ -846,6 +859,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257EAFD21898AED0097B271 /* SDImageGraphics.m in Sources */,
 				3290FA0C1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				321E60C61F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				328BB6A42081FED200760D6C /* SDWebImageCacheKeyFilter.m in Sources */,
@@ -899,6 +913,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257EAFC21898AED0097B271 /* SDImageGraphics.m in Sources */,
 				3290FA0A1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				321E60C41F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				328BB6A22081FED200760D6C /* SDWebImageCacheKeyFilter.m in Sources */,
@@ -953,6 +968,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80B6DFA72142B71600BCB334 /* MKAnnotationView+WebCache.m in Sources */,
+				3257EAFE21898AED0097B271 /* SDImageGraphics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SDWebImage/SDImageGraphics.h
+++ b/SDWebImage/SDImageGraphics.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCompat.h"
+#import <CoreGraphics/CoreGraphics.h>
+
+/**
+ These following graphics context method are provided to easily write cross-platform(AppKit/UIKit) code.
+ For UIKit, these methods just call the same method in `UIGraphics.h`. See the documentation for usage.
+ For AppKit, these methods use `NSGraphicsContext` to create image context and match the behavior like UIKit.
+ */
+FOUNDATION_EXPORT CGContextRef __nullable SDGraphicsGetCurrentContext(void) CF_RETURNS_NOT_RETAINED;
+FOUNDATION_EXPORT void SDGraphicsBeginImageContext(CGSize size);
+FOUNDATION_EXPORT void SDGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale);
+FOUNDATION_EXPORT void SDGraphicsEndImageContext(void);
+FOUNDATION_EXPORT UIImage * __nullable SDGraphicsGetImageFromCurrentImageContext(void);

--- a/SDWebImage/SDImageGraphics.m
+++ b/SDWebImage/SDImageGraphics.m
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDImageGraphics.h"
+#import "NSImage+Compatibility.h"
+#import "objc/runtime.h"
+
+#if SD_MAC
+static void *kNSGraphicsContextScaleFactorKey;
+
+static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
+    if (scale == 0) {
+        // Match `UIGraphicsBeginImageContextWithOptions`, reset to the scale factor of the device’s main screen if scale is 0.
+        scale = [NSScreen mainScreen].backingScaleFactor;
+    }
+    size_t width = ceil(size.width * scale);
+    size_t height = ceil(size.height * scale);
+    if (width < 1 || height < 1) return NULL;
+    
+    //pre-multiplied BGRA for non-opaque, BGRX for opaque, 8-bits per component, as Apple's doc
+    CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+    CGImageAlphaInfo alphaInfo = kCGBitmapByteOrder32Host | (opaque ? kCGImageAlphaNoneSkipFirst : kCGImageAlphaPremultipliedFirst);
+    CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, 0, space, kCGBitmapByteOrderDefault | alphaInfo);
+    CGColorSpaceRelease(space);
+    if (!context) {
+        return NULL;
+    }
+    CGContextScaleCTM(context, scale, scale);
+    
+    return context;
+}
+#endif
+
+CGContextRef SDGraphicsGetCurrentContext(void) {
+#if SD_UIKIT || SD_WATCH
+    return UIGraphicsGetCurrentContext();
+#else
+    return NSGraphicsContext.currentContext.CGContext;
+#endif
+}
+
+void SDGraphicsBeginImageContext(CGSize size) {
+#if SD_UIKIT || SD_WATCH
+    SDGraphicsBeginImageContext(size);
+#else
+    SDGraphicsBeginImageContextWithOptions(size, NO, 1.0);
+#endif
+}
+
+void SDGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale) {
+#if SD_UIKIT || SD_WATCH
+    UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
+#else
+    CGContextRef context = SDCGContextCreateBitmapContext(size, opaque, scale);
+    if (!context) {
+        return;
+    }
+    NSGraphicsContext *graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:context flipped:NO];
+    objc_setAssociatedObject(graphicsContext, &kNSGraphicsContextScaleFactorKey, @(scale), OBJC_ASSOCIATION_RETAIN);
+    CGContextRelease(context);
+    [NSGraphicsContext saveGraphicsState];
+    NSGraphicsContext.currentContext = graphicsContext;
+#endif
+}
+
+void SDGraphicsEndImageContext(void) {
+#if SD_UIKIT || SD_WATCH
+    UIGraphicsEndImageContext();
+#else
+    [NSGraphicsContext restoreGraphicsState];
+#endif
+}
+
+UIImage * SDGraphicsGetImageFromCurrentImageContext(void) {
+#if SD_UIKIT || SD_WATCH
+    return UIGraphicsGetImageFromCurrentImageContext();
+#else
+    NSGraphicsContext *context = NSGraphicsContext.currentContext;
+    CGContextRef contextRef = context.CGContext;
+    if (!contextRef) {
+        return nil;
+    }
+    CGImageRef imageRef = CGBitmapContextCreateImage(contextRef);
+    if (!imageRef) {
+        return nil;
+    }
+    CGFloat scale = 0;
+    NSNumber *scaleFactor = objc_getAssociatedObject(context, &kNSGraphicsContextScaleFactorKey);
+    if ([scaleFactor isKindOfClass:[NSNumber class]]) {
+        scale = scaleFactor.doubleValue;
+    }
+    if (!scale) {
+        // reset to the scale factor of the device’s main screen if scale is 0.
+        scale = [NSScreen mainScreen].backingScaleFactor;
+    }
+    NSImage *image = [[NSImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
+    CGImageRelease(imageRef);
+    return image;
+#endif
+}

--- a/SDWebImage/UIImage+Transform.m
+++ b/SDWebImage/UIImage+Transform.m
@@ -18,6 +18,10 @@
 static void *kNSGraphicsContextScaleFactorKey;
 
 static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
+    if (scale == 0) {
+        // Match `UIGraphicsBeginImageContextWithOptions`, reset to the scale factor of the device’s main screen if scale is 0.
+        scale = [NSScreen mainScreen].backingScaleFactor;
+    }
     size_t width = ceil(size.width * scale);
     size_t height = ceil(size.height * scale);
     if (width < 1 || height < 1) return NULL;
@@ -29,10 +33,6 @@ static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGF
     CGColorSpaceRelease(space);
     if (!context) {
         return NULL;
-    }
-    if (scale == 0) {
-        // Match `UIGraphicsBeginImageContextWithOptions`, reset to the scale factor of the device’s main screen if scale is 0.
-        scale = [NSScreen mainScreen].backingScaleFactor;
     }
     CGContextScaleCTM(context, scale, scale);
     

--- a/SDWebImage/UIImage+Transform.m
+++ b/SDWebImage/UIImage+Transform.m
@@ -8,97 +8,11 @@
 
 #import "UIImage+Transform.h"
 #import "NSImage+Compatibility.h"
+#import "SDImageGraphics.h"
 #import <Accelerate/Accelerate.h>
 #if SD_UIKIT || SD_MAC
 #import <CoreImage/CoreImage.h>
-#import "objc/runtime.h"
 #endif
-
-#if SD_MAC
-static void *kNSGraphicsContextScaleFactorKey;
-
-static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
-    if (scale == 0) {
-        // Match `UIGraphicsBeginImageContextWithOptions`, reset to the scale factor of the device’s main screen if scale is 0.
-        scale = [NSScreen mainScreen].backingScaleFactor;
-    }
-    size_t width = ceil(size.width * scale);
-    size_t height = ceil(size.height * scale);
-    if (width < 1 || height < 1) return NULL;
-    
-    //pre-multiplied BGRA for non-opaque, BGRX for opaque, 8-bits per component, as Apple's doc
-    CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGImageAlphaInfo alphaInfo = kCGBitmapByteOrder32Host | (opaque ? kCGImageAlphaNoneSkipFirst : kCGImageAlphaPremultipliedFirst);
-    CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, 0, space, kCGBitmapByteOrderDefault | alphaInfo);
-    CGColorSpaceRelease(space);
-    if (!context) {
-        return NULL;
-    }
-    CGContextScaleCTM(context, scale, scale);
-    
-    return context;
-}
-#endif
-
-static void SDGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale) {
-#if SD_UIKIT || SD_WATCH
-    UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
-#else
-    CGContextRef context = SDCGContextCreateBitmapContext(size, opaque, scale);
-    if (!context) {
-        return;
-    }
-    NSGraphicsContext *graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:context flipped:NO];
-    objc_setAssociatedObject(graphicsContext, &kNSGraphicsContextScaleFactorKey, @(scale), OBJC_ASSOCIATION_RETAIN);
-    CGContextRelease(context);
-    [NSGraphicsContext saveGraphicsState];
-    NSGraphicsContext.currentContext = graphicsContext;
-#endif
-}
-
-static CGContextRef SDGraphicsGetCurrentContext(void) {
-#if SD_UIKIT || SD_WATCH
-    return UIGraphicsGetCurrentContext();
-#else
-    return NSGraphicsContext.currentContext.CGContext;
-#endif
-}
-
-static void SDGraphicsEndImageContext(void) {
-#if SD_UIKIT || SD_WATCH
-    UIGraphicsEndImageContext();
-#else
-    [NSGraphicsContext restoreGraphicsState];
-#endif
-}
-
-static UIImage * SDGraphicsGetImageFromCurrentImageContext(void) {
-#if SD_UIKIT || SD_WATCH
-    return UIGraphicsGetImageFromCurrentImageContext();
-#else
-    NSGraphicsContext *context = NSGraphicsContext.currentContext;
-    CGContextRef contextRef = context.CGContext;
-    if (!contextRef) {
-        return nil;
-    }
-    CGImageRef imageRef = CGBitmapContextCreateImage(contextRef);
-    if (!imageRef) {
-        return nil;
-    }
-    CGFloat scale = 0;
-    NSNumber *scaleFactor = objc_getAssociatedObject(context, &kNSGraphicsContextScaleFactorKey);
-    if ([scaleFactor isKindOfClass:[NSNumber class]]) {
-        scale = scaleFactor.doubleValue;
-    }
-    if (!scale) {
-        // reset to the scale factor of the device’s main screen if scale is 0.
-        scale = [NSScreen mainScreen].backingScaleFactor;
-    }
-    NSImage *image = [[NSImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
-    CGImageRelease(imageRef);
-    return image;
-#endif
-}
 
 static inline CGRect SDCGRectFitWithScaleMode(CGRect rect, CGSize size, SDImageScaleMode scaleMode) {
     rect = CGRectStandardize(rect);

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -59,6 +59,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDImageIOCoder.h>
 #import <SDWebImage/SDImageFrame.h>
 #import <SDWebImage/SDImageCoderHelper.h>
+#import <SDWebImage/SDImageGraphics.h>
 #import <SDWebImage/UIImage+GIF.h>
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass // Just code movement, they've already been tested via transformer tests
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

😅 Current we have some cross-platform helper method, like these `SDGraphics *` method to create and render bitmap context for images. Those methods are really useful for our image transform implementation cross UIKit/AppKit.

Currently we hide them tied to the `UIImage+Transform` as static method, however, some coder plugin author wants to use them as well. And other modules like `SDImageCoderHelper` may also use some of them to simply code. Instead of each one duplicate a copy of these method, I think since these method are for really common usage, and does not cause too much of maintain issue. It's a good idea to expose them.

I put all of them into a single files (like `UIGraphics.h), to make it modular to use. Our PDF coder [SDWebImagePDFCoder](https://github.com/SDWebImage/SDWebImagePDFCoder) want to use this to render bitmap representation PDF. I previously [copy the code there](https://github.com/SDWebImage/SDWebImagePDFCoder/blob/master/SDWebImagePDFCoder/Classes/SDImagePDFCoder.m#L26-L110). I think it's a suck...So this approach it much more better.