### PR TITLE
Fix the issue when WebP contains the ICC Profile with colorSpace other than RGB, which cause the CGImageCreate failed

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -347,6 +347,14 @@
             NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
             colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
             WebPDemuxReleaseChunkIterator(&chunk_iter);
+            if (colorSpaceRef) {
+                // `CGImageCreate` does not support colorSpace other than RGB (such as Monochrome), we must filter the colorSpace mode
+                CGColorSpaceModel model = CGColorSpaceGetModel(colorSpaceRef);
+                if (model != kCGColorSpaceModelRGB) {
+                    CGColorSpaceRelease(colorSpaceRef);
+                    colorSpaceRef = NULL;
+                }
+            }
         }
     }
     


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2626

### Pull Request Description

See #2626

In the 4.4.5 version, we add support to load WebP images' ICC Profile. However, current code seems does not check whether the ICC Profile color space is RGB. When using the color space other than RGB (such as Monochrome, CMYK), the `CGImageCreate` call will fail, so this cause the decoding failed.

So, we must do filter of the ICC Profile's color space before using. To ensure we only use RGB color mode to feed the `CGImageCreate` built-in API.
