### PR TITLE
Remove the unused hack of intrinsicContentSize for SDAnimatedImageView

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -228,8 +228,6 @@ static NSUInteger SDDeviceFreeMemory() {
         
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
         super.highlighted = NO;
-        // UIImageView seems to bypass some accessors when calculating its intrinsic content size, so this ensures its intrinsic content size comes from the animated image.
-        [self invalidateIntrinsicContentSize];
         
         // Calculate max buffer size
         [self calculateMaxBufferCount];
@@ -427,23 +425,6 @@ static NSUInteger SDDeviceFreeMemory() {
     } else {
         [self stopAnimating];
     }
-}
-
-#pragma mark Auto Layout
-
-- (CGSize)intrinsicContentSize
-{
-    // Default to let UIImageView handle the sizing of its image, and anything else it might consider.
-    CGSize intrinsicContentSize = [super intrinsicContentSize];
-    
-    // If we have have an animated image, use its image size.
-    // UIImageView's intrinsic content size seems to be the size of its image. The obvious approach, simply calling `-invalidateIntrinsicContentSize` when setting an animated image, results in UIImageView steadfastly returning `{UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric}` for its intrinsicContentSize.
-    // (Perhaps UIImageView bypasses its `-image` getter in its implementation of `-intrinsicContentSize`, as `-image` is not called after calling `-invalidateIntrinsicContentSize`.)
-    if (self.animatedImage) {
-        intrinsicContentSize = self.image.size;
-    }
-    
-    return intrinsicContentSize;
 }
 
 #pragma mark - UIImageView Method Overrides

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -129,6 +129,14 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     expect(image1.animatedImageFrameCount).equal(image2.animatedImageFrameCount);
 }
 
+- (void)test11AnimatedImageViewIntrinsicContentSize {
+    // Test that SDAnimatedImageView.intrinsicContentSize return the correct value of image size
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
+    imageView.image = image;
+    expect(imageView.intrinsicContentSize).equal(image.size);
+}
+
 - (void)test20AnimatedImageViewRendering {
     XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView rendering"];
     SDAnimatedImageView *imageView = [[SDAnimatedImageView alloc] init];


### PR DESCRIPTION
This is original from FL and it's proved to be a of FL itself, but not what UIKit/AppKit behavior.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass: Added `test11AnimatedImageViewIntrinsicContentSize`
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The `SDAnimatedImageView` implementation, here is a strange hack for `intrinsicContentSize`.

Actually, this code is original from [FLAnimatedImage](https://github.com/Flipboard/FLAnimatedImage/blob/master/FLAnimatedImage/FLAnimatedImageView.m#L199-L214) here. At that time I didn't check whether this is true of false.

But today, during my revisit of 5.0 main feature's functions, I found that this strange hack is useless.

This is the bug of FLAnimatedImage itself, but not what UIKit/AppKit behavior issue. Even without this code, our `SDAnimatedImageView.intrinsicContentSize` works great and return the animated image's size.

So, just remove this hack code, which can solve some potential issue.

I've also add one test case `test11AnimatedImageViewIntrinsicContentSize` to ensure this behavior correctly.
