### PR TITLE
Fix progress、activity indicator and setImage logic when loading multiple images concurrently

### DIFF
--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -28,7 +28,7 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
 @interface UIView (WebCache)
 
 /**
- * Get the current image URL.
+ * Get the current image URL, if you load images concurrently, this return the latest image URL.
  *
  * @note Note that because of the limitations of categories this property can get out of sync if you use setImage: directly.
  */

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -162,13 +162,11 @@ static char TAG_ACTIVITY_SHOW;
                 if (group) {
                     dispatch_group_enter(group);
                 }
-                if ([sself.sd_imageURL isEqual:url]) {
 #if SD_UIKIT || SD_MAC
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
+                [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
 #else
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
+                [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
 #endif
-                }
                 if (group) {
                     // compatible code for FLAnimatedImage, because we assume completedBlock called after image was set. This will be removed in 5.x
                     BOOL shouldUseGroup = [objc_getAssociatedObject(group, &SDWebImageInternalSetImageGroupKey) boolValue];

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -163,7 +163,7 @@ static char TAG_ACTIVITY_SHOW;
                 if (group) {
                     dispatch_group_enter(group);
                 }
-                NSURL *operationURL = [sself sd_getImageURLWithOperationKey:validOperationKey];
+                NSURL *operationURL = [sself sd_imageURLWithOperationKey:validOperationKey];
                 // One operation key associate one url, check wether current operation still loading image of url, prevent set wrong image
                 if ([operationURL isEqual:url]) {
 #if SD_UIKIT || SD_MAC

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -54,6 +54,6 @@
  *  @param operationKey   key for storing the image URL
  *  @return image URL
  */
-- (nullable NSURL *)sd_getImageURLWithOperationKey:(nullable NSString *)operationKey;
+- (nullable NSURL *)sd_imageURLWithOperationKey:(nullable NSString *)operationKey;
 
 @end

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -22,11 +22,16 @@
 - (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key;
 
 /**
- *  Cancel all operations for the current UIView and key
+ *  Cancel operation for the current UIView and key
  *
  *  @param key key for identifying the operations
  */
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key;
+
+/**
+ *  Cancel all operations for the current UIView
+ */
+- (void)sd_cancelAllImageLoadOperations;
 
 /**
  *  Just remove the operations corresponding to the current UIView and key without cancelling them
@@ -34,5 +39,21 @@
  *  @param key key for identifying the operations
  */
 - (void)sd_removeImageLoadOperationWithKey:(nullable NSString *)key;
+
+/**
+ *  Set the image URL for the operation key
+ *
+ *  @param url            the image URL
+ *  @param operationKey   key for storing the image URL
+ */
+- (void)sd_setImageURL:(nullable NSURL *)url forOperationKey:(nullable NSString *)operationKey;
+
+/**
+ *  Get the image URL for the operation key
+ *
+ *  @param operationKey   key for storing the image URL
+ *  @return image URL
+ */
+- (nullable NSURL *)sd_getImageURLWithOperationKey:(nullable NSString *)operationKey;
 
 @end

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -102,7 +102,7 @@ typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
     }
 }
 
-- (NSURL *)sd_getImageURLWithOperationKey:(nullable NSString *)operationKey {
+- (NSURL *)sd_imageURLWithOperationKey:(nullable NSString *)operationKey {
     if (operationKey) {
         @synchronized (self) {
             return [self sd_imageURLOperationDictionary][operationKey];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

We support `UIView` loading multiple images concurrently by `operationKey`, but this would mess up `NSProgress`、`Activity Indicator`、`setImage` logical.
My opinion is we only do these operation when `url` is equal to `sd_imageURL`. Other words, we only do for latest loading image.

