### PR TITLE
Supports store original image to cache for transformer

### DIFF
--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -203,10 +203,17 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageT
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageScaleFactor;
 
 /**
- A SDImageCacheType raw value which specify the cache type when the image has just been downloaded and will be stored to the cache. Specify `SDImageCacheTypeNone` to disable cache storage; `SDImageCacheTypeDisk` to store in disk cache only; `SDImageCacheTypeMemory` to store in memory only. And `SDImageCacheTypeAll` to store in both memory cache and disk cache.
+ A SDImageCacheType raw value which specify the store cache type when the image has just been downloaded and will be stored to the cache. Specify `SDImageCacheTypeNone` to disable cache storage; `SDImageCacheTypeDisk` to store in disk cache only; `SDImageCacheTypeMemory` to store in memory only. And `SDImageCacheTypeAll` to store in both memory cache and disk cache.
+ If you use image transformer feature, this actually apply for the transformed image, but not the original image itself. Use `SDWebImageContextOriginalStoreCacheType` if you want to control the original image's store cache type at the same time.
  If not provide or the value is invalid, we will use `SDImageCacheTypeAll`. (NSNumber)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextStoreCacheType;
+
+/**
+ The same behavior like `SDWebImageContextStoreCacheType`, but control the store cache type for the original image when you use image transformer feature. This allows the detail control of cache storage for these two images. For example, if you want to store the transformed image into both memory/disk cache, store the original image into disk cache only, use `[.storeCacheType : .all, .originalStoreCacheType : .disk]`
+ If not provide or the value is invalid, we will use `SDImageCacheTypeNone`, which does not store the original image into cache. (NSNumber)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextOriginalStoreCacheType;
 
 /**
  A Class object which the instance is a `UIImage/NSImage` subclass and adopt `SDAnimatedImage` protocol. We will call `initWithData:scale:options:` to create the instance (or `initWithAnimatedCoder:scale:` when using progressive download) . If the instance create failed, fallback to normal `UIImage/NSImage`.

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -123,6 +123,7 @@ SDWebImageContextOption const SDWebImageContextCustomManager = @"customManager";
 SDWebImageContextOption const SDWebImageContextImageTransformer = @"imageTransformer";
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextStoreCacheType = @"storeCacheType";
+SDWebImageContextOption const SDWebImageContextOriginalStoreCacheType = @"originalStoreCacheType";
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";
 SDWebImageContextOption const SDWebImageContextDownloadRequestModifier = @"downloadRequestModifier";
 SDWebImageContextOption const SDWebImageContextCacheKeyFilter = @"cacheKeyFilter";

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -185,6 +185,40 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test11ThatStoreCacheTypeWork {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Image store cache type (including transformer) work"];
+    
+    // Use a fresh manager && cache to avoid get effected by other test cases
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"SDWebImageStoreCacheType"];
+    SDWebImageManager *manager = [[SDWebImageManager alloc] initWithCache:cache loader:SDWebImageDownloader.sharedDownloader];
+    SDWebImageTestTransformer *transformer = [[SDWebImageTestTransformer alloc] init];
+    transformer.testImage = [[UIImage alloc] initWithContentsOfFile:[self testJPEGPath]];
+    manager.transformer = transformer;
+    
+    // test: original image -> disk only, transformed image -> memory only
+    SDWebImageContext *context = @{SDWebImageContextOriginalStoreCacheType : @(SDImageCacheTypeDisk), SDWebImageContextStoreCacheType : @(SDImageCacheTypeMemory)};
+    NSURL *url = [NSURL URLWithString:kTestJPEGURL];
+    NSString *originalKey = [manager cacheKeyForURL:url];
+    NSString *transformedKey = SDTransformedKeyForKey(originalKey, transformer.transformerKey);
+    
+    [manager loadImageWithURL:url options:SDWebImageTransformAnimatedImage context:context progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image).equal(transformer.testImage);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2*kMinDelayNanosecond), dispatch_get_main_queue(), ^{
+            // original -> disk only
+            [manager.imageCache containsImageForKey:originalKey cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType originalCacheType) {
+                expect(originalCacheType).equal(SDImageCacheTypeDisk);
+                // transformed -> memory only
+                [manager.imageCache containsImageForKey:transformedKey cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType transformedCacheType) {
+                    expect(transformedCacheType).equal(SDImageCacheTypeMemory);
+                    [expectation fulfill];
+                }];
+            }];
+        });
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 - (NSString *)testJPEGPath {
     NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass: Added `test11ThatStoreCacheTypeWork`
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2542 

### Pull Request Description

# Propose
This is enhacement for current 5.0.0 feature [Image Transformer](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#image-transformer-50). It's from the feature request from the user #2542 

To achieve that feature, we actually need to implements two different parts.

1. **How we store the original image into cache using transformer**
2. **How we query the original image from cache using transformer without downloading**

Actually, both of these two can be seperfated into different PRs. It's better to check, test and merge.

This phase 1 only care about the question 1. And here is the solution.

## Support store the original image when transformer is applied

Before I start to implements this feature, I reference some image framworks with the same feature. For example, [Kingfisher](https://github.com/onevcat/Kingfisher), here is the same feature in wiki: [Using processor with ImageCache](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#using-processor-with-imagecache). Their solution is that they provide a option `cacheOriginalImage`, which will store the original image data into disk cache, when transformer is applied. See the code [here](https://github.com/onevcat/Kingfisher/blob/master/Sources/General/KingfisherManager.swift#L255-L265).

But however, I want to make SDWebImage's feature more customizable, because we have both memory cache and disk cache. Since we already have one `SDWebImageContextStoreCacheType`, which allows user to specify the target cache (memory/disk/both/none). So we can benefit from this, to allow the same config for the original image.

## Solution

Introduce a new option, which behave nearlly the same like `SDWebImageContextStoreCacheType`, but this time it's for original image store cache type. The default value is `none`, which means don't store the original image into cache. To keep the consisdent behavior and I think it's the most approved option. (This is also the default as Kingfisher)

Also, update the current `SDWebImageContextStoreCacheType` documentation, clarity about what it does when using image transformer.

```objective-c
/**
 The same behavior like `SDWebImageContextStoreCacheType`, but control the store cache type for the original image when you use image transformer feature. This allows the detail control of cache storage for these two images. For example, if you want to store the transformed image into both memory/disk cache, store the original image into disk cache only, use `[.storeCacheType : .all, .originalStoreCacheType : .disk]`
 If not provide or the value is invalid, we will use `SDImageCacheTypeNone`, which does not store the original image into cache. (NSNumber)
 */
FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextOriginalStoreCacheType;
```

## Usage
For example, if you want to use a transformer, and store the transformed image (target image) into memory && disk cache, but store original image into disk cache, use the follow code:

```swift
let transformer = SDImageRoundCornerTransformer(radius: 0.5, corners: .allCorners, borderWidth: 0, borderColor: nil)
let imageView = UIImageView()
let url = URL(string: "test")!
imageView.sd_setImage(with: url, placeholderImage: nil, options: [], context: [.imageTransformer : transformer, .storeCacheType : SDImageCacheType.all, .originalStoreCacheType : SDImageCacheType.disk])
```

See test case `test11ThatStoreCacheTypeWork` about how detailed it behaved.