### PR TITLE
Revert "Add image url check when set image"

### DIFF
--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -101,7 +101,7 @@ static char TAG_ACTIVITY_SHOW;
         };
         id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options progress:combinedProgressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong __typeof (wself) sself = wself;
-            if (!sself || ![imageURL isEqual:sself.sd_imageURL]) { return; }
+            if (!sself) { return; }
 #if SD_UIKIT
             [sself sd_removeActivityIndicator];
 #endif
@@ -114,10 +114,9 @@ static char TAG_ACTIVITY_SHOW;
             BOOL shouldNotSetImage = ((image && (options & SDWebImageAvoidAutoSetImage)) ||
                                       (!image && !(options & SDWebImageDelayPlaceholder)));
             SDWebImageNoParamsBlock callCompletedBlockClojure = ^{
-                __strong __typeof(wself) strongSelf = wself;
-                if (!strongSelf || ![strongSelf.sd_imageURL isEqual:imageURL]) { return; }
+                if (!sself) { return; }
                 if (!shouldNotSetImage) {
-                    [strongSelf sd_setNeedsLayout];
+                    [sself sd_setNeedsLayout];
                 }
                 if (completedBlock && shouldCallCompletedBlock) {
                     completedBlock(image, error, cacheType, url);
@@ -155,7 +154,6 @@ static char TAG_ACTIVITY_SHOW;
                 if (group) {
                     dispatch_group_enter(group);
                 }
-                if (![sself.sd_imageURL isEqual:imageURL]) { return ; }
 #if SD_UIKIT || SD_MAC
                 [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
 #else


### PR DESCRIPTION
Reverts SDWebImage/SDWebImage#2531

This PR seems break current usage of `UIButton+WebCache` && `UIImageView+HighlightedWebCache`, because if user call the different catagory to set image URL, the previous one will be ignored and no completion callback been called.

Just tempoary revert. If we fix the related issue in the future (see conversation in the #2531), we can re-add this patch.