### PR TITLE
simplify assign downloaderOperation's minimumProgressInterval code

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -291,9 +291,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     }
         
     if ([operation respondsToSelector:@selector(setMinimumProgressInterval:)]) {
-        NSTimeInterval minimumProgressInterval = self.config.minimumProgressInterval;
-        minimumProgressInterval = MIN(MAX(minimumProgressInterval, 0), 1);
-        operation.minimumProgressInterval = minimumProgressInterval;
+        operation.minimumProgressInterval = MIN(MAX(self.config.minimumProgressInterval, 0), 1);
     }
     
     if (options & SDWebImageDownloaderHighPriority) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Simplify assign downloaderOperation's minimumProgressInterval code, had passed by my repo travis ci.
