### PR TITLE
Update the libwebp dependency to support using 1.0 version and above

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -59,6 +59,6 @@ Pod::Spec.new do |s|
       'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
     }
     webp.dependency 'SDWebImage/Core'
-    webp.dependency 'libwebp', '~> 0.5'
+    webp.dependency 'libwebp', '>= 0.5'
   end
 end


### PR DESCRIPTION
which can fix some rare WebP issues

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2431

### Pull Request Description

See #2431 

Our current 4.x branch's WebP subspec, use the libwebp dependency like this.

```ruby
webp.dependency 'libwebp', '~> 0.5'
```

However, since libwebp already bumped version to 1.0 (current latest is 1.0.2), which fix a lots of bugs of WebP decoding && performance. Some of our user and the people from my company want to upgrade to libwebp 1.0. However, current dependency resolve cause we could not upgrade the version.

So, let's update the dependency to use a looser limit of libwebp. I check the code, the libwebp 1.0 is API-compatible with 0.6.1, so it's safe to upgrade.