### PR TITLE
Bugfix macOS related small improvement for SDAnimatedImageView

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -66,7 +66,7 @@ static NSUInteger SDDeviceFreeMemory() {
 
 @implementation SDAnimatedImageView
 #if SD_UIKIT
-@dynamic animationRepeatCount;
+@dynamic animationRepeatCount; // we re-use this property from `UIImageView` super class on iOS.
 #endif
 
 #pragma mark - Initializers
@@ -236,15 +236,6 @@ static NSUInteger SDDeviceFreeMemory() {
         [self.layer displayIfNeeded]; // macOS's imageViewLayer may not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
 #endif
     }
-}
-
-- (void)setAnimationRepeatCount:(NSInteger)animationRepeatCount
-{
-#if SD_MAC
-    _animationRepeatCount = animationRepeatCount;
-#else
-    [super setAnimationRepeatCount:animationRepeatCount];
-#endif
 }
 
 #if SD_UIKIT

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -61,18 +61,12 @@ static NSUInteger SDDeviceFreeMemory() {
 #else
 @property (nonatomic, strong) CADisplayLink *displayLink;
 #endif
-// Layer-backed NSImageView use a subview of `NSImageViewContainerView` to do actual layer rendering. We use this layer instead of `self.layer` during animated image rendering.
-#if SD_MAC
-@property (nonatomic, strong, readonly) CALayer *imageViewLayer;
-#endif
 
 @end
 
 @implementation SDAnimatedImageView
 #if SD_UIKIT
 @dynamic animationRepeatCount;
-#else
-@dynamic imageViewLayer;
 #endif
 
 #pragma mark - Initializers
@@ -239,7 +233,7 @@ static NSUInteger SDDeviceFreeMemory() {
         
         [self.layer setNeedsDisplay];
 #if SD_MAC
-        [self.layer displayIfNeeded]; // macOS's imageViewLayer is not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
+        [self.layer displayIfNeeded]; // macOS's imageViewLayer may not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
 #endif
     }
 }
@@ -309,13 +303,6 @@ static NSUInteger SDDeviceFreeMemory() {
         [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:self.runLoopMode];
     }
     return _displayLink;
-}
-#endif
-
-#if SD_MAC
-- (CALayer *)imageViewLayer {
-    NSView *imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageView"));
-    return imageView.layer;
 }
 #endif
 
@@ -681,6 +668,18 @@ static NSUInteger SDDeviceFreeMemory() {
 }
 
 #if SD_MAC
+// Layer-backed NSImageView optionally optimize to use a subview to do actual layer rendering.
+// When the optimization is turned on, it calls `updateLayer` instead of `displayLayer:` to update subview's layer.
+// When the optimization it turned off, this return nil and calls `displayLayer:` directly.
+- (CALayer *)imageViewLayer {
+    NSView *imageView = imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageView"));
+    if (!imageView) {
+        // macOS 10.14
+        imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageSubview"));
+    }
+    return imageView.layer;
+}
+
 - (void)updateLayer
 {
     if (_currentFrame) {

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -281,8 +281,7 @@ static NSUInteger SDDeviceFreeMemory() {
 - (CVDisplayLinkRef)displayLink
 {
     if (!_displayLink) {
-        CGDirectDisplayID displayID = CGMainDisplayID();
-        CVReturn error = CVDisplayLinkCreateWithCGDisplay(displayID, &_displayLink);
+        CVReturn error = CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
         if (error) {
             return NULL;
         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR fix two small issue specify for macOS platform.

1.The `CVDisplayLink` previouslly using the main display. This is OK for most cases.

But when macOS user connect a external display with 120Hz refresh rate and set its as current display, the rendering aniamtion will be slower than expected. The better way, we can call `CVDisplayLinkCreateWithActiveCGDisplays`, to get the current available display's refresh rate. See: https://developer.apple.com/library/archive/qa/qa1385/_index.html
(Typcially this does not cause issue, because most of animated image, the frame duration is larger than 16ms, which is 60Hz)

2.Update the comments of the `imageViewLayer`. This is acutally a fix specify for macOS. Because macOS's layer-backed `NSImageView`, using a internal subview, do actual image rendering. So our `SDAnimatedImageView` rendering pipeline’s current frame’s CGImage, should feed to that subview's layer instead.

In macOS 10.14, seems this subview optimization, become the optional. (Previously in macOS 10.13, it's not optional and default behavior). So I update the comments there.