### PR TITLE
Fix FLAnimatedImage cache invalid

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -121,7 +121,7 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
     // Fix user uses `UIImageView` category method to load GIF, and then uses `FLAnimatedImageView` category method to load the same image.
     // Fix image load from disk, and then `SDImageCache` restore it to memory cache.
     // It's not 100% safe, race condition would appear if we remove and then store cache when using `UIImageView` category method before `FLAnimatedImageView` category method complete.
-    if (cacheImage && (!cacheFLAnimatedImage || !cacheImage.sd_FLAnimatedImage)) {
+    if (cacheImage && cacheImage.sd_imageFormat == SDImageFormatGIF && (!cacheFLAnimatedImage || !cacheImage.sd_FLAnimatedImage)) {
         [[SDImageCache sharedImageCache] removeImageForKey:cacheKey fromDisk:NO withCompletion:nil];
     }
     


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 

### Pull Request Description

If memory cache hit, but the cached image do not have `sd_cacheFLAnimatedImage`, we remove it directly. Because `disk` data is not always exist even if memory data exist.
