### PR TITLE
Fixes typo in SDImageCacheConfig maxDiskAge info

### DIFF
--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
  * The maximum length of time to keep an image in the disk cache, in seconds.
  * Setting this to a negative value means no expiring.
  * Setting this to zero means that all cached files would be removed when do expiration check.
- * Defaults to 1 weak.
+ * Defaults to 1 week.
  */
 @property (assign, nonatomic) NSTimeInterval maxDiskAge;
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This pull request fixes a typo in SDImageCacheConfig maxDiskAge property description