### PR TITLE
Fix that WebP decoder in master branch, does not consider the global `shouldDecompressImages` config and always do pre-draw for static WebP images.

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -419,19 +419,8 @@ didReceiveResponse:(NSURLResponse *)response
                             NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                             image = [self scaledImageForKey:key image:image];
                             
-                            BOOL shouldDecode = YES;
-                            // Do not force decoding animated GIFs and WebPs
-                            if (image.images) {
-                                shouldDecode = NO;
-                            } else {
-#ifdef SD_WEBP
-                                SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
-                                if (imageFormat == SDImageFormatWebP) {
-                                    shouldDecode = NO;
-                                }
-#endif
-                            }
-                            
+                            // Do not force decoding animated images
+                            BOOL shouldDecode = !image.images;
                             if (shouldDecode) {
                                 if (self.shouldDecompressImages) {
                                     BOOL shouldScaleDown = self.options & SDWebImageDownloaderScaleDownLargeImages;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Current WebP coder in the master branch for 4.x version contains Bug. It ignore the user-config for `shouldDecompressImages`, and always do pre-draw for static WebP images. Not all the user use this feature because it's a trade-off between CPU && RAM.

Instead, it need to share the same logic as normal PNG (via `SDWebImageIOCoder`).

The 5.x WebP coder [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder/blob/master/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m#L134-L148) already fix this issue. But I'm sorry that I did not sync back that changes into 4.x branch.