### PR TITLE
Fix that SDAnimatedImageView initWithImage will skip the initialize logic and crash

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -62,6 +62,7 @@ static NSUInteger SDDeviceFreeMemory() {
 #else
 @property (nonatomic, strong) CADisplayLink *displayLink;
 #endif
+@property (nonatomic, assign) BOOL hasInitialized;
 
 @end
 
@@ -123,6 +124,11 @@ static NSUInteger SDDeviceFreeMemory() {
 
 - (void)commonInit
 {
+    if (self.hasInitialized) {
+        return;
+    }
+    self.hasInitialized = YES;
+    
     self.shouldCustomLoopCount = NO;
     self.shouldIncrementalLoad = YES;
     self.lock = dispatch_semaphore_create(1);
@@ -181,6 +187,11 @@ static NSUInteger SDDeviceFreeMemory() {
 {
     if (self.image == image) {
         return;
+    }
+    
+    // Check has initlized
+    if (!self.hasInitialized) {
+        [self commonInit];
     }
     
     // Check Progressive rendering

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -247,14 +247,14 @@ static NSUInteger SDDeviceFreeMemory() {
 #if SD_UIKIT
 - (void)setRunLoopMode:(NSRunLoopMode)runLoopMode
 {
-    if ([_runLoopMode isEqualToString:runLoopMode]) {
+    if ([_runLoopMode isEqual:runLoopMode]) {
         return;
     }
     if (_displayLink) {
         if (_runLoopMode) {
             [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:_runLoopMode];
         }
-        if (runLoopMode) {
+        if (runLoopMode.length > 0) {
             [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:runLoopMode];
         }
     }

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -156,6 +156,20 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #endif
 }
 
+- (void)test12AnimatedImageViewInitWithImage {
+    // Test that -[SDAnimatedImageView initWithImage:] this convenience initializer not crash
+    SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
+    SDAnimatedImageView *imageView;
+#if SD_UIKIT
+    imageView = [[SDAnimatedImageView alloc] initWithImage:image];
+#else
+    if (@available(macOS 10.12, *)) {
+        imageView = [SDAnimatedImageView imageViewWithImage:image];
+    }
+#endif
+    expect(imageView.image).equal(image);
+}
+
 - (void)test20AnimatedImageViewRendering {
     XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView rendering"];
     SDAnimatedImageView *imageView = [[SDAnimatedImageView alloc] init];

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -156,7 +156,7 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #endif
 }
 
-- (void)test12AnimatedImageViewInitWithImage {
+- (void)test13AnimatedImageViewInitWithImage {
     // Test that -[SDAnimatedImageView initWithImage:] this convenience initializer not crash
     SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
     SDAnimatedImageView *imageView;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass Added one `test13AnimatedImageViewInitWithImage`
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2727 

### Pull Request Description

This PR fix the issue of #2727 . I can translate that issue:

Before this PR, this code will cause crash

```objective-c
SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
SDAnimatedImageView *imageView = [[SDAnimatedImageView alloc] initWithImage:image];
// Crash here
```

The crash because, the UIKit's method [UIImageView initWithImage:](https://developer.apple.com/documentation/uikit/uiimageview/1621062-initwithimage?language=objc), will implictlly call `setImage:`, which will skip our `commonInit` method to setup the dispatch queue and semaphore. So the next code logic will cause crash.