### PR TITLE
Fix the issue about image doesn't show up, when set NSImage object to…

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -236,6 +236,20 @@ static NSUInteger SDDeviceFreeMemory() {
         [self.layer displayIfNeeded]; // macOS's imageViewLayer may not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
 #endif
     }
+#if SD_MAC
+    else {
+        // Set wantLayer to YES turns NSView into a layer-backed view
+        // super setIamge won't show the image, so need set image as layer's contents
+        // check https://developer.apple.com/documentation/appkit/nsview/1483695-wantslayer?language=objc
+        CGFloat desiredScaleFactor = [self.window backingScaleFactor];
+        CGFloat actualScaleFactor = [image recommendedLayerContentsScale:desiredScaleFactor];
+        
+        id layerContents = [image layerContentsForContentsScale:actualScaleFactor];
+        
+        [self.layer setContents:layerContents];
+        [self.layer setContentsScale:actualScaleFactor];
+    }
+#endif
 }
 
 #if SD_UIKIT


### PR DESCRIPTION
… SDAnimatedImageView

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Set wantLayer to YES turns NSView into a layer-backed view
[super setImage:] won't show the image, so need set image as layer's contents
