### PR TITLE
Fix the unused user header search path warning for CocoaPods 1.6.0.

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -46,9 +46,6 @@ Pod::Spec.new do |s|
     gif.source_files = 'SDWebImage/FLAnimatedImage/*.{h,m}'
     gif.dependency 'SDWebImage/Core'
     gif.dependency 'FLAnimatedImage', '~> 1.0'
-    gif.xcconfig = {
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/FLAnimatedImage/FLAnimatedImage'
-    }
   end
 
   s.subspec 'WebP' do |webp|


### PR DESCRIPTION
We already use the dependency of FL && libwebp Pods, these build configurations does not do anything

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2619 

### Pull Request Description

Current SDWebImage's podspec, contains the build settings for `USER_HEADER_SEARCH_PATH`. However, this option does not do anything useful. Because we already add dependency for `FLAnimatedImage`,  the header search path is already here. (I guess this may because of historical issue which use FL/libwebp git submodules, which is only used for Manual Install user, but does not help for CocoaPods. They are separate build dependency).

Remove these can also fix the CocoaPods 1.6.0 warning:

> Can't merge pod_target_xcconfig for pod targets: ["GIF", "WebP"]. Singular build setting USER_HEADER_SEARCH_PATHS has different values.

The `libwebp` header search path should still be kept. Because we use `#import <webp/decode.h>` to search the header, however, libwebp pod use the `libwebp` module name, so they can be only used like `#import <libwebp/decode.h>`. However, Carthage or Manual Install user will build a framework which need that `<webp/decode.h>` import.

- Update

This PR also fix the issue of current Travis-CI build (using pod 1.6.0). Beucase the `Test Scheme` will face this warning and cause the generated xcconfig `USER_HEADER_SEARCH_PATHS` wrong.