### PR TITLE
Revert "Filter the error domain with NSURLErrorDomain before checking the URL Error Codes

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -209,19 +209,14 @@
                     if ([self.delegate respondsToSelector:@selector(imageManager:shouldBlockFailedURL:withError:)]) {
                         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
                     } else {
-                        // Filter the error domain and check error codes
-                        if ([error.domain isEqualToString:NSURLErrorDomain]) {
-                            shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
-                                                    && error.code != NSURLErrorCancelled
-                                                    && error.code != NSURLErrorTimedOut
-                                                    && error.code != NSURLErrorInternationalRoamingOff
-                                                    && error.code != NSURLErrorDataNotAllowed
-                                                    && error.code != NSURLErrorCannotFindHost
-                                                    && error.code != NSURLErrorCannotConnectToHost
-                                                    && error.code != NSURLErrorNetworkConnectionLost);
-                        } else {
-                            shouldBlockFailedURL = NO;
-                        }
+                        shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
+                                                && error.code != NSURLErrorCancelled
+                                                && error.code != NSURLErrorTimedOut
+                                                && error.code != NSURLErrorInternationalRoamingOff
+                                                && error.code != NSURLErrorDataNotAllowed
+                                                && error.code != NSURLErrorCannotFindHost
+                                                && error.code != NSURLErrorCannotConnectToHost
+                                                && error.code != NSURLErrorNetworkConnectionLost);
                     }
                     
                     if (shouldBlockFailedURL) {


### PR DESCRIPTION

This reverts commit 40abbd648d8f788ba385c2c090eeb6a596dffe7a.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Revert #2648 , it break the processing logic when domain is not `NSURLErrorDomain`.