### PR TITLE
Fix that macOS does not support bitcode, current xcconfig cause build issue on Legacy Build System

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -111,6 +111,8 @@ DYLIB_INSTALL_NAME_BASE = @rpath
 
 // Activating this setting indicates that the target or project should generate bitcode during compilation for platforms and architectures that support it. For Archive builds, bitcode will be generated in the linked binary for submission to the App Store. For other builds, the compiler and linker will check whether the code complies with the requirements for bitcode generation, but will not generate actual bitcode.
 ENABLE_BITCODE = YES
+// Mac OS X does not support bitcode.
+ENABLE_BITCODE[sdk=macosx*] = NO
 
 // Controls whether `objc_msgSend` calls must be cast to the appropriate function pointer type before being called.
 ENABLE_STRICT_OBJC_MSGSEND = YES


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2494 

### Pull Request Description

@bpoplauschi Those xcconfig project refactor contains issue. The `ENABLE_BITCODE` must be set `NO` in macOS. You can also check previous Xcode configuration in GUI.

This break usage of current Legacy Build System. The New Build System can build because they ignore this wrong config. But the New Build Systrem contains some small issue in producation from many environment. We shuold support both of them. (Don't need to specify global workspace setting, user can use `xcodebuild` to dynamic specify which build system should be used.)

