### PR TITLE
Fix the thread safe issue of caches manager and specify the default caches array value.

### DIFF
--- a/SDWebImage/SDImageCachesManager.h
+++ b/SDWebImage/SDImageCachesManager.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
 @interface SDImageCachesManager : NSObject <SDImageCache>
 
 /**
- Returns the global shared caches manager instance.
+ Returns the global shared caches manager instance. By default we will set [`SDImageCache.sharedImageCache`] into the caches array.
  */
 @property (nonatomic, class, readonly, nonnull) SDImageCachesManager *sharedManager;
 

--- a/SDWebImage/SDImageCachesManager.h
+++ b/SDWebImage/SDImageCachesManager.h
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
 /**
  All caches in caches manager. The caches array is a priority queue, which means the later added cache will have the highest priority
  */
-@property (atomic, copy, readwrite, nullable) NSArray<id<SDImageCache>> *caches;
+@property (nonatomic, copy, readwrite, nullable) NSArray<id<SDImageCache>> *caches;
 
 /**
  Add a new cache to the end of caches array. Which has the highest priority.

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -36,8 +36,8 @@
         self.containsOperationPolicy = SDImageCachesManagerOperationPolicySerial;
         self.clearOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
         // initialize with default image caches
-        self.caches = @[[SDImageCache sharedImageCache]];
-        self.cachesLock = dispatch_semaphore_create(1);
+        _caches = @[[SDImageCache sharedImageCache]];
+        _cachesLock = dispatch_semaphore_create(1);
     }
     return self;
 }

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -75,7 +75,9 @@
     if (!key) {
         return nil;
     }
-    NSArray<id<SDImageCache>> *caches = [self.caches copy];
+    SD_LOCK(self.cachesLock);
+    NSArray<id<SDImageCache>> *caches = self.caches;
+    SD_UNLOCK(self.cachesLock);
     NSUInteger count = caches.count;
     if (count == 0) {
         return nil;
@@ -117,7 +119,9 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDImageCache>> *caches = [self.caches copy];
+    SD_LOCK(self.cachesLock);
+    NSArray<id<SDImageCache>> *caches = self.caches;
+    SD_UNLOCK(self.cachesLock);
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -155,7 +159,9 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDImageCache>> *caches = [self.caches copy];
+    SD_LOCK(self.cachesLock);
+    NSArray<id<SDImageCache>> *caches = self.caches;
+    SD_UNLOCK(self.cachesLock);
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -193,7 +199,9 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDImageCache>> *caches = [self.caches copy];
+    SD_LOCK(self.cachesLock);
+    NSArray<id<SDImageCache>> *caches = self.caches;
+    SD_UNLOCK(self.cachesLock);
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -230,7 +238,9 @@
 }
 
 - (void)clearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock {
-    NSArray<id<SDImageCache>> *caches = [self.caches copy];
+    SD_LOCK(self.cachesLock);
+    NSArray<id<SDImageCache>> *caches = self.caches;
+    SD_UNLOCK(self.cachesLock);
     NSUInteger count = caches.count;
     if (count == 0) {
         return;

--- a/SDWebImage/SDImageCodersManager.h
+++ b/SDWebImage/SDImageCodersManager.h
@@ -17,10 +17,10 @@
  
  Note: the `coders` getter will return the coders in their reversed order
  Example:
- - by default we internally set coders = `IOCoder`, `GIFCoder`
- - calling `coders` will return `@[IOCoder, GIFCoder]`
+ - by default we internally set coders = `IOCoder`, `GIFCoder`, `APNGCoder`
+ - calling `coders` will return `@[IOCoder, GIFCoder, APNGCoder]`
  - call `[addCoder:[MyCrazyCoder new]]`
- - calling `coders` now returns `@[IOCoder, GIFCoder, MyCrazyCoder]`
+ - calling `coders` now returns `@[IOCoder, GIFCoder, APNGCoder, MyCrazyCoder]`
  
  Coders
  ------

--- a/SDWebImage/SDImageCodersManager.m
+++ b/SDWebImage/SDImageCodersManager.m
@@ -31,8 +31,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         // initialize with default coders
-        NSMutableArray<id<SDImageCoder>> *mutableCoders = [@[[SDImageIOCoder sharedCoder], [SDImageGIFCoder sharedCoder], [SDImageAPNGCoder sharedCoder]] mutableCopy];
-        _coders = [mutableCoders copy];
+        _coders = @[[SDImageIOCoder sharedCoder], [SDImageGIFCoder sharedCoder], [SDImageAPNGCoder sharedCoder]];
         _codersLock = dispatch_semaphore_create(1);
     }
     return self;

--- a/SDWebImage/SDImageLoadersManager.h
+++ b/SDWebImage/SDImageLoadersManager.h
@@ -10,6 +10,9 @@
 
 @interface SDImageLoadersManager : NSObject <SDImageLoader>
 
+/**
+ Returns the global shared loaders manager instance. By default we will set [`SDWebImageDownloader.sharedDownloader`] into the loaders array.
+ */
 @property (nonatomic, class, readonly, nonnull) SDImageLoadersManager *sharedManager;
 
 /**

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -30,8 +30,8 @@
     self = [super init];
     if (self) {
         // initialize with default image loaders
-        self.loaders = @[[SDWebImageDownloader sharedDownloader]];
-        self.loadersLock = dispatch_semaphore_create(1);
+        _loaders = @[[SDWebImageDownloader sharedDownloader]];
+        _loadersLock = dispatch_semaphore_create(1);
     }
     return self;
 }

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -27,14 +27,6 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
 
 @implementation SDImageCacheTests
 
-+ (void)setUp {
-    [[SDImageCachesManager sharedManager] addCache:[SDImageCache sharedImageCache]];
-}
-
-+ (void)tearDown {
-    [[SDImageCachesManager sharedManager] removeCache:[SDImageCache sharedImageCache]];
-}
-
 - (void)test01SharedImageCache {
     expect([SDImageCache sharedImageCache]).toNot.beNil();
 }
@@ -452,8 +444,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
-    [cachesManager addCache:cache1];
-    [cachesManager addCache:cache2];
+    cachesManager.caches = @[cache1, cache2];
     
     [[NSFileManager defaultManager] removeItemAtPath:cache1.diskCachePath error:nil];
     [[NSFileManager defaultManager] removeItemAtPath:cache2.diskCachePath error:nil];
@@ -502,8 +493,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
-    [cachesManager addCache:cache1];
-    [cachesManager addCache:cache2];
+    cachesManager.caches = @[cache1, cache2];
     
     [[NSFileManager defaultManager] removeItemAtPath:cache1.diskCachePath error:nil];
     [[NSFileManager defaultManager] removeItemAtPath:cache2.diskCachePath error:nil];
@@ -543,8 +533,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
-    [cachesManager addCache:cache1];
-    [cachesManager addCache:cache2];
+    cachesManager.caches = @[cache1, cache2];
     
     [[NSFileManager defaultManager] removeItemAtPath:cache1.diskCachePath error:nil];
     [[NSFileManager defaultManager] removeItemAtPath:cache2.diskCachePath error:nil];


### PR DESCRIPTION
Update the test cases and documents about this behavior.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #841 

### Pull Request Description

During my detailed reviewing of 5.0's new feature, I found this `SDImageCachesManager`, does not keep thread-safe unlike `SDImageLoadersManager`. And it does not apply a default value unlike `SDImageLoadersManager`.

These two `SDImageCachesManager` and `SDImageLoadersManager` are the similar class, to support multiple cacehs and multiple downloaders. They should have the same design and concept. So this fix it.

Does not effect the API, only the implementation.

