### PR TITLE
Fix caches manager operation thread safe issue

### DIFF
--- a/SDWebImage/Private/SDImageCachesManagerOperation.m
+++ b/SDWebImage/Private/SDImageCachesManagerOperation.m
@@ -9,10 +9,22 @@
 #import "SDImageCachesManagerOperation.h"
 
 @implementation SDImageCachesManagerOperation
+{
+    dispatch_semaphore_t _pendingCountLock;
+}
 
 @synthesize executing = _executing;
 @synthesize finished = _finished;
 @synthesize cancelled = _cancelled;
+@synthesize pendingCount = _pendingCount;
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _pendingCountLock = dispatch_semaphore_create(1);
+        _pendingCount = 0;
+    }
+    return self;
+}
 
 - (void)beginWithTotalCount:(NSUInteger)totalCount {
     self.executing = YES;
@@ -20,8 +32,17 @@
     _pendingCount = totalCount;
 }
 
+- (NSUInteger)pendingCount {
+    SD_LOCK(_pendingCountLock);
+    NSUInteger pendingCount = _pendingCount;
+    SD_UNLOCK(_pendingCountLock);
+    return pendingCount;
+}
+
 - (void)completeOne {
+    SD_LOCK(_pendingCountLock);
     _pendingCount = _pendingCount > 0 ? _pendingCount - 1 : 0;
+    SD_UNLOCK(_pendingCountLock);
 }
 
 - (void)cancel {
@@ -36,7 +57,9 @@
 }
 
 - (void)reset {
+    SD_LOCK(_pendingCountLock);
     _pendingCount = 0;
+    SD_UNLOCK(_pendingCountLock);
 }
 
 - (void)setFinished:(BOOL)finished {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Fixes thread-safe issue, CachesManager support concurrency read-write.

