### PR TITLE
Fix the SDAnimatedImageRep which use the deprecated API and cause compile issue on Xcode 11

### DIFF
--- a/SDWebImage/SDAnimatedImageRep.m
+++ b/SDWebImage/SDAnimatedImageRep.m
@@ -13,9 +13,9 @@
 #import "SDImageGIFCoderInternal.h"
 #import "SDImageAPNGCoderInternal.h"
 
-@interface SDAnimatedImageRep ()
-
-@property (nonatomic, assign, readonly, nullable) CGImageSourceRef imageSource;
+@interface SDAnimatedImageRep () {
+    CGImageSourceRef _imageSource;
+}
 
 @end
 
@@ -31,7 +31,7 @@
 - (instancetype)initWithData:(NSData *)data {
     self = [super initWithData:data];
     if (self) {
-        CGImageSourceRef imageSource = self.imageSource;
+        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef) data, NULL);
         if (!imageSource) {
             return self;
         }
@@ -43,6 +43,8 @@
         if (!type) {
             return self;
         }
+        // Valid CGImageSource for Animated Image
+        _imageSource = imageSource;
         if (CFStringCompare(type, kUTTypeGIF, 0) == kCFCompareEqualTo) {
             // GIF
             // Do nothing because NSBitmapImageRep support it
@@ -63,7 +65,7 @@
     [super setProperty:property withValue:value];
     if ([property isEqualToString:NSImageCurrentFrame]) {
         // Access the image source
-        CGImageSourceRef imageSource = self.imageSource;
+        CGImageSourceRef imageSource = _imageSource;
         if (!imageSource) {
             return;
         }
@@ -87,16 +89,6 @@
         // Reset super frame duration with the actual frame duration
         [super setProperty:NSImageCurrentFrameDuration withValue:@(frameDuration)];
     }
-}
-
-- (CGImageSourceRef)imageSource {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    if (_tiffData) {
-        return (__bridge CGImageSourceRef)(_tiffData);
-    }
-#pragma GCC diagnostic pop
-    return NULL;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: 

### Pull Request Description

Now, we use the self-created CGImageSource instance instead of super class implementation detail. This is more suitable instead of using this ivar marked as Private.

Though this change may reduce performance a little, but since object always processed under global queue, so this does not trigger issue.


![image](https://user-images.githubusercontent.com/6919743/58937126-18aeb580-87a4-11e9-9f47-358d7cc0c266.png)
