### PR TITLE
Prioritize SDWebImageDownloaderHighPriority if operation already exists

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -307,6 +307,15 @@
         // `addOperation:` does not synchronously execute the `operation.completionBlock` so this will not cause deadlock.
         [self.downloadQueue addOperation:operation];
     }
+    else if (!operation.isExecuting) {
+        if (options & SDWebImageDownloaderHighPriority) {
+            operation.queuePriority = NSOperationQueuePriorityHigh;
+        } else if (options & SDWebImageDownloaderLowPriority) {
+            operation.queuePriority = NSOperationQueuePriorityLow;
+        } else {
+            operation.queuePriority = NSOperationQueuePriorityNormal;
+        }
+    }
     UNLOCK(self.operationsLock);
 
     id downloadOperationCancelToken = [operation addHandlersForProgress:progressBlock completed:completedBlock];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Related `PR`, #2562 ,#2554

After #2574 merged, we can merge this to add the priority feature for operation creation.

