### PR TITLE
Fix the bug of SDAnimatedImageView, which can not render the normal NSImage (including animated image) at all. Only `SDAnimatedImage` can be rendered

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -29,13 +29,16 @@
     
     // For animated GIF rendering, set `animates` to YES or will only show the first frame
     self.imageView2.animates = YES; // `SDAnimatedImageRep` can be used for built-in `NSImageView` to support better GIF & APNG rendering as well. No need `SDAnimatedImageView`
-    self.imageView3.animates = YES;
     self.imageView4.animates = YES;
+    
+    // NSImageView + Static Image
     self.imageView1.sd_imageIndicator = SDWebImageProgressIndicator.defaultIndicator;
     [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"] placeholderImage:nil options:SDWebImageProgressiveLoad];
+    // NSImageView + Animated Image
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"https:raw.githubusercontent.com/onevcat/APNGKit/master/TestImages/APNG-cube.apng"]];
-    [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"]];
-    self.imageView4.wantsLayer = YES;
+    // SDAnimatedImageView + Static Image
+    [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png"]];
+    // SDAnimatedImageView + Animated Image
     self.imageView4.sd_imageTransition = SDWebImageTransition.fadeTransition;
     [self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"] placeholderImage:nil options:SDWebImageForceTransition];
     

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -678,6 +678,17 @@ static NSUInteger SDDeviceFreeMemory() {
         [super updateLayer];
     }
 }
+
+- (BOOL)wantsUpdateLayer {
+    // AppKit is different from UIKit, it need extra check before the layer is updated
+    // When we use the custom animation, the layer.setNeedsDisplay is directly called from display link (See `displayDidRefresh:`). However, for normal image rendering, we must implements and return YES to mark it need display
+    if (_currentFrame) {
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
 #endif
 
 

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -137,6 +137,18 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     expect(imageView.intrinsicContentSize).equal(image.size);
 }
 
+- (void)test12AnimatedImageViewLayerContents {
+    // Test that SDAnimatedImageView with built-in UIImage/NSImage will actually setup the layer for display
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    UIImage *image = [[UIImage alloc] initWithData:[self testJPEGData]];
+    imageView.image = image;
+#if SD_MAC
+    expect(imageView.wantsUpdateLayer).beTruthy();
+#else
+    expect(imageView.layer.contents).notTo.beNil();
+#endif
+}
+
 - (void)test20AnimatedImageViewRendering {
     XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView rendering"];
     SDAnimatedImageView *imageView = [[SDAnimatedImageView alloc] init];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass Added one `test12AnimatedImageViewLayerContents `
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2705 

### Pull Request Description

See #2705 for bug description.
There is one solution #2704 , but it does not help for animated NSImage. This one do the correct way for this problem.

### Bug's reason

AppKit's Layer-backed view, have a method to let you implements, the [wantsUpdateLayer](https://developer.apple.com/documentation/appkit/nsview/1483461-wantsupdatelayer).

Unlike the UIKit's `UIImageView`, `NSImageView`, by default, does not using any layer-backed, and it using **a optimize policy** to detect the whether to refresh the layer or not. The policy is that NSImageView will using a subview's layer for actual rendering. See the comments there:

> // Layer-backed NSImageView optionally optimize to use a subview to do actual layer rendering.
> // When the optimization is turned on, it calls `updateLayer` instead of `displayLayer:` to update subview's layer.
> // When the optimization it turned off, this return nil and calls `displayLayer:` directly.

If the`SDAnimatedImageView` (macOS) + `NSImage` case occur, the policy will not be trigged. So there are no subview layer for rendering. The `displayLayer:` method will be trigged, but not layer's contents is updated at all.

### Solution
The solution, is to do the correct thing, we implements the `wantsUpdateLayer`, and when using our custom animation rendering, we return the NO, to using the directly call for `CALayer.setNeedsDisplay`.

When our custom animation rendering is disabled, we always return YES, to let AppKit render the NSImage, it works for normal static image, as well as animated image. (NSImage can also be animation one, like GIF/APNG, see `SDAnimatedImageRep`).

