### PR TITLE
Fix the example NSLog issue, and replace the unavailable test image dataset

### DIFF
--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
@@ -101,13 +101,6 @@
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "default"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -76,8 +76,9 @@
                     @"http://via.placeholder.com/200x200.jpg",
                     nil];
 
-        for (int i=0; i<100; i++) {
-            [self.objects addObject:[NSString stringWithFormat:@"https://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage%03d.jpg", i]];
+        for (int i=1; i<25; i++) {
+            // From http://r0k.us/graphics/kodak/, 768x512 resolution, 24 bit depth PNG
+            [self.objects addObject:[NSString stringWithFormat:@"http://r0k.us/graphics/kodak/kodak/kodim%02d.png", i]];
         }
     }
     return self;

--- a/Examples/SDWebImage TV Demo/ViewController.m
+++ b/Examples/SDWebImage TV Demo/ViewController.m
@@ -27,7 +27,7 @@
     // Do any additional setup after loading the view, typically from a nib.
     [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
     
-    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"http://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage001.jpg"]];
+    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic"]];
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test2.webp"]];
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"]];
     [self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"]];

--- a/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -62,13 +62,6 @@
             ReferencedContainer = "container:SDWebImage Tests.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -66,7 +66,7 @@
     
     // need a bigger image here, that is why we don't use kTestJPEGURL
     // if the image is too small, it will get downloaded before we can cancel :)
-    NSURL *url = [NSURL URLWithString:@"https://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage001.jpg"];
+    NSURL *url = [NSURL URLWithString:@"https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"];
     [[SDWebImageManager sharedManager] loadImageWithURL:url options:0 progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         XCTFail(@"Should not get here");
     }];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2739 

### Pull Request Description

### For NSLog

The NSLog issue is because of `OS_ACTIVITY_MODE`. From iOS 11+, all the `NSLog` is just pass to [os_log](https://developer.apple.com/documentation/os/os_log). This will hide all the logs from both System framework as well as our Demo app. I guess this changes is from the [stackoverflow](https://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-logs). It works in Xcode 8 + iOS 10, but now, this will disable all `NSLog`, it's not a good idea.

For a framework development, system framework will log errors if we misuse the APIs. I don't think hide the log is a good idea. Instead, we should turn it on (The default option in Xcode), so if we face some strange log, we can find it easily.

### For Demo image dataset

This PR, also fix the Demo image dataset. The previous used images `https://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage`, is no longer maintained. So I choose another open image dataset. Thanks to [Kodak Lossless True Color Image Suite](http://r0k.us/graphics/kodak/). It's a Licence-free image dataset for our Demo usage.