### PR TITLE
Rename the SDImageLoaderProtocol method naming to avoid the Selector conflict with SDWebImageManager and cause misunderstanding usage

### DIFF
--- a/SDWebImage/SDImageLoader.h
+++ b/SDWebImage/SDImageLoader.h
@@ -26,7 +26,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextLoader
 
 /**
  This is the built-in decoding process for image download from network or local file.
- @note If you want to implement your custom loader with `loadImageWithURL:options:context:progress:completed:` API, but also want to keep compatible with SDWebImage's behavior, you'd better use this to produce image.
+ @note If you want to implement your custom loader with `requestImageWithURL:options:context:progress:completed:` API, but also want to keep compatible with SDWebImage's behavior, you'd better use this to produce image.
 
  @param imageData The image data from the network. Should not be nil
  @param imageURL The image URL from the input. Should not be nil
@@ -38,7 +38,7 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Non
 
 /**
  This is the built-in decoding process for image progressive download from network. It's used when `SDWebImageProgressiveLoad` option is set. (It's not required when your loader does not support progressive image loading)
- @note If you want to implement your custom loader with `loadImageWithURL:options:context:progress:completed:` API, but also want to keep compatible with SDWebImage's behavior, you'd better use this to produce image.
+ @note If you want to implement your custom loader with `requestImageWithURL:options:context:progress:completed:` API, but also want to keep compatible with SDWebImage's behavior, you'd better use this to produce image.
 
  @param imageData The image data from the network so far. Should not be nil
  @param imageURL The image URL from the input. Should not be nil
@@ -61,12 +61,12 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NS
 
 /**
  Whether current image loader supports to load the provide image URL.
- This will be checked everytime a new image request come for loader. If this return NO, we will mark this image load as failed. If return YES, we will start to call `loadImageWithURL:options:context:progress:completed:`.
+ This will be checked everytime a new image request come for loader. If this return NO, we will mark this image load as failed. If return YES, we will start to call `requestImageWithURL:options:context:progress:completed:`.
 
  @param url The image URL to be loaded.
  @return YES to continue download, NO to stop download.
  */
-- (BOOL)canLoadWithURL:(nullable NSURL *)url;
+- (BOOL)canRequestImageForURL:(nullable NSURL *)url;
 
 /**
  Load the image and image data with the given URL and return the image data. You're responsible for producing the image instance.
@@ -79,10 +79,10 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NS
  @param completedBlock A block called when operation has been completed.
  @return An operation which allow the user to cancel the current request.
  */
-- (nullable id<SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
-                                             options:(SDWebImageOptions)options
-                                             context:(nullable SDWebImageContext *)context
-                                            progress:(nullable SDImageLoaderProgressBlock)progressBlock
-                                           completed:(nullable SDImageLoaderCompletedBlock)completedBlock;
+- (nullable id<SDWebImageOperation>)requestImageWithURL:(nullable NSURL *)url
+                                                options:(SDWebImageOptions)options
+                                                context:(nullable SDWebImageContext *)context
+                                               progress:(nullable SDImageLoaderProgressBlock)progressBlock
+                                              completed:(nullable SDImageLoaderCompletedBlock)completedBlock;
 
 @end

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -65,19 +65,19 @@
 
 #pragma mark - SDImageLoader
 
-- (BOOL)canLoadWithURL:(nullable NSURL *)url {
+- (BOOL)canRequestImageForURL:(nullable NSURL *)url {
     SD_LOCK(self.loadersLock);
     NSArray<id<SDImageLoader>> *loaders = self.loaders;
     SD_UNLOCK(self.loadersLock);
     for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
-        if ([loader canLoadWithURL:url]) {
+        if ([loader canRequestImageForURL:url]) {
             return YES;
         }
     }
     return NO;
 }
 
-- (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
+- (id<SDWebImageOperation>)requestImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
     if (!url) {
         return nil;
     }
@@ -85,8 +85,8 @@
     NSArray<id<SDImageLoader>> *loaders = self.loaders;
     SD_UNLOCK(self.loadersLock);
     for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
-        if ([loader canLoadWithURL:url]) {
-            return [loader loadImageWithURL:url options:options context:context progress:progressBlock completed:completedBlock];
+        if ([loader canRequestImageForURL:url]) {
+            return [loader requestImageWithURL:url options:options context:context progress:progressBlock completed:completedBlock];
         }
     }
     return nil;

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -499,7 +499,7 @@ didReceiveResponse:(NSURLResponse *)response
 
 @implementation SDWebImageDownloader (SDImageLoader)
 
-- (BOOL)canLoadWithURL:(NSURL *)url {
+- (BOOL)canRequestImageForURL:(NSURL *)url {
     if (!url) {
         return NO;
     }
@@ -507,7 +507,7 @@ didReceiveResponse:(NSURLResponse *)response
     return YES;
 }
 
-- (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
+- (id<SDWebImageOperation>)requestImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
     UIImage *cachedImage = context[SDWebImageContextLoaderCachedImage];
     
     SDWebImageDownloaderOptions downloaderOptions = 0;

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -218,7 +218,7 @@ static id<SDImageLoader> _defaultImageLoader;
     BOOL shouldDownload = (options & SDWebImageFromCacheOnly) == 0;
     shouldDownload &= (!cachedImage || options & SDWebImageRefreshCached);
     shouldDownload &= (![self.delegate respondsToSelector:@selector(imageManager:shouldDownloadImageForURL:)] || [self.delegate imageManager:self shouldDownloadImageForURL:url]);
-    shouldDownload &= [self.imageLoader canLoadWithURL:url];
+    shouldDownload &= [self.imageLoader canRequestImageForURL:url];
     if (shouldDownload) {
         if (cachedImage && options & SDWebImageRefreshCached) {
             // If image was found in the cache but SDWebImageRefreshCached is provided, notify about the cached image
@@ -237,7 +237,7 @@ static id<SDImageLoader> _defaultImageLoader;
         
         // `SDWebImageCombinedOperation` -> `SDWebImageDownloadToken` -> `downloadOperationCancelToken`, which is a `SDCallbacksDictionary` and retain the completed block below, so we need weak-strong again to avoid retain cycle
         @weakify(operation);
-        operation.loaderOperation = [self.imageLoader loadImageWithURL:url options:options context:context progress:progressBlock completed:^(UIImage *downloadedImage, NSData *downloadedData, NSError *error, BOOL finished) {
+        operation.loaderOperation = [self.imageLoader requestImageWithURL:url options:options context:context progress:progressBlock completed:^(UIImage *downloadedImage, NSData *downloadedData, NSError *error, BOOL finished) {
             @strongify(operation);
             if (!operation || operation.isCancelled) {
                 // Do nothing if the operation was cancelled

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -443,7 +443,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Custom image not works"];
     SDWebImageTestLoader *loader = [[SDWebImageTestLoader alloc] init];
     NSURL *imageURL = [NSURL URLWithString:kTestJPEGURL];
-    [loader loadImageWithURL:imageURL options:0 context:nil progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
+    [loader requestImageWithURL:imageURL options:0 context:nil progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
         expect(targetURL).notTo.beNil();
     } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         expect(error).to.beNil();
@@ -457,7 +457,7 @@
 - (void)test31ThatLoadersManagerWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Loaders manager not works"];
     NSURL *imageURL = [NSURL URLWithString:kTestJPEGURL];
-    [[SDImageLoadersManager sharedManager] loadImageWithURL:imageURL options:0 context:nil progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
+    [[SDImageLoadersManager sharedManager] requestImageWithURL:imageURL options:0 context:nil progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
         expect(targetURL).notTo.beNil();
     } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         expect(error).to.beNil();

--- a/Tests/Tests/SDWebImageTestLoader.m
+++ b/Tests/Tests/SDWebImageTestLoader.m
@@ -16,11 +16,11 @@
 
 @implementation SDWebImageTestLoader
 
-- (BOOL)canLoadWithURL:(NSURL *)url {
+- (BOOL)canRequestImageForURL:(NSURL *)url {
     return YES;
 }
 
-- (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
+- (id<SDWebImageOperation>)requestImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: https://github.com/SDWebImage/SDWebImagePhotosPlugin/issues/5

### Pull Request Description

### Background
Current during 5.0 development, we introduced a new protocol, called `SDImageLoaderProtocol`. To provide the function for advanced user to customize the image downloader. Wiki page [here](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#custom-loader-50)

This is the feature from other popurlar image framework like [Kingfisher](https://github.com/onevcat/Kingfisher/blob/master/Sources/General/ImageSource/ImageDataProvider.swift) or [LKImageKit](https://github.com/Tencent/LKImageKit/blob/master/LKImageKit/Core/Manager/LKImageLoaderManager.h).

Our SDWebImage group also provide a PhotosKit loader, to load the Photos Library assets using the same API of SD. See : [SDWebImagePhotosPlugin](https://github.com/SDWebImage/SDWebImagePhotosPlugin)

### Problem
However, seems the naming of these procotol methods, cause the issue. Because it use the same naming like `SDWebImageManager`. See the difference of this two naming:

```objective-c
// This is `SDWebImageManager` instance method
- (nullable SDWebImageCombinedOperation *)loadImageWithURL:(nullable NSURL *)url
                                                   options:(SDWebImageOptions)options
                                                   context:(nullable SDWebImageContext *)context
                                                  progress:(nullable SDImageLoaderProgressBlock)progressBlock
                                                 completed:(nonnull SDInternalCompletionBlock)completedBlock;

// This is `SDImageLoader` protocol method, looks same on selector, but not the same args
- (nullable id<SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
                                             options:(SDWebImageOptions)options
                                             context:(nullable SDWebImageContext *)context
                                            progress:(nullable SDImageLoaderProgressBlock)progressBlock
                                           completed:(nullable SDImageLoaderCompletedBlock)completedBlock;
```

The same Selector naming, will cause some potential issue, like some user pass a manager instance to the `id<SDImageLoader>` arg, which will cause a `respondsToSelector:` been passed, but the actually call of method will crash. It's dangerous. 😨

### Solution

To solve this potential issue, this PR change the API naming, and avoid this issue. The API is developed from 5.0.0-beta2, and it does not have compatible issue. Seems this is the last chance for us to change. Or we have to keeping this potential issue until 6.0.0.