### PR TITLE
Let SD can be imported using static library by CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,16 @@ platform :ios, '7.0'
 pod 'SDWebImage', '~> 4.0'
 ```
 
-If you are using Swift, be sure to add `use_frameworks!` and set your target to iOS 8+:
+##### Swift
+
+If you are using `Swift`, `Xcode 9+` and `CocoaPods` `1.5.0+`, you only need to set your target to `iOS 8+` if you need static library:
+
+```
+platform :ios, '8.0'
+```
+
+If not, you still need to add `use_frameworks!` to use dynamic framework:
+
 ```
 platform :ios, '8.0'
 use_frameworks!

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.framework = 'ImageIO'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   
   s.default_subspec = 'Core'
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2547 .

`CocoaPods` 1.5.0 support swift static library, refer to the [guide](http://blog.cocoapods.org/CocoaPods-1.5.0/), we can add 'DEFINES_MODULE' => 'YES' to `pod_target_xcconfig`. 

