### PR TITLE
Fix the black list error domain should filter specify SDWebImageErrorDomain codes which is indeed un-recoverable

### DIFF
--- a/SDWebImage/SDImageLoader.h
+++ b/SDWebImage/SDImageLoader.h
@@ -86,11 +86,9 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NS
                                               completed:(nullable SDImageLoaderCompletedBlock)completedBlock;
 
 
-@optional
 /**
  Whether the error from image loader should be marked indded un-recoverable or not.
  If this return YES, failed URL which does not using `SDWebImageRetryFailed` will be blocked into black list. Else not.
- If does not implements this method, assume always return NO.
 
  @param url The URL represent the image. Note this may not be a HTTP URL
  @param error The URL's loading error, from previous `requestImageWithURL:options:context:progress:completed:` completedBlock's error.

--- a/SDWebImage/SDImageLoader.h
+++ b/SDWebImage/SDImageLoader.h
@@ -85,4 +85,18 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NS
                                                progress:(nullable SDImageLoaderProgressBlock)progressBlock
                                               completed:(nullable SDImageLoaderCompletedBlock)completedBlock;
 
+
+@optional
+/**
+ Whether the error from image loader should be marked indded un-recoverable or not.
+ If this return YES, failed URL which does not using `SDWebImageRetryFailed` will be blocked into black list. Else not.
+ If does not implements this method, assume always return NO.
+
+ @param url The URL represent the image. Note this may not be a HTTP URL
+ @param error The URL's loading error, from previous `requestImageWithURL:options:context:progress:completed:` completedBlock's error.
+ @return Whether to block this url or not. Return YES to mark this URL as failed.
+ */
+- (BOOL)shouldBlockFailedURLWithURL:(nonnull NSURL *)url
+                              error:(nonnull NSError *)error;
+
 @end

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -103,11 +103,12 @@
 - (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
     NSArray<id<SDImageLoader>> *loaders = self.loaders;
     for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
-        if (![loader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
-            break;
-        }
         if ([loader canRequestImageForURL:url]) {
-            return [loader shouldBlockFailedURLWithURL:url error:error];
+            if ([loader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
+                return [loader shouldBlockFailedURLWithURL:url error:error];
+            } else {
+                return NO;
+            }
         }
     }
     return NO;

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -104,11 +104,7 @@
     NSArray<id<SDImageLoader>> *loaders = self.loaders;
     for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
         if ([loader canRequestImageForURL:url]) {
-            if ([loader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
-                return [loader shouldBlockFailedURLWithURL:url error:error];
-            } else {
-                return NO;
-            }
+            return [loader shouldBlockFailedURLWithURL:url error:error];
         }
     }
     return NO;

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -100,4 +100,17 @@
     return nil;
 }
 
+- (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
+    NSArray<id<SDImageLoader>> *loaders = self.loaders;
+    for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
+        if (![loader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
+            break;
+        }
+        if ([loader canRequestImageForURL:url]) {
+            return [loader shouldBlockFailedURLWithURL:url error:error];
+        }
+    }
+    return NO;
+}
+
 @end

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -546,4 +546,25 @@ didReceiveResponse:(NSURLResponse *)response
     return [self downloadImageWithURL:url options:downloaderOptions context:context progress:progressBlock completed:completedBlock];
 }
 
+- (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
+    BOOL shouldBlockFailedURL;
+    // Filter the error domain and check error codes
+    if ([error.domain isEqualToString:SDWebImageErrorDomain]) {
+        shouldBlockFailedURL = (   error.code == SDWebImageErrorInvalidURL
+                                || error.code == SDWebImageErrorBadImageData);
+    } else if ([error.domain isEqualToString:NSURLErrorDomain]) {
+        shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
+                                && error.code != NSURLErrorCancelled
+                                && error.code != NSURLErrorTimedOut
+                                && error.code != NSURLErrorInternationalRoamingOff
+                                && error.code != NSURLErrorDataNotAllowed
+                                && error.code != NSURLErrorCannotFindHost
+                                && error.code != NSURLErrorCannotConnectToHost
+                                && error.code != NSURLErrorNetworkConnectionLost);
+    } else {
+        shouldBlockFailedURL = NO;
+    }
+    return shouldBlockFailedURL;
+}
+
 @end

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -374,19 +374,8 @@ static id<SDImageLoader> _defaultImageLoader;
     if ([self.delegate respondsToSelector:@selector(imageManager:shouldBlockFailedURL:withError:)]) {
         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
     } else {
-        // Filter the error domain and check error codes
-        if ([error.domain isEqualToString:SDWebImageErrorDomain]) {
-            shouldBlockFailedURL = (   error.code == SDWebImageErrorInvalidURL
-                                    || error.code == SDWebImageErrorBadImageData);
-        } else if ([error.domain isEqualToString:NSURLErrorDomain]) {
-            shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
-                                    && error.code != NSURLErrorCancelled
-                                    && error.code != NSURLErrorTimedOut
-                                    && error.code != NSURLErrorInternationalRoamingOff
-                                    && error.code != NSURLErrorDataNotAllowed
-                                    && error.code != NSURLErrorCannotFindHost
-                                    && error.code != NSURLErrorCannotConnectToHost
-                                    && error.code != NSURLErrorNetworkConnectionLost);
+        if ([self.imageLoader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
+            shouldBlockFailedURL = [self.imageLoader shouldBlockFailedURLWithURL:url error:error];
         } else {
             shouldBlockFailedURL = NO;
         }

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -178,7 +178,7 @@ static id<SDImageLoader> _defaultImageLoader;
 
 // Query cache process
 - (void)callCacheProcessForOperation:(nonnull SDWebImageCombinedOperation *)operation
-                                 url:(nullable NSURL *)url
+                                 url:(nonnull NSURL *)url
                              options:(SDWebImageOptions)options
                              context:(nullable SDWebImageContext *)context
                             progress:(nullable SDImageLoaderProgressBlock)progressBlock
@@ -206,7 +206,7 @@ static id<SDImageLoader> _defaultImageLoader;
 
 // Download process
 - (void)callDownloadProcessForOperation:(nonnull SDWebImageCombinedOperation *)operation
-                                    url:(nullable NSURL *)url
+                                    url:(nonnull NSURL *)url
                                 options:(SDWebImageOptions)options
                                 context:(SDWebImageContext *)context
                             cachedImage:(nullable UIImage *)cachedImage
@@ -280,7 +280,7 @@ static id<SDImageLoader> _defaultImageLoader;
 
 // Store cache process
 - (void)callStoreCacheProcessForOperation:(nonnull SDWebImageCombinedOperation *)operation
-                                      url:(nullable NSURL *)url
+                                      url:(nonnull NSURL *)url
                                   options:(SDWebImageOptions)options
                                   context:(SDWebImageContext *)context
                           downloadedImage:(nullable UIImage *)downloadedImage
@@ -375,7 +375,10 @@ static id<SDImageLoader> _defaultImageLoader;
         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
     } else {
         // Filter the error domain and check error codes
-        if ([error.domain isEqualToString:NSURLErrorDomain]) {
+        if ([error.domain isEqualToString:SDWebImageErrorDomain]) {
+            shouldBlockFailedURL = (   error.code == SDWebImageErrorInvalidURL
+                                    || error.code == SDWebImageErrorBadImageData);
+        } else if ([error.domain isEqualToString:NSURLErrorDomain]) {
             shouldBlockFailedURL = (   error.code != NSURLErrorNotConnectedToInternet
                                     && error.code != NSURLErrorCancelled
                                     && error.code != NSURLErrorTimedOut

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -374,11 +374,7 @@ static id<SDImageLoader> _defaultImageLoader;
     if ([self.delegate respondsToSelector:@selector(imageManager:shouldBlockFailedURL:withError:)]) {
         shouldBlockFailedURL = [self.delegate imageManager:self shouldBlockFailedURL:url withError:error];
     } else {
-        if ([self.imageLoader respondsToSelector:@selector(shouldBlockFailedURLWithURL:error:)]) {
-            shouldBlockFailedURL = [self.imageLoader shouldBlockFailedURLWithURL:url error:error];
-        } else {
-            shouldBlockFailedURL = NO;
-        }
+        shouldBlockFailedURL = [self.imageLoader shouldBlockFailedURLWithURL:url error:error];
     }
     
     return shouldBlockFailedURL;

--- a/Tests/Tests/SDWebImageTestLoader.m
+++ b/Tests/Tests/SDWebImageTestLoader.m
@@ -50,4 +50,8 @@
     return task;
 }
 
+- (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
+    return NO;
+}
+
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

In 4.x, we will blocking any error during network downloading, including the `invalidURL` as well as `badImageData`(image pixel is 0).

Since this is already used in applications, and it's a suitable logic, add check the specify error domain and codes as well.

