### PR TITLE
Prioritize operation queue priority if operation exist but is still pending

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -308,6 +308,15 @@
         [self.downloadQueue addOperation:operation];
     }
     UNLOCK(self.operationsLock);
+    
+    // Prioritize the operation queue priority when the current operation is pending in queue
+    if ((options & SDWebImageDownloaderHighPriority || options & SDWebImageDownloaderLowPriority) && !operation.isFinished && !operation.isExecuting) {
+        if (options & SDWebImageDownloaderHighPriority) {
+            operation.queuePriority = NSOperationQueuePriorityHigh;
+        } else if (options & SDWebImageDownloaderLowPriority) {
+            operation.queuePriority = NSOperationQueuePriorityLow;
+        }
+    }
 
     id downloadOperationCancelToken = [operation addHandlersForProgress:progressBlock completed:completedBlock];
     


### PR DESCRIPTION
For URL which is previously load by prefetcher then with SDWebImageDownloaderHighPriority

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2554

### Pull Request Description

This is a polish PR from #2554. The feature request is from @jerelevine.

The use case is that user previously use `SDWebImagePrefetcher` to prefetch a URL (which use the low priority) and the operation is queued, then use `SDWebImageDownloaderHighPriority` option to query the same URL.

From the Apple's documentation about [NSOperation.queuePriority](https://developer.apple.com/documentation/foundation/nsoperation/1411204-queuepriority). This can help to manage and prioritize the pending operation to be executed in a concurrent operation queue. So we can just check and optimize for this case.
