### PR TITLE
Filter the error domain with NSURLErrorDomain before checking the URL Error Codes

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -209,14 +209,19 @@
                     if ([self.delegate respondsToSelector:@selector(imageManager:shouldBlockFailedURL:withError:)]) {
                         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
                     } else {
-                        shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
-                                                && error.code != NSURLErrorCancelled
-                                                && error.code != NSURLErrorTimedOut
-                                                && error.code != NSURLErrorInternationalRoamingOff
-                                                && error.code != NSURLErrorDataNotAllowed
-                                                && error.code != NSURLErrorCannotFindHost
-                                                && error.code != NSURLErrorCannotConnectToHost
-                                                && error.code != NSURLErrorNetworkConnectionLost);
+                        // Filter the error domain and check error codes
+                        if ([error.domain isEqualToString:NSURLErrorDomain]) {
+                            shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
+                                                    && error.code != NSURLErrorCancelled
+                                                    && error.code != NSURLErrorTimedOut
+                                                    && error.code != NSURLErrorInternationalRoamingOff
+                                                    && error.code != NSURLErrorDataNotAllowed
+                                                    && error.code != NSURLErrorCannotFindHost
+                                                    && error.code != NSURLErrorCannotConnectToHost
+                                                    && error.code != NSURLErrorNetworkConnectionLost);
+                        } else {
+                            shouldBlockFailedURL = NO;
+                        }
                     }
                     
                     if (shouldBlockFailedURL) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2582 #2623 

### Pull Request Description

See the #2582 comments. Current these code checking the codes, listed in [URL Loading System Error Codes](https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes), but without checking the Error Domain.

This is actually wrong code, See Apple's [Error Handling Programming Guide](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html).

> Domains serve several useful purposes. They give Cocoa programs a way to identify the OS X subsystem that is detecting an error. They also help to prevent collisions between error codes from different subsystems with the same numeric value.

So, current checking the codes will cause a mismatch when other error domain code occur, such as using the 4.0 feature [Custom Download Operation](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#custom-download-operation-40). This should have a check before the usage.

