### PR TITLE
Add server errors support

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -92,6 +92,7 @@ FOUNDATION_EXPORT UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
 typedef void(^SDWebImageNoParamsBlock)(void);
 
 FOUNDATION_EXPORT NSString *const SDWebImageErrorDomain;
+FOUNDATION_EXPORT NSString *const SDWebImageServerErrorDomain;
 
 #ifndef dispatch_queue_async_safe
 #define dispatch_queue_async_safe(queue, block)\

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -69,3 +69,4 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
 }
 
 NSString *const SDWebImageErrorDomain = @"SDWebImageErrorDomain";
+NSString *const SDWebImageServerErrorDomain = @"SDWebImageServerErrorDomain";


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Fixes #2589 .
Currently, we would cancel dataTask if server error happened, like 404, but this provide wrong `NSError` to user like `-999`, because `- URLSession:task:didCompleteWithError:` only report client-side errors, so we call the `completionBlocks` in advance if server errors happened and provide the response status code to user.

