### PR TITLE
Use the memory bytes size, instead of pixel size to calculate the cost for SDMemoryCache

### DIFF
--- a/SDWebImage/SDAnimatedImage.h
+++ b/SDWebImage/SDAnimatedImage.h
@@ -57,6 +57,12 @@
  */
 @property (nonatomic, assign, readonly, getter=isAllFramesLoaded) BOOL allFramesLoaded;
 
+/**
+ Retuens the current loaded animated image memory size, this can help to optimize memory usage, for the cache system.
+ It's recommaned to return the current loaded frames size * bytes per frame. If you don't implements `preloadAllFrams`, don't keep decoded frames in the memory, you may not need to implements this method because we provide a default calculation.
+ */
+@property (nonatomic, assign, readonly) NSUInteger animatedImageMemoryCost;
+
 @end
 
 @interface SDAnimatedImage : UIImage <SDAnimatedImage>

--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -349,6 +349,21 @@ static NSArray *SDBundlePreferredScales() {
     }
 }
 
+- (NSUInteger)animatedImageMemoryCost {
+    CGImageRef imageRef = self.CGImage;
+    if (!imageRef) {
+        return 0;
+    }
+    NSUInteger bytesPerFrame = CGImageGetBytesPerRow(imageRef) * CGImageGetHeight(imageRef);
+    NSUInteger frameCount;
+    if (self.isAllFramesLoaded) {
+        frameCount = self.animatedImageFrameCount;
+    }
+    frameCount = frameCount > 0 ? frameCount : 1;
+    NSUInteger cost = bytesPerFrame * frameCount;
+    return cost;
+}
+
 #pragma mark - NSSecureCoding
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -181,7 +181,7 @@
     }
     // if memory cache is enabled
     if (toMemory && self.config.shouldCacheImagesInMemory) {
-        NSUInteger cost = [self.class memoryCacheCostForImage:image];
+        NSUInteger cost = SDMemoryCacheCostForImage(image);
         [self.memCache setObject:image forKey:key cost:cost];
     }
     
@@ -219,7 +219,7 @@
     if (!image || !key) {
         return;
     }
-    NSUInteger cost = [self.class memoryCacheCostForImage:image];
+    NSUInteger cost = SDMemoryCacheCostForImage(image);
     [self.memCache setObject:image forKey:key cost:cost];
 }
 
@@ -297,7 +297,7 @@
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key {
     UIImage *diskImage = [self diskImageForKey:key];
     if (diskImage && self.config.shouldCacheImagesInMemory) {
-        NSUInteger cost = [self.class memoryCacheCostForImage:diskImage];
+        NSUInteger cost = SDMemoryCacheCostForImage(diskImage);
         [self.memCache setObject:diskImage forKey:key cost:cost];
     }
 
@@ -414,7 +414,7 @@
                 // decode image data only if in-memory cache missed
                 diskImage = [self diskImageForKey:key data:diskData options:options context:context];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
-                    NSUInteger cost = [self.class memoryCacheCostForImage:diskImage];
+                    NSUInteger cost = SDMemoryCacheCostForImage(diskImage);
                     [self.memCache setObject:diskImage forKey:key cost:cost];
                 }
             }
@@ -603,16 +603,6 @@
     if (cacheOptions & SDImageCacheAvoidDecodeImage) options |= SDWebImageAvoidDecodeImage;
     
     return options;
-}
-
-+ (NSUInteger)memoryCacheCostForImage:(nonnull UIImage *)image {
-    NSUInteger cost;
-    if ([image conformsToProtocol:@protocol(SDAnimatedImage)] && [image respondsToSelector:@selector(animatedImageMemoryCost)]) {
-        cost = ((id<SDAnimatedImage>)image).animatedImageMemoryCost;
-    } else {
-        cost = SDMemoryCacheCostForImage(image);
-    }
-    return cost;
 }
 
 @end

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -181,7 +181,7 @@
     }
     // if memory cache is enabled
     if (toMemory && self.config.shouldCacheImagesInMemory) {
-        NSUInteger cost = SDMemoryCacheCostForImage(image);
+        NSUInteger cost = [self.class memoryCacheCostForImage:image];
         [self.memCache setObject:image forKey:key cost:cost];
     }
     
@@ -219,7 +219,7 @@
     if (!image || !key) {
         return;
     }
-    NSUInteger cost = SDMemoryCacheCostForImage(image);
+    NSUInteger cost = [self.class memoryCacheCostForImage:image];
     [self.memCache setObject:image forKey:key cost:cost];
 }
 
@@ -297,7 +297,7 @@
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key {
     UIImage *diskImage = [self diskImageForKey:key];
     if (diskImage && self.config.shouldCacheImagesInMemory) {
-        NSUInteger cost = SDMemoryCacheCostForImage(diskImage);
+        NSUInteger cost = [self.class memoryCacheCostForImage:diskImage];
         [self.memCache setObject:diskImage forKey:key cost:cost];
     }
 
@@ -414,7 +414,7 @@
                 // decode image data only if in-memory cache missed
                 diskImage = [self diskImageForKey:key data:diskData options:options context:context];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
-                    NSUInteger cost = SDMemoryCacheCostForImage(diskImage);
+                    NSUInteger cost = [self.class memoryCacheCostForImage:diskImage];
                     [self.memCache setObject:diskImage forKey:key cost:cost];
                 }
             }
@@ -603,6 +603,16 @@
     if (cacheOptions & SDImageCacheAvoidDecodeImage) options |= SDWebImageAvoidDecodeImage;
     
     return options;
+}
+
++ (NSUInteger)memoryCacheCostForImage:(nonnull UIImage *)image {
+    NSUInteger cost;
+    if ([image conformsToProtocol:@protocol(SDAnimatedImage)] && [image respondsToSelector:@selector(animatedImageMemoryCost)]) {
+        cost = ((id<SDAnimatedImage>)image).animatedImageMemoryCost;
+    } else {
+        cost = SDMemoryCacheCostForImage(image);
+    }
+    return cost;
 }
 
 @end

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -82,13 +82,14 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 @property (assign, nonatomic) NSUInteger maxCacheSize;
 
 /**
- * The maximum "total cost" of the in-memory image cache. The cost function is the number of pixels held in memory.
+ * The maximum "total cost" of the in-memory image cache. The cost function is the bytes size held in memory.
+ * @note The memory cost is bytes size in memory, but not simple pixels count. For common ARGB8888 image, one pixel is 4 bytes (32 bits).
  * Defaults to 0. Which means there is no memory cost limit.
  */
 @property (assign, nonatomic) NSUInteger maxMemoryCost;
 
 /**
- * The maximum number of objects the cache should hold.
+ * The maximum number of objects in-memory image cache should hold.
  * Defaults to 0. Which means there is no memory count limit.
  */
 @property (assign, nonatomic) NSUInteger maxMemoryCount;

--- a/SDWebImage/SDMemoryCache.h
+++ b/SDWebImage/SDMemoryCache.h
@@ -13,8 +13,8 @@
  
  For `UIImage`, this method return the single frame bytes size when `image.images` is nil for static image. Retuen full bytes per frame * frame count when `image.images` is not nil for animated image.
  For `NSImage`, this method return the single frame bytes size because `NSImage` does not store all frames in memory.
+ For custom animated class conforms to `SDAnimatedImage` and implements `animatedImageMemoryCost` method, return that value instead.
  For any other case which cause the image's CGImage bitmap representation invalid (for example, vector image), return 0;
- @note For advanced custom animated class conforms to `SDAnimatedImage`, you can also use `animatedImageMemoryCost` method to return the desired value instead of this default calculation.
 
  @param image The image to store in cache
  @return The memory cost for the image

--- a/SDWebImage/SDMemoryCache.h
+++ b/SDWebImage/SDMemoryCache.h
@@ -9,7 +9,12 @@
 #import "SDWebImageCompat.h"
 
 /**
- Return the memory cache cost for specify image
+ Return the memory cache cost for specify image. The cost function is the bytes size held in memory.
+ 
+ For `UIImage`, this method return the single frame bytes size when `image.images` is nil for static image. Retuen full bytes per frame * frame count when `image.images` is not nil for animated image.
+ For `NSImage`, this method return the single frame bytes size because `NSImage` does not store all frames in memory.
+ For any other case which cause the image's CGImage bitmap representation invalid (for example, vector image), return 0;
+ @note For advanced custom animated class conforms to `SDAnimatedImage`, you can also use `animatedImageMemoryCost` method to return the desired value instead of this default calculation.
 
  @param image The image to store in cache
  @return The memory cost for the image

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -8,6 +8,7 @@
 
 #import "SDMemoryCache.h"
 #import "SDImageCacheConfig.h"
+#import "SDAnimatedImage.h"
 
 NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
     CGImageRef imageRef = image.CGImage;
@@ -117,7 +118,7 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
             // Sync cache
             NSUInteger cost = 0;
             if ([obj isKindOfClass:[UIImage class]]) {
-                cost = SDMemoryCacheCostForImage(obj);
+                cost = [self.class memoryCacheCostForImage:obj];
             }
             [super setObject:obj forKey:key cost:cost];
         }
@@ -148,6 +149,18 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
     [self.weakCache removeAllObjects];
     SD_UNLOCK(self.weakCacheLock);
 }
+
+#pragma mark - Helper
++ (NSUInteger)memoryCacheCostForImage:(nonnull UIImage *)image {
+    NSUInteger cost;
+    if ([image conformsToProtocol:@protocol(SDAnimatedImage)] && [image respondsToSelector:@selector(animatedImageMemoryCost)]) {
+        cost = ((id<SDAnimatedImage>)image).animatedImageMemoryCost;
+    } else {
+        cost = SDMemoryCacheCostForImage(image);
+    }
+    return cost;
+}
+
 #endif
 
 #pragma mark - KVO

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -11,6 +11,9 @@
 #import "SDAnimatedImage.h"
 
 NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
+    if ([image conformsToProtocol:@protocol(SDAnimatedImage)] && [image respondsToSelector:@selector(animatedImageMemoryCost)]) {
+        return ((id<SDAnimatedImage>)image).animatedImageMemoryCost;
+    }
     CGImageRef imageRef = image.CGImage;
     if (!imageRef) {
         return 0;
@@ -118,7 +121,7 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
             // Sync cache
             NSUInteger cost = 0;
             if ([obj isKindOfClass:[UIImage class]]) {
-                cost = [self.class memoryCacheCostForImage:obj];
+                cost = SDMemoryCacheCostForImage(obj);
             }
             [super setObject:obj forKey:key cost:cost];
         }
@@ -149,18 +152,6 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
     [self.weakCache removeAllObjects];
     SD_UNLOCK(self.weakCacheLock);
 }
-
-#pragma mark - Helper
-+ (NSUInteger)memoryCacheCostForImage:(nonnull UIImage *)image {
-    NSUInteger cost;
-    if ([image conformsToProtocol:@protocol(SDAnimatedImage)] && [image respondsToSelector:@selector(animatedImageMemoryCost)]) {
-        cost = ((id<SDAnimatedImage>)image).animatedImageMemoryCost;
-    } else {
-        cost = SDMemoryCacheCostForImage(image);
-    }
-    return cost;
-}
-
 #endif
 
 #pragma mark - KVO

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -10,11 +10,19 @@
 #import "SDImageCacheConfig.h"
 
 NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
+    CGImageRef imageRef = image.CGImage;
+    if (!imageRef) {
+        return 0;
+    }
+    NSUInteger bytesPerFrame = CGImageGetBytesPerRow(imageRef) * CGImageGetHeight(imageRef);
+    NSUInteger frameCount;
 #if SD_MAC
-    return image.size.height * image.size.width;
+    frameCount = 1;
 #elif SD_UIKIT || SD_WATCH
-    return image.size.height * image.size.width * image.scale * image.scale;
+    frameCount = image.images.count > 0 ? image.images.count : 1;
 #endif
+    NSUInteger cost = bytesPerFrame * frameCount;
+    return cost;
 }
 
 static void * SDMemoryCacheContext = &SDMemoryCacheContext;


### PR DESCRIPTION
For custom animated class, add new optional method for this case

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

## Propose

Current 4.x, the memory cache cost, using the `pixels count` of image. For normal usage, it works.

```objectivec
return image.size.height * image.size.width * image.scale * image.scale;
```

However, think this idea carefully. Why we use memory cache, because memory is fast, compared to disk. But however, it's realy limited (iPhone 6 contains only 1GM memory) and too much memory pressure will cause OOM.

Actually, for memory, what we mostly care about is not **How many pixels here we stored in the memory**. We care about **How many memory bytes we occupied in the memory**. Also, our memory cache implementation, use [NSCache](https://developer.apple.com/documentation/foundation/nscache). The cost value is recommaned to use the memory bytes size for more accurate evicting.

If we use pixel count, here is a problem that pixels does not represent the actual bytes it occupied in bitmap buffer. One image can represent different pixel format, and different pixel format have different bytes per pixel. (If you're not familiar with this, learn: [Quartz 2D Programming Guide](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_images/dq_images.html#//apple_ref/doc/uid/TP30001066-CH212-TPXREF101))

+ `ARGB8888`, 8-bit per component, 32-bit(4 bytes) per pixel
+ `RGB888`, 8-bit per componentr, 24-bit(3 bytes) per pixel
+ `ARGB16161616`, wide color, 16-bit per componenr, 64-bit(8 bytes) per pixel.

So, this means the pixel count is not a good way for cache. Some user, who want to limit the memory size to avoid OOM or memory pressure, want to specify the accurate size like 128MB. It's hard to do it correctly in the previous pixel count cost function. 

### Solution

So we can change the cost function, from pixels count, into the pixels bytes size. Then all of cache cost, we just concentrate on bytes size we care about, but not pixel count.

For implementation, we should considerate these cases:

+ Single Static Image: One image object contains only one static bitmap buffer. Then calculate the bytes size with `1 * bytesPerFrame`. Bytes per frame can be done use `CGImageGetBytesPerRow * CGImageGetHeight`.
+ Animated Image which occupied all frames: `UIImage` can be animated when `images` property is not nil. They store all frames into memory. Then calculate the bytes size with `frameCount * bytesPerFrame`.
+ Animated Image does not occupied all frame: `NSImage` && `SDAnimatedImage` custom class can works like this, so this can be done via Single Static Image rule. However, for advacend usage and performance, that `SDAnimatedImage` can represent complicated rule like preloading, internal buffer storage, etc. So we should put a optional protocol method for them. The method looks like this: `-(NSUInteger)animatedImageMemoryCost;`
+ Vector Image: `NSImage` && `UIImage` (from iOS 11+) can hold vector format, which does not hold any bitmap buffer, it's rendered when usage and occupy nearly nothing. So this can just simply return 0.

### Our Coder Plugin Changes

+ For [SDWebImageYYPlugin](https://github.com/SDWebImage/SDWebImageYYPlugin), that `YYImage` need change, to implements the optional protocol method. Because it supports dynamnic loading frames into memory.
+ For [SDWebImageFLPlugin](https://github.com/SDWebImage/SDWebImageFLPlugin), that `SDFLAnimatedImage` need change, to implements the optional protocol method. Because it store internal storage of frame buffers. Which can not be calculated by simple CGImage API.
+ For [SDWebImageSVGCoder](https://github.com/SDWebImage/SDWebImageSVGCoder) && [SDWebImagePDFCoder](https://github.com/SDWebImage/SDWebImagePDFCoder), they don't need change because they use vector image format and does not contains CGImage. So the calculation return 0.
+ For others, no change.