### PR TITLE
Fix get button background image operation key bug

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -189,7 +189,7 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
     } else {
         mutableContext = [NSMutableDictionary dictionary];
     }
-    mutableContext[SDWebImageContextSetImageOperationKey] = imageOperationKeyForState(state);
+    mutableContext[SDWebImageContextSetImageOperationKey] = backgroundImageOperationKeyForState(state);
     @weakify(self);
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -171,10 +171,9 @@
     SDImageTintTransformer *transformer6 = [SDImageTintTransformer transformerWithColor:tintColor];
     SDImageBlurTransformer *transformer7 = [SDImageBlurTransformer transformerWithRadius:blurRadius];
     
-#if SD_UIKIT || SD_MAC
     CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];
     SDImageFilterTransformer *transformer8 = [SDImageFilterTransformer transformerWithFilter:filter];
-#endif
+    
     // Chain all built-in transformers for test case
     SDImagePipelineTransformer *pipelineTransformer = [SDImagePipelineTransformer transformerWithTransformers:@[
                                                                                                                 transformer1,
@@ -184,9 +183,7 @@
                                                                                                                 transformer5,
                                                                                                                 transformer6,
                                                                                                                 transformer7,
-#if SD_UIKIT || SD_MAC
-                                                                                                                transformer8,
-#endif
+                                                                                                                transformer8
                                                                                                                 ]];
     NSArray *transformerKeys = @[
                       @"SDImageResizingTransformer({100.000000,100.000000},2)",
@@ -196,9 +193,7 @@
                       @"SDImageCroppingTransformer({0.000000,0.000000,50.000000,50.000000})",
                       @"SDImageTintTransformer(#00000000)",
                       @"SDImageBlurTransformer(5.000000)",
-#if SD_UIKIT || SD_MAC
-                      @"SDImageFilterTransformer(CIColorInvert)",
-#endif
+                      @"SDImageFilterTransformer(CIColorInvert)"
                       ];
     NSString *transformerKey = [transformerKeys componentsJoinedByString:@"-"]; // SDImageTransformerKeySeparator
     expect([pipelineTransformer.transformerKey isEqualToString:transformerKey]).beTruthy();

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -120,6 +120,16 @@
                                }];
     [self waitForExpectationsWithCommonTimeout];
 }
+
+- (void)testUIButtonBackgroundImageCancelCurrentImageLoad {
+    UIButton *button = [[UIButton alloc] init];
+    NSURL *originalImageURL = [NSURL URLWithString:kTestJPEGURL];
+    [button sd_setBackgroundImageWithURL:originalImageURL forState:UIControlStateNormal];
+    [button sd_cancelBackgroundImageLoadForState:UIControlStateNormal];
+    NSString *backgroundImageOperationKey = [self testBackgroundImageOperationKeyForState:UIControlStateNormal];
+    expect([button sd_imageLoadOperationForKey:backgroundImageOperationKey]).beNil();
+}
+
 #endif
 
 #if SD_MAC
@@ -337,6 +347,10 @@
 - (NSString *)testJPEGPath {
     NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
+}
+
+- (NSString *)testBackgroundImageOperationKeyForState:(UIControlState)state {
+    return [NSString stringWithFormat:@"UIButtonBackgroundImageOperation%lu", (unsigned long)state];
 }
 
 @end

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -349,8 +349,10 @@
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
 }
 
+#if SD_UIKIT
 - (NSString *)testBackgroundImageOperationKeyForState:(UIControlState)state {
     return [NSString stringWithFormat:@"UIButtonBackgroundImageOperation%lu", (unsigned long)state];
 }
+#endif
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)


Test cases are actually used in UIKIt && AppKit environment, So it doesn't need  macro judgment!

