### PR TITLE
Fix the potential leak for SDAnimatedImageRep image source

### DIFF
--- a/SDWebImage/SDAnimatedImageRep.m
+++ b/SDWebImage/SDAnimatedImageRep.m
@@ -13,13 +13,16 @@
 #import "SDImageGIFCoderInternal.h"
 #import "SDImageAPNGCoderInternal.h"
 
-@interface SDAnimatedImageRep () {
+@implementation SDAnimatedImageRep {
     CGImageSourceRef _imageSource;
 }
 
-@end
-
-@implementation SDAnimatedImageRep
+- (void)dealloc {
+    if (_imageSource) {
+        CFRelease(_imageSource);
+        _imageSource = NULL;
+    }
+}
 
 // `NSBitmapImageRep`'s `imageRepWithData:` is not designed initlizer
 + (instancetype)imageRepWithData:(NSData *)data {
@@ -35,6 +38,7 @@
         if (!imageSource) {
             return self;
         }
+        _imageSource = imageSource;
         NSUInteger frameCount = CGImageSourceGetCount(imageSource);
         if (frameCount <= 1) {
             return self;
@@ -43,8 +47,6 @@
         if (!type) {
             return self;
         }
-        // Valid CGImageSource for Animated Image
-        _imageSource = imageSource;
         if (CFStringCompare(type, kUTTypeGIF, 0) == kCFCompareEqualTo) {
             // GIF
             // Do nothing because NSBitmapImageRep support it


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2745 

### Pull Request Description

This self created `CGImageSourceRef` should be released when instance is dealloced.
Also a little code style format.

