### PR TITLE
Replace the private prefix header files with the manually import for each implementation files

### DIFF
--- a/Configs/App-Shared.xcconfig
+++ b/Configs/App-Shared.xcconfig
@@ -5,6 +5,3 @@
 
 // Name of an asset catalog app icon set whose contents will be merged into the `Info.plist`.
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
-
-// Implicitly include the named header. The path given should either be a project relative path or an absolute path.
-GCC_PREFIX_HEADER =

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -223,6 +223,3 @@ VERSIONING_SYSTEM = apple-generic
 
 // Code will load on this and later versions of watchOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
 WATCHOS_DEPLOYMENT_TARGET = 2.0
-
-// Implicitly include the named header. The path given should either be a project relative path or an absolute path.
-GCC_PREFIX_HEADER = WebImage/SDWebImage-Prefix.pch

--- a/Configs/Test-Shared.xcconfig
+++ b/Configs/Test-Shared.xcconfig
@@ -3,8 +3,5 @@
 
 #include "Module-Shared.xcconfig"
 
-// Implicitly include the named header. The path given should either be a project relative path or an absolute path.
-GCC_PREFIX_HEADER =
-
 // This is a list of paths to folders to be searched by the compiler for included or imported header files when compiling C, Objective-C, C++, or Objective-C++. Paths are delimited by whitespace, so any paths with spaces in them need to be properly quoted.
 HEADER_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../SDWebImage/Private"

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -31,7 +31,6 @@ Pod::Spec.new do |s|
     core.source_files = 'SDWebImage/*.{h,m}', 'WebImage/SDWebImage.h', 'SDWebImage/Private/*.{h,m}'
     core.exclude_files = 'SDWebImage/MapKit/*.{h,m}'
     core.private_header_files = 'SDWebImage/Private/*.h'
-    core.prefix_header_contents = '#import "SDInternalMacros.h"'
   end
 
   s.subspec 'MapKit' do |mk|

--- a/SDWebImage/MapKit/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MapKit/MKAnnotationView+WebCache.m
@@ -13,6 +13,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
+#import "SDInternalMacros.h"
 
 @implementation MKAnnotationView (WebCache)
 

--- a/SDWebImage/NSButton+WebCache.m
+++ b/SDWebImage/NSButton+WebCache.m
@@ -13,6 +13,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
+#import "SDInternalMacros.h"
 
 static NSString * const SDAlternateImageOperationKey = @"NSButtonAlternateImageOperation";
 

--- a/SDWebImage/Private/SDImageAssetManager.m
+++ b/SDWebImage/Private/SDImageAssetManager.m
@@ -7,6 +7,7 @@
  */
 
 #import "SDImageAssetManager.h"
+#import "SDInternalMacros.h"
 
 static NSArray *SDBundlePreferredScales() {
     static NSArray *scales;

--- a/SDWebImage/Private/SDImageCachesManagerOperation.m
+++ b/SDWebImage/Private/SDImageCachesManagerOperation.m
@@ -7,6 +7,7 @@
  */
 
 #import "SDImageCachesManagerOperation.h"
+#import "SDInternalMacros.h"
 
 @implementation SDImageCachesManagerOperation
 {

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -13,6 +13,7 @@
 #import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 #import "SDWeakProxy.h"
+#import "SDInternalMacros.h"
 #import <mach/mach.h>
 #import <objc/runtime.h>
 

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -9,6 +9,7 @@
 #import "SDImageCachesManager.h"
 #import "SDImageCachesManagerOperation.h"
 #import "SDImageCache.h"
+#import "SDInternalMacros.h"
 
 @interface SDImageCachesManager ()
 

--- a/SDWebImage/SDImageCodersManager.m
+++ b/SDWebImage/SDImageCodersManager.m
@@ -10,6 +10,7 @@
 #import "SDImageIOCoder.h"
 #import "SDImageGIFCoder.h"
 #import "SDImageAPNGCoder.h"
+#import "SDInternalMacros.h"
 
 @interface SDImageCodersManager ()
 

--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -8,6 +8,7 @@
 
 #import "SDImageLoadersManager.h"
 #import "SDWebImageDownloader.h"
+#import "SDInternalMacros.h"
 
 @interface SDImageLoadersManager ()
 

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -9,6 +9,7 @@
 #import "SDMemoryCache.h"
 #import "SDImageCacheConfig.h"
 #import "UIImage+MemoryCacheCost.h"
+#import "SDInternalMacros.h"
 
 static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -10,6 +10,7 @@
 #import "SDWebImageDownloaderConfig.h"
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageError.h"
+#import "SDInternalMacros.h"
 
 NSNotificationName const SDWebImageDownloadStartNotification = @"SDWebImageDownloadStartNotification";
 NSNotificationName const SDWebImageDownloadReceiveResponseNotification = @"SDWebImageDownloadReceiveResponseNotification";

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -8,6 +8,7 @@
 
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageError.h"
+#import "SDInternalMacros.h"
 
 // iOS 8 Foundation.framework extern these symbol but the define is in CFNetwork.framework. We just fix this without import CFNetwork.framework
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -11,6 +11,7 @@
 #import "SDWebImageDownloader.h"
 #import "UIImage+Metadata.h"
 #import "SDWebImageError.h"
+#import "SDInternalMacros.h"
 
 static id<SDImageCache> _defaultImageCache;
 static id<SDImageLoader> _defaultImageLoader;

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -8,6 +8,7 @@
 
 #import "SDWebImagePrefetcher.h"
 #import "SDAsyncBlockOperation.h"
+#import "SDInternalMacros.h"
 #import <stdatomic.h>
 
 @interface SDWebImagePrefetchToken () {

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -13,6 +13,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
+#import "SDInternalMacros.h"
 
 static char imageURLStorageKey;
 

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -12,6 +12,7 @@
 
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
+#import "SDInternalMacros.h"
 
 static NSString * const SDHighlightedImageOperationKey = @"UIImageViewImageOperationHighlighted";
 

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -10,6 +10,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "SDWebImageError.h"
+#import "SDInternalMacros.h"
 
 const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 

--- a/WebImage/SDWebImage-Prefix.pch
+++ b/WebImage/SDWebImage-Prefix.pch
@@ -1,9 +1,0 @@
-/*
- * This file is part of the SDWebImage package.
- * (c) Olivier Poitrey <rs@dailymotion.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
-#import "SDInternalMacros.h"


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2646 #2683 

### Pull Request Description

Seems someone found that the prefix header files contains issues related to project.

> Actually, I think this will not cause issue. That #2683 is the bad install issue, which does not use Xcode to embed code, and they ignore the `HEADER_SEARCH_PATH` config. Until oneday the `GCC_PREFIX_HEADER` xcconfig option is deprecated (current not), it's still the only way to help us to avoid written import one by one in project implementation files only.

But since changing this is not hard. So let me just replace this.