### PR TITLE
fix under XCode 10.1 (10B61) Examples's build error

### DIFF
--- a/SDWebImage.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SDWebImage.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Under Xcode Version 10.1 (10B61), branch 5.x's Example failed build for [Embedded binary is not signed with the same certificate as the parent app. Verify the embedded binary target's code sign settings match the parent app's
](https://forums.developer.apple.com/thread/107563). Switch the workspace build system to the legacy  (under File->Project Settings or File->Workspace Settings).
