### PR TITLE
Revert failed block processing logic

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -374,21 +374,14 @@ static id<SDImageLoader> _defaultImageLoader;
     if ([self.delegate respondsToSelector:@selector(imageManager:shouldBlockFailedURL:withError:)]) {
         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
     } else {
-        NSString *domain = error.domain;
-        NSInteger code = error.code;
-        if ([domain isEqualToString:NSURLErrorDomain]) {
-            shouldBlockFailedURL = (   code != NSURLErrorNotConnectedToInternet
-                                    && code != NSURLErrorCancelled
-                                    && code != NSURLErrorTimedOut
-                                    && code != NSURLErrorInternationalRoamingOff
-                                    && code != NSURLErrorDataNotAllowed
-                                    && code != NSURLErrorCannotFindHost
-                                    && code != NSURLErrorCannotConnectToHost
-                                    && code != NSURLErrorNetworkConnectionLost);
-        } else {
-            // Custom loader, don't do extra error code check
-            shouldBlockFailedURL = NO;
-        }
+        shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
+                                && error.code != NSURLErrorCancelled
+                                && error.code != NSURLErrorTimedOut
+                                && error.code != NSURLErrorInternationalRoamingOff
+                                && error.code != NSURLErrorDataNotAllowed
+                                && error.code != NSURLErrorCannotFindHost
+                                && error.code != NSURLErrorCannotConnectToHost
+                                && error.code != NSURLErrorNetworkConnectionLost);
     }
     
     return shouldBlockFailedURL;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2578 .

#2578  breaks the failed block url processing logical. We don't need to do this, if user wants custom, use delegate instead.

