### PR TITLE
Fix memory cost override for SDAnimatedImage

### DIFF
--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -429,13 +429,9 @@ static NSArray *SDBundlePreferredScales() {
 
 @end
 
-@interface SDAnimatedImage (MemoryCacheCost)
-
-@end
-
 @implementation SDAnimatedImage (MemoryCacheCost)
 
-- (NSUInteger)sd_imageMemoryCost {
+- (NSUInteger)sd_memoryCost {
     NSNumber *value = objc_getAssociatedObject(self, @selector(sd_memoryCost));
     if (value != nil) {
         return value.unsignedIntegerValue;

--- a/SDWebImage/UIImage+MemoryCacheCost.h
+++ b/SDWebImage/UIImage+MemoryCacheCost.h
@@ -16,8 +16,8 @@
  
  For `UIImage`, this method return the single frame bytes size when `image.images` is nil for static image. Retuen full frame bytes size when `image.images` is not nil for animated image.
  For `NSImage`, this method return the single frame bytes size because `NSImage` does not store all frames in memory.
- @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
- @note For custom animated class conforms to `SDAnimatedImage`, you can override this getter method in your subclass to return a more proper value instead, which representing the current frames' total bytes.
+ @note Note that because of the limitations of category this property can get out of sync if you create another instance with CGImage or other methods.
+ @note For custom animated class conforms to `SDAnimatedImage`, you can override this getter method in your subclass to return a more proper value instead, which representing the current frame's total bytes.
  */
 @property (assign, nonatomic) NSUInteger sd_memoryCost;
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2568 
