### PR TITLE
Add image url check when set image

### DIFF
--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -101,7 +101,7 @@ static char TAG_ACTIVITY_SHOW;
         };
         id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options progress:combinedProgressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong __typeof (wself) sself = wself;
-            if (!sself) { return; }
+            if (!sself || ![imageURL isEqual:sself.sd_imageURL]) { return; }
 #if SD_UIKIT
             [sself sd_removeActivityIndicator];
 #endif
@@ -114,9 +114,10 @@ static char TAG_ACTIVITY_SHOW;
             BOOL shouldNotSetImage = ((image && (options & SDWebImageAvoidAutoSetImage)) ||
                                       (!image && !(options & SDWebImageDelayPlaceholder)));
             SDWebImageNoParamsBlock callCompletedBlockClojure = ^{
-                if (!sself) { return; }
+                __strong __typeof(wself) strongSelf = wself;
+                if (!strongSelf || ![strongSelf.sd_imageURL isEqual:imageURL]) { return; }
                 if (!shouldNotSetImage) {
-                    [sself sd_setNeedsLayout];
+                    [strongSelf sd_setNeedsLayout];
                 }
                 if (completedBlock && shouldCallCompletedBlock) {
                     completedBlock(image, error, cacheType, url);
@@ -154,6 +155,7 @@ static char TAG_ACTIVITY_SHOW;
                 if (group) {
                     dispatch_group_enter(group);
                 }
+                if (![sself.sd_imageURL isEqual:imageURL]) { return ; }
 #if SD_UIKIT || SD_MAC
                 [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
 #else


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

`sd_cancelImageLoadOperationWithKey` would remove the operation, but it's not sufficient, because `completed` block can be executing when remove the operation, so we need to add the url check before we call `setImage`.