### PR TITLE
Fix that WebP with custom ICC Profile will randomly crash, because `CGColorSpaceCreateWithICCProfile` does not copy the ICC data pointer

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -342,7 +342,9 @@
         WebPChunkIterator chunk_iter;
         int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
         if (result) {
-            NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
+            // See #2618, the `CGColorSpaceCreateWithICCProfile` does not copy ICC Profile data, it only retain the byte ptr.
+            // When the libwebp `WebPDemuxer` dealloc, all chunk will be freed. So we must copy the ICC data (really cheap, less than 10KB)
+            NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
             colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
             WebPDemuxReleaseChunkIterator(&chunk_iter);
         }

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -342,8 +342,8 @@
         WebPChunkIterator chunk_iter;
         int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
         if (result) {
-            // See #2618, the `CGColorSpaceCreateWithICCProfile` does not copy ICC Profile data, it only retain the byte ptr.
-            // When the libwebp `WebPDemuxer` dealloc, all chunk will be freed. So we must copy the ICC data (really cheap, less than 10KB)
+            // See #2618, the `CGColorSpaceCreateWithICCProfile` does not copy ICC Profile data, it only retain `CFDataRef`.
+            // When the libwebp `WebPDemuxer` dealloc, all chunks will be freed. So we must copy the ICC data (really cheap, less than 10KB)
             NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
             colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
             WebPDemuxReleaseChunkIterator(&chunk_iter);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2618 #2585 

### Pull Request Description

See #2618. And the reproduce WebP URL: http://carben.b0.upaiyun.com/Images/1510913905.png!/format/webp

After I reproduce the issue, I finally found this issue is related to the code

```objective-c
NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
```

However, the `CGColorSpaceCreateWithICCProfile` does not do a copy of your byte pointer. So, when the WebP decoder dealloc, the chunk iter will cleanup, the ICC profile data pointer become a dangling pointer and cause crash. This cause a **use-after-free** issue.

@zhongwuzw To say, I think last time when we review the code due to performance issue, we should take more careful. At first I use the `+[NSData dataWithBytes:length:]`, but you say this copy is not needed. However, we don't have a check again after that changes. Since the ICC profile data is always really small (less than 10 KB), using copy is much more safer and does not harm for performance. We are apprehensive or worrying about performance, but not the robustness.