### PR TITLE
Fix potential memory leaks for ICCP && optimize ICCP handler

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -25,29 +25,6 @@
 #endif
 #import <Accelerate/Accelerate.h>
 
-// Create and return the correct colorspace by checking the ICC Profile
-static CGColorSpaceRef SDColorSpaceCreateWithDemuxer(WebPDemuxer *demuxer) {
-    // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
-    // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
-    
-    WebPChunkIterator chunk_iter;
-    CGColorSpaceRef colorSpaceRef = NULL;
-    
-    int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
-    if (result) {
-        NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
-        colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
-    }
-    
-    WebPDemuxReleaseChunkIterator(&chunk_iter);
-    
-    if (!colorSpaceRef) {
-        colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
-        CGColorSpaceRetain(colorSpaceRef);
-    }
-    
-    return colorSpaceRef;
-}
 
 @implementation SDWebImageWebPCoder {
     WebPIDecoder *_idec;
@@ -115,7 +92,7 @@ static CGColorSpaceRef SDColorSpaceCreateWithDemuxer(WebPDemuxer *demuxer) {
     CGColorSpaceRef colorSpace = NULL;
     // ICC profile
     if (flags & ICCP_FLAG) {
-        colorSpace = SDColorSpaceCreateWithDemuxer(demuxer);
+        colorSpace = [self sd_colorSpaceWithDemuxer:demuxer];
     } else {
         colorSpace = SDCGColorSpaceGetDeviceRGB();
         CGColorSpaceRetain(colorSpace);
@@ -363,6 +340,30 @@ static CGColorSpaceRef SDColorSpaceCreateWithDemuxer(WebPDemuxer *demuxer) {
     CGImageRelease(imageRef);
     
     return image;
+}
+
+// Create and return the correct colorspace by checking the ICC Profile
+- (nonnull CGColorSpaceRef)sd_colorSpaceWithDemuxer:(nonnull WebPDemuxer *)demuxer CF_RETURNS_RETAINED {
+    // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
+    // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
+    
+    WebPChunkIterator chunk_iter;
+    CGColorSpaceRef colorSpaceRef = NULL;
+    
+    int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
+    if (result) {
+        NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
+        colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
+    }
+    
+    WebPDemuxReleaseChunkIterator(&chunk_iter);
+    
+    if (!colorSpaceRef) {
+        colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
+        CGColorSpaceRetain(colorSpaceRef);
+    }
+    
+    return colorSpaceRef;
 }
 
 #pragma mark - Encode

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -27,26 +27,26 @@
 
 // Create and return the correct colorspace by checking the ICC Profile
 static CGColorSpaceRef SDColorSpaceCreateWithDemuxer(WebPDemuxer *demuxer) {
-	// WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
-	// See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
-	
-	WebPChunkIterator chunk_iter;
-	CGColorSpaceRef colorSpaceRef = NULL;
-	
-	int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
-	if (result) {
-		NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
-		colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
-	}
-	
-	WebPDemuxReleaseChunkIterator(&chunk_iter);
-	
-	if (!colorSpaceRef) {
-		colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
-		CGColorSpaceRetain(colorSpaceRef);
-	}
-	
-	return colorSpaceRef;
+    // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
+    // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
+    
+    WebPChunkIterator chunk_iter;
+    CGColorSpaceRef colorSpaceRef = NULL;
+    
+    int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
+    if (result) {
+        NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
+        colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
+    }
+    
+    WebPDemuxReleaseChunkIterator(&chunk_iter);
+    
+    if (!colorSpaceRef) {
+        colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
+        CGColorSpaceRetain(colorSpaceRef);
+    }
+    
+    return colorSpaceRef;
 }
 
 @implementation SDWebImageWebPCoder {
@@ -111,15 +111,15 @@ static CGColorSpaceRef SDColorSpaceCreateWithDemuxer(WebPDemuxer *demuxer) {
         WebPDemuxDelete(demuxer);
         return nil;
     }
-	
-	CGColorSpaceRef colorSpace = NULL;
-	// ICC profile
-	if (flags & ICCP_FLAG) {
-		colorSpace = SDColorSpaceCreateWithDemuxer(demuxer);
-	} else {
-		colorSpace = SDCGColorSpaceGetDeviceRGB();
-		CGColorSpaceRetain(colorSpace);
-	}
+    
+    CGColorSpaceRef colorSpace = NULL;
+    // ICC profile
+    if (flags & ICCP_FLAG) {
+        colorSpace = SDColorSpaceCreateWithDemuxer(demuxer);
+    } else {
+        colorSpace = SDCGColorSpaceGetDeviceRGB();
+        CGColorSpaceRetain(colorSpace);
+    }
     
     if (!(flags & ANIMATION_FLAG)) {
         // for static single webp image


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2585 .

1. Add `WebPDemuxReleaseChunkIterator` for `iter`.
2. Add flags check for ICCP.
3. Use `dataWithBytesNoCopy` instead.
4. Satisfy `Create Rule` for function naming.