### PR TITLE
Revert modular framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,27 @@ platform :ios, '7.0'
 pod 'SDWebImage', '~> 4.0'
 ```
 
-##### Swift
+##### Swift and static framework
 
-If you are using `Swift`, `Xcode 9+` and `CocoaPods` `1.5.0+`, you only need to set your target to `iOS 8+` if you need static library:
+Swift project previously have to use `use_frameworks!` to make all Pods into dynamic framework to let CocoaPods works.
+
+However, start with `CocoaPods 1.5.0+` (with `Xcode 9+`), which supports to build both Objective-C && Swift code into static framework. You can use modular headers to use SDWebImage as static framework, without the need of `use_frameworks!`:
 
 ```
 platform :ios, '8.0'
+# Uncomment the next line when you want Pods as static framework
+# use_modular_headers!
+pod 'SDWebImage', :modular_headers => true
 ```
 
-If not, you still need to add `use_frameworks!` to use dynamic framework:
+See more on [CocoaPods 1.5.0 — Swift Static Libraries](http://blog.cocoapods.org/CocoaPods-1.5.0/)
+
+If not, you still need to add `use_frameworks!` to use SDWebImage as dynamic framework:
 
 ```
 platform :ios, '8.0'
 use_frameworks!
+pod 'SDWebImage'
 ```
 
 #### Subspecs
@@ -184,3 +192,5 @@ All source code is licensed under the [MIT License](https://raw.github.com/SDWeb
 <p align="center">
     <img src="Docs/SDWebImageSequenceDiagram.png" title="SDWebImage sequence diagram">
 </p>
+
+

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.framework = 'ImageIO'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   
   s.default_subspec = 'Core'
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2601 

### Pull Request Description

See #2601 and #2549 . We turn on the `DEFINES_MODULE` in the Podspec, to mark our SDWebImage as modular framework. Which the aim is to help Swift user, to use SDWebImage as staic framework without the usage of `use_frameworks!`.

However, there are some compatible issue about Xcode and CocoaPods. Some user reply that this break the their project build. And I think it's related to this [CocoaPods #7584 issue](https://github.com/CocoaPods/CocoaPods/issues/7584) and here is one [demo project](https://github.com/dreampiggy/CocoaPodsXCAssetsIssue).

We can not always wait for CocoaPods to fix this issue. It break current some of users usage. So, instead of define the framework as modular framework in Podspec. I prefer to let the user to do this thing. They can use the `modular_headers` syntax in Podfile to mark SDWebImage as static framework.

```ruby
pod 'SDWebImage', '~> 4.4.0', :modular_headers => true
```

See: http://blog.cocoapods.org/CocoaPods-1.5.0/ for more detail.



