### PR TITLE
fix issues: SDWebImageDecodeFirstFrameOnly flag is ignored when image loaded from cache

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -15,6 +15,7 @@
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 #import "UIImage+MemoryCacheCost.h"
+#import "UIImage+Metadata.h"
 
 @interface SDImageCache ()
 
@@ -378,6 +379,15 @@
     
     // First check the in-memory cache...
     UIImage *image = [self imageFromMemoryCacheForKey:key];
+
+    if ((options & SDImageCacheDecodeFirstFrameOnly) && image.sd_isAnimated) {
+#if SD_MAC
+        image = [[NSImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:kCGImagePropertyOrientationUp];
+#else
+        image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:image.imageOrientation];
+#endif
+    }
+
     BOOL shouldQueryMemoryOnly = (image && !(options & SDImageCacheQueryMemoryData));
     if (shouldQueryMemoryOnly) {
         if (doneBlock) {


### PR DESCRIPTION
… loaded from cache.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

first time, load from internet, it is a thumbnail imageview.
```objc
 [imageView sd_setImageWithURL:[NSURL URLWithString:url]
                         placeholderImage:nil
                                  options:SDWebImageDecodeFirstFrameOnly];
```

second time, load the same image from loader, it is a detail imageview.
```objc
 [imageView sd_setImageWithURL:[NSURL URLWithString:url]
                         placeholderImage:nil
                                  options:SDWebImageFromLoaderOnly];
```

and when thumbnail imageview load the image using `SDWebImageDecodeFirstFrameOnly` on next time, SDWebImage will give it an animated image, it should be a static image.