### PR TITLE
Fix the current image cost (pixels) for FLAnimatedImage

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -15,6 +15,7 @@
 #import "NSData+ImageContentType.h"
 #import "UIImageView+WebCache.h"
 #import "UIImage+MultiFormat.h"
+#import "UIImage+MemoryCacheCost.h"
 
 static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageView *imageView, NSData *imageData) {
     if ([NSData sd_imageFormatForImageData:imageData] != SDImageFormatGIF) {
@@ -28,6 +29,16 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
         animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
     }
     return animatedImage;
+}
+
+static inline NSUInteger SDWebImageMemoryCostFLAnimatedImage(FLAnimatedImage *animatedImage, UIImage *image) {
+    NSUInteger frameCacheSizeCurrent = animatedImage.frameCacheSizeCurrent; // [1...frame count], more suitable than raw frame count because FLAnimatedImage internal actually store a buffer size but not full frames (they called `window`)
+    NSUInteger pixelsPerFrame = animatedImage.size.width * animatedImage.size.height; // FLAnimatedImage does not support scale factor
+    NSUInteger animatedImageCost = frameCacheSizeCurrent * pixelsPerFrame;
+    
+    NSUInteger imageCost = image.size.height * image.size.width * image.scale * image.scale; // Same as normal cost calculation
+    
+    return animatedImageCost + imageCost;
 }
 
 @implementation UIImage (FLAnimatedImage)
@@ -152,9 +163,9 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                __strong typeof(wweakSelf) sstrongSelf = wweakSelf;
                                if (!sstrongSelf || ![url isEqual:sstrongSelf.sd_imageURL]) { return ; }
                                // Step 3. Check if data exist or query disk cache
+                               NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
                                __block NSData *gifData = imageData;
                                if (!gifData) {
-                                   NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
                                    gifData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
                                }
                                // Step 4. Create FLAnimatedImage
@@ -163,8 +174,12 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                    if (![url isEqual:sstrongSelf.sd_imageURL]) { return ; }
                                    // Step 5. Set animatedImage or normal image
                                    if (animatedImage) {
-                                       if (sstrongSelf.sd_cacheFLAnimatedImage) {
+                                       if (sstrongSelf.sd_cacheFLAnimatedImage && SDImageCache.sharedImageCache.config.shouldCacheImagesInMemory) {
                                            image.sd_FLAnimatedImage = animatedImage;
+                                           image.sd_memoryCost = SDWebImageMemoryCostFLAnimatedImage(animatedImage, image);
+                                           // Update the memory cache
+                                           [SDImageCache.sharedImageCache removeImageForKey:key fromDisk:NO withCompletion:nil];
+                                           [SDImageCache.sharedImageCache storeImage:image forKey:key toDisk:NO completion:nil];
                                        }
                                        sstrongSelf.image = animatedImage.posterImage;
                                        sstrongSelf.animatedImage = animatedImage;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -37,6 +37,7 @@ static inline NSUInteger SDWebImageMemoryCostFLAnimatedImage(FLAnimatedImage *an
     NSUInteger animatedImageCost = frameCacheSizeCurrent * pixelsPerFrame;
     
     NSUInteger imageCost = image.size.height * image.size.width * image.scale * image.scale; // Same as normal cost calculation
+    imageCost = image.images ? (imageCost * image.images.count) : imageCost;
     
     return animatedImageCost + imageCost;
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2486 

### Pull Request Description

@zhongwuzw I think maybe you want this. In 4.x, we can not change the image cost function from pixels count into bytes size.

But actually, since you point out that current memory cost calculation for aniamted image contains issue. We can just focus on to fix those, instead of change too much of thing un-related.

In 5.x, we can totally do refactory and use bytes size for cost function, then using the new protocol method for animated image solution.

