### PR TITLE
Fix the Demo WebP coder import issue when enable modular headers

### DIFF
--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -9,7 +9,7 @@
 #import "MasterViewController.h"
 #import "DetailViewController.h"
 #import <SDWebImage/SDWebImage.h>
-#import <SDWebImageWebPCoder/SDImageWebPCoder.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 @interface MyCustomTableViewCell : UITableViewCell
 

--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -8,7 +8,7 @@
 
 #import "ViewController.h"
 #import <SDWebImage/SDWebImage.h>
-#import <SDWebImageWebPCoder/SDImageWebPCoder.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 @interface ViewController ()
 

--- a/Examples/SDWebImage TV Demo/ViewController.m
+++ b/Examples/SDWebImage TV Demo/ViewController.m
@@ -8,7 +8,7 @@
 
 #import "ViewController.h"
 #import <SDWebImage/SDWebImage.h>
-#import <SDWebImageWebPCoder/SDImageWebPCoder.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 @interface ViewController ()
 

--- a/Examples/SDWebImage Watch Demo Extension/InterfaceController.m
+++ b/Examples/SDWebImage Watch Demo Extension/InterfaceController.m
@@ -8,7 +8,7 @@
 
 #import "InterfaceController.h"
 #import <SDWebImage/SDWebImage.h>
-#import <SDWebImageWebPCoder/SDImageWebPCoder.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 
 @interface InterfaceController()


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Fix CI issue.

This is because of CocoaPods 1.7.1. And the WebPCoder, which use the `#import <SDWebImage/SDWebImage.h>` inside the umbrella headers.

To fix this, one options is to enable `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES`. See [clang warnings](https://clang.llvm.org/docs/DiagnosticsReference.html#wnon-modular-include-in-framework-module)

Another is to fix each of umbrella headers which import the `<SDWebImageWebPCoder/XX.h>` to `<SDWebImageWebPCoder/SDWebImageWebPCoder.h>`. It may need recursive downstream changes. 

This time I choose the second one.

