### PR TITLE
Fix shouldDecode check when image format is GIF

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -419,7 +419,8 @@ didReceiveResponse:(NSURLResponse *)response
                             NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                             image = [self scaledImageForKey:key image:image];
                             
-                            // Do not force decoding animated images
+                            // Do not force decoding animated images or GIF,
+                            // because there has imageCoder which can change `image` or `imageData` to static image, lose the animated feature totally.
                             BOOL shouldDecode = !image.images && image.sd_imageFormat != SDImageFormatGIF;
                             if (shouldDecode) {
                                 if (self.shouldDecompressImages) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -10,6 +10,7 @@
 #import "SDWebImageManager.h"
 #import "NSImage+WebCache.h"
 #import "SDWebImageCodersManager.h"
+#import "UIImage+MultiFormat.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
@@ -419,7 +420,7 @@ didReceiveResponse:(NSURLResponse *)response
                             image = [self scaledImageForKey:key image:image];
                             
                             // Do not force decoding animated images
-                            BOOL shouldDecode = !image.images;
+                            BOOL shouldDecode = !image.images && image.sd_imageFormat != SDImageFormatGIF;
                             if (shouldDecode) {
                                 if (self.shouldDecompressImages) {
                                     BOOL shouldScaleDown = self.options & SDWebImageDownloaderScaleDownLargeImages;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2592 

`image.images` is `nil` if image is GIF, if we don't add this check, in case options have `SDWebImageDownloaderScaleDownLargeImages`, things may go wrong.
