### PR TITLE
Feature transformer cache phase 2 - Supports query original image from cache and do transform

### DIFF
--- a/SDWebImage/Private/SDInternalMacros.h
+++ b/SDWebImage/Private/SDInternalMacros.h
@@ -20,7 +20,10 @@
 #ifndef weakify
 #define weakify(...) \
 sd_keywordify \
-metamacro_foreach_cxt(sd_weakify_,, __weak, __VA_ARGS__)
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wshadow\"") \
+metamacro_foreach_cxt(sd_weakify_,, __weak, __VA_ARGS__) \
+_Pragma("clang diagnostic pop")
 #endif
 
 #ifndef strongify

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -11,7 +11,6 @@
 #import "SDDiskCache.h"
 #import "NSImage+Compatibility.h"
 #import "SDImageCodersManager.h"
-#import "SDImageTransformer.h"
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 #import "UIImage+MemoryCacheCost.h"
@@ -368,13 +367,6 @@
             doneBlock(nil, nil, SDImageCacheTypeNone);
         }
         return nil;
-    }
-    
-    id<SDImageTransformer> transformer = context[SDWebImageContextImageTransformer];
-    if (transformer) {
-        // grab the transformed disk image if transformer provided
-        NSString *transformerKey = [transformer transformerKey];
-        key = SDTransformedKeyForKey(key, transformerKey);
     }
     
     // First check the in-memory cache...

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -176,7 +176,15 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. However, you can specify to preload all frames into memory to reduce CPU usage when the animated image is shared by lots of imageViews.
      * This will actually trigger `preloadAllAnimatedImageFrames` in the background queue(Disk Cache & Download only).
      */
-    SDWebImagePreloadAllFrames = 1 << 20
+    SDWebImagePreloadAllFrames = 1 << 20,
+    
+    /**
+     * By default, when current image request contains image transformer, we only check the image cache with the exact transformed key and do normal cache query.
+     * But however, there is a case when the original image (data) is in the image cache, and you want to avoid extra downloading. Using this option, will cause we firstly do query with the transformed key. If cache miss, then do a secondary query with the original key. If original image cache hit, do image transforming in global queue. If all the caches miss, continue downloading.
+     * @note This option does no effect if you don't use image transformer feature.
+     * @note We always do image transforming asynchronously in global queue, to avoid block the main queue. So if you use this option and the image is transformed from an original image in cache, the callback is always asynchronously.
+     */
+    SDWebImageQueryOriginalAndTransform = 1 << 21,
 };
 
 

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -203,10 +203,17 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageT
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageScaleFactor;
 
 /**
- A SDImageCacheType raw value which specify the cache type when the image has just been downloaded and will be stored to the cache. Specify `SDImageCacheTypeNone` to disable cache storage; `SDImageCacheTypeDisk` to store in disk cache only; `SDImageCacheTypeMemory` to store in memory only. And `SDImageCacheTypeAll` to store in both memory cache and disk cache.
+ A SDImageCacheType raw value which specify the store cache type when the image has just been downloaded and will be stored to the cache. Specify `SDImageCacheTypeNone` to disable cache storage; `SDImageCacheTypeDisk` to store in disk cache only; `SDImageCacheTypeMemory` to store in memory only. And `SDImageCacheTypeAll` to store in both memory cache and disk cache.
+ If you use image transformer feature, this actually apply for the transformed image, but not the original image itself. Use `SDWebImageContextOriginalStoreCacheType` if you want to control the original image's store cache type at the same time.
  If not provide or the value is invalid, we will use `SDImageCacheTypeAll`. (NSNumber)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextStoreCacheType;
+
+/**
+ The same behavior like `SDWebImageContextStoreCacheType`, but control the store cache type for the original image when you use image transformer feature. This allows the detail control of cache storage for these two images. For example, if you want to store the transformed image into both memory/disk cache, store the original image into disk cache only, use `[.storeCacheType : .all, .originalStoreCacheType : .disk]`
+ If not provide or the value is invalid, we will use `SDImageCacheTypeNone`, which does not store the original image into cache. (NSNumber)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextOriginalStoreCacheType;
 
 /**
  A Class object which the instance is a `UIImage/NSImage` subclass and adopt `SDAnimatedImage` protocol. We will call `initWithData:scale:options:` to create the instance (or `initWithAnimatedCoder:scale:` when using progressive download) . If the instance create failed, fallback to normal `UIImage/NSImage`.

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -123,6 +123,7 @@ SDWebImageContextOption const SDWebImageContextCustomManager = @"customManager";
 SDWebImageContextOption const SDWebImageContextImageTransformer = @"imageTransformer";
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextStoreCacheType = @"storeCacheType";
+SDWebImageContextOption const SDWebImageContextOriginalStoreCacheType = @"originalStoreCacheType";
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";
 SDWebImageContextOption const SDWebImageContextDownloadRequestModifier = @"downloadRequestModifier";
 SDWebImageContextOption const SDWebImageContextCacheKeyFilter = @"cacheKeyFilter";

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -185,6 +185,40 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test11ThatStoreCacheTypeWork {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Image store cache type (including transformer) work"];
+    
+    // Use a fresh manager && cache to avoid get effected by other test cases
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"SDWebImageStoreCacheType"];
+    SDWebImageManager *manager = [[SDWebImageManager alloc] initWithCache:cache loader:SDWebImageDownloader.sharedDownloader];
+    SDWebImageTestTransformer *transformer = [[SDWebImageTestTransformer alloc] init];
+    transformer.testImage = [[UIImage alloc] initWithContentsOfFile:[self testJPEGPath]];
+    manager.transformer = transformer;
+    
+    // test: original image -> disk only, transformed image -> memory only
+    SDWebImageContext *context = @{SDWebImageContextOriginalStoreCacheType : @(SDImageCacheTypeDisk), SDWebImageContextStoreCacheType : @(SDImageCacheTypeMemory)};
+    NSURL *url = [NSURL URLWithString:kTestJPEGURL];
+    NSString *originalKey = [manager cacheKeyForURL:url];
+    NSString *transformedKey = SDTransformedKeyForKey(originalKey, transformer.transformerKey);
+    
+    [manager loadImageWithURL:url options:SDWebImageTransformAnimatedImage context:context progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image).equal(transformer.testImage);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2*kMinDelayNanosecond), dispatch_get_main_queue(), ^{
+            // original -> disk only
+            [manager.imageCache containsImageForKey:originalKey cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType originalCacheType) {
+                expect(originalCacheType).equal(SDImageCacheTypeDisk);
+                // transformed -> memory only
+                [manager.imageCache containsImageForKey:transformedKey cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType transformedCacheType) {
+                    expect(transformedCacheType).equal(SDImageCacheTypeMemory);
+                    [expectation fulfill];
+                }];
+            }];
+        });
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 - (NSString *)testJPEGPath {
     NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass. Added `test12ThatQueryOriginalAndTransformWorks`
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2590 #2542 

### Pull Request Description

# Propose
This is the Phase 2 of #2590. To answer the question.2

**2. How we query the original image from cache using transformer without downloading**

The Phase 2 is based on the Phased 1 (#2590)'s latest commit, and with some changes to make it works. After the Phase 1 is merged, this Phase 2 can be directlly merged without extra diff changes.

**To simplify review and diff compare, check [this link](https://github.com/dreampiggy/SDWebImage/compare/feature_transformer_cache_phase_1...feature_transformer_cache_phase_2) to see the changes after #2590**.

## Add a option to check original image and do transform during cache query process

As normal, before I start writing this propose and code, I check the [Kingfisher](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#using-processor-with-imagecache) for the similar feature. Kingfisher support this feature via `originalCache` option. And then query the cache without default processor again, when the first time cache miss. Then do a transform in the global queue and continue download process. See the code [here](https://github.com/onevcat/Kingfisher/blob/master/Sources/General/KingfisherManager.swift#L346-L390).

Actually I' agreed with their approach, we actually want to do the same thing.

## Solution

Implements the secondary query for cache during `callCacheProcessForOperation`. The changes is not so hard. And because when the secondary query success, we need do transform and store the transformed image into cache again. It's nearly the same as the current `callStoreCacheProcessForOperation`. So I update the code to make we share the code, without copy it twice.

And since this seconary query need extra time, it's not suitable to become default behavior. So we need a extra option to enable this feature.

```objective-c
/**
 * By default, when current image request contains image transformer, we only check the image cache with the exact transformed key and do normal cache query.
 * But however, there is a case when the original image (data) is in the image cache, and you want to avoid extra downloading. Using this option, will cause we firstly do query with the transformed key. If cache miss, then do a secondary query with the original key. If original image cache hit, do image transforming in global queue. If all the caches miss, continue downloading.
 * @note This option does no effect if you don't use image transformer feature.
 * @note We always do image transforming asynchronously in global queue, to avoid block the main queue. So if you use this option and the image is transformed from an original image in cache, the callback is always asynchronously.
 */
SDWebImageQueryOriginalAndTransform = 1 << 21,
```


## Usage

For example, you have stored the original image into disk cache, and you're using a image transformer. However, you want to avoid extra downloading, instead, just grab that cached image and do transform again. For this case, you can use that option.

```swift
let transformer = SDImageRoundCornerTransformer(radius: 0.5, corners: .allCorners, borderWidth: 0, borderColor: nil)
let imageView = UIImageView()
let url = URL(string: "https://foo/bar.png")!
imageView.sd_setImage(with: url, placeholderImage: nil, options: [queryOriginalAndTransform], context: [.imageTransformer : transformer)
```

See test case `test12ThatQueryOriginalAndTransformWorks` for detailed behavior with this option. 

