### PR TITLE
Fix the `SDGraphicsBeginImageContext` method recursive call issue

### DIFF
--- a/SDWebImage/SDImageGraphics.m
+++ b/SDWebImage/SDImageGraphics.m
@@ -46,7 +46,7 @@ CGContextRef SDGraphicsGetCurrentContext(void) {
 
 void SDGraphicsBeginImageContext(CGSize size) {
 #if SD_UIKIT || SD_WATCH
-    SDGraphicsBeginImageContext(size);
+    UIGraphicsBeginImageContext(size);
 #else
     SDGraphicsBeginImageContextWithOptions(size, NO, 1.0);
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2523 

### Pull Request Description

A code mistake, which cause recursive call. Currently this method seems have no test case coverage. Only that `SDGraphicsBeginImageContextWithOptions` is covered. Need we add one ?

