### PR TITLE
Fix the current transformer cache key generating rules, try to keep the image file extension

### DIFF
--- a/SDWebImage/SDImageTransformer.m
+++ b/SDWebImage/SDImageTransformer.m
@@ -18,7 +18,23 @@ NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullable key, NSString *
     if (!key || !transformerKey) {
         return nil;
     }
-    return [[key stringByAppendingString:SDImageTransformerKeySeparator] stringByAppendingString:transformerKey];
+    // Find the file extension
+    NSURL *keyURL = [NSURL URLWithString:key];
+    NSString *ext = keyURL ? keyURL.pathExtension : key.pathExtension;
+    if (ext.length > 0) {
+        // For non-file URL
+        if (keyURL && !keyURL.isFileURL) {
+            // keep anything except path (like URL query)
+            NSURLComponents *component = [NSURLComponents componentsWithURL:keyURL resolvingAgainstBaseURL:NO];
+            component.path = [[[component.path.stringByDeletingPathExtension stringByAppendingString:SDImageTransformerKeySeparator] stringByAppendingString:transformerKey] stringByAppendingPathExtension:ext];
+            return component.URL.absoluteString;
+        } else {
+            // file URL
+            return [[[key.stringByDeletingPathExtension stringByAppendingString:SDImageTransformerKeySeparator] stringByAppendingString:transformerKey] stringByAppendingPathExtension:ext];
+        }
+    } else {
+        return [[key stringByAppendingString:SDImageTransformerKeySeparator] stringByAppendingString:transformerKey];
+    }
 }
 
 @interface UIColor (HexString)

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -148,6 +148,42 @@
     expect(CGSizeEqualToSize(transformedImage.size, size)).beTruthy();
 }
 
+- (void)test10TransformerKeyForCacheKey {
+    NSString *transformerKey = @"SDImageFlippingTransformer(1,0)";
+    
+    // File path representation test cases
+    NSString *key = @"image.png";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"image-SDImageFlippingTransformer(1,0).png");
+    
+    key = @"image";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"image-SDImageFlippingTransformer(1,0)");
+    
+    key = @".image";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@".image-SDImageFlippingTransformer(1,0)");
+    
+    key = @"image.";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"image.-SDImageFlippingTransformer(1,0)");
+    
+    key = @"Test/image.png";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"Test/image-SDImageFlippingTransformer(1,0).png");
+    
+    // URL representation test cases
+    key = @"http://foo/image.png";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"http://foo/image-SDImageFlippingTransformer(1,0).png");
+    
+    key = @"http://foo/image";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"http://foo/image-SDImageFlippingTransformer(1,0)");
+    
+    key = @"http://foo/.image";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"http://foo/.image-SDImageFlippingTransformer(1,0)");
+    
+    key = @"http://foo/image.png?foo=bar#mark";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"http://foo/image-SDImageFlippingTransformer(1,0).png?foo=bar#mark");
+    
+    key = @"ftp://root:password@foo.com/image.png";
+    expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"ftp://root:password@foo.com/image-SDImageFlippingTransformer(1,0).png");
+}
+
 #pragma mark - Helper
 
 - (UIImage *)testImage {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding: Added `test10TransformerKeyForCacheKey`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass 
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

SD 5.0 introduce a feature called [Image Transformer](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#image-transformer-50), which allows user to transform the decoded image bitmap and save it to a seperate cache.

However, current 5.0.0-beta5, the cache key generated from the transformer, does not match what the comment here:

```
`image.png` |> flip(YES,NO) |> rotate(pi/4,YES) => 'image-SDImageFlippingTransformer(1,0)-SDImageRotationTransformer(0.78539816339,1).png'
```

Instead, it only appending the transformer key one by one, and this result the final cache key like this

```
`image.png` |> flip(YES,NO) |> rotate(pi/4,YES) => `image.png-SDImageFlippingTransformer(1,0)-SDImageRotationTransformer(0.78539816339,1)`
```

And finally, this will result our disk cache, treating `png-SDImageFlippingTransformer(1,0)-SDImageRotationTransformer(0.78539816339,1)` as its file extension, the actual saved disk file name is `MD5(image).png-SDImageFlippingTransformer(1,0)-SDImageRotationTransformer(0.78539816339,1)`.

But, for some of reason and use case, the user need to keep the image file extension. Like some business code which rely the `.png`, `.jpeg` extension, to detect the original compressed image format. Or when using some network uploader to upload the transformed image to network, they may grab the MIME type from the file name. Keeping a file extension with those strange suffix is not always a good idea.

So it's better to keep the original file extension after transforming. The current `SDTransformedKeyForKey` filename generating rules should be updated to keep the file extension as much as we can.

This PR fix it, which introduce a better way to generating the cache key from transformer key. The detailed test cases, are listed in `test10TransformerKeyForCacheKey` test case and it's more matching the expectations.