### PR TITLE
Feature supports dynamic style indicator for iOS 13, fix indicator color on macOS 10.14+

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -35,6 +35,7 @@
     self.imageView1.sd_imageIndicator = SDWebImageProgressIndicator.defaultIndicator;
     [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"] placeholderImage:nil options:SDWebImageProgressiveLoad];
     // NSImageView + Animated Image
+    self.imageView2.sd_imageIndicator = SDWebImageActivityIndicator.largeIndicator;
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"https:raw.githubusercontent.com/onevcat/APNGKit/master/TestImages/APNG-cube.apng"]];
     // SDAnimatedImageView + Static Image
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png"]];

--- a/SDWebImage/SDWebImageIndicator.h
+++ b/SDWebImage/SDWebImageIndicator.h
@@ -66,6 +66,7 @@
  */
 @interface SDWebImageActivityIndicator (Conveniences)
 
+/// These indicator use the fixed color without dark mode support
 /// gray-style activity indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *grayIndicator;
 /// large gray-style activity indicator
@@ -74,9 +75,10 @@
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *whiteIndicator;
 /// large white-style activity indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *whiteLargeIndicator;
-/// large activity indicator, supports dark mode if available
+/// These indicator use the system style, supports dark mode if available (iOS 13+/macOS 10.14+)
+/// large activity indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *largeIndicator;
-/// medium activity indicator, supports dark mode if available
+/// medium activity indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *mediumIndicator;
 
 @end

--- a/SDWebImage/SDWebImageIndicator.h
+++ b/SDWebImage/SDWebImageIndicator.h
@@ -74,6 +74,10 @@
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *whiteIndicator;
 /// large white-style activity indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *whiteLargeIndicator;
+/// large activity indicator, supports dark mode if available
+@property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *largeIndicator;
+/// medium activity indicator, supports dark mode if available
+@property (nonatomic, class, nonnull, readonly) SDWebImageActivityIndicator *mediumIndicator;
 
 @end
 

--- a/SDWebImage/SDWebImageIndicator.m
+++ b/SDWebImage/SDWebImageIndicator.m
@@ -14,6 +14,16 @@
 #import <QuartzCore/QuartzCore.h>
 #endif
 
+#if SD_UIKIT
+#if __IPHONE_13_0 || __TVOS_13_0 || __MAC_10_15
+// Xcode 11
+#else
+// Supports Xcode 9 && 10 users, for those users, define these enum
+static NSInteger UIActivityIndicatorViewStyleMedium = 100;
+static NSInteger UIActivityIndicatorViewStyleLarge = 101;
+#endif
+#endif
+
 #pragma mark - Activity Indicator
 
 @interface SDWebImageActivityIndicator ()

--- a/SDWebImage/SDWebImageIndicator.m
+++ b/SDWebImage/SDWebImageIndicator.m
@@ -124,6 +124,36 @@
     return indicator;
 }
 
++ (SDWebImageActivityIndicator *)largeIndicator {
+    SDWebImageActivityIndicator *indicator = [SDWebImageActivityIndicator new];
+#if SD_UIKIT
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
+        indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleLarge;
+    } else {
+        indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhiteLarge;
+    }
+#else
+    indicator.indicatorView.controlSize = NSControlSizeRegular;
+    [indicator.indicatorView sizeToFit];
+#endif
+    return indicator;
+}
+
++ (SDWebImageActivityIndicator *)mediumIndicator {
+    SDWebImageActivityIndicator *indicator = [SDWebImageActivityIndicator new];
+#if SD_UIKIT
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
+        indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
+    } else {
+        indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
+    }
+#else
+    indicator.indicatorView.controlSize = NSControlSizeSmall;
+    [indicator.indicatorView sizeToFit];
+#endif
+    return indicator;
+}
+
 @end
 
 #pragma mark - Progress Indicator

--- a/SDWebImage/SDWebImageIndicator.m
+++ b/SDWebImage/SDWebImageIndicator.m
@@ -93,6 +93,8 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 #else
     indicator.indicatorView.color = [UIColor colorWithWhite:0 alpha:0.45]; // Color from `UIActivityIndicatorViewStyleGray`
 #endif
+#else
+    indicator.indicatorView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua]; // Disable dark mode support
 #endif
     return indicator;
 }
@@ -104,6 +106,7 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
     indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhiteLarge;
     indicator.indicatorView.color = grayColor;
 #else
+    indicator.indicatorView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua]; // Disable dark mode support
     indicator.indicatorView.controlSize = NSControlSizeRegular;
 #endif
     [indicator.indicatorView sizeToFit];
@@ -115,6 +118,7 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 #if SD_UIKIT
     indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
 #else
+    indicator.indicatorView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua]; // Disable dark mode support
     CIFilter *lighten = [CIFilter filterWithName:@"CIColorControls"];
     [lighten setDefaults];
     [lighten setValue:@(1) forKey:kCIInputBrightnessKey];
@@ -128,6 +132,7 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 #if SD_UIKIT
     indicator.indicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhiteLarge;
 #else
+    indicator.indicatorView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua]; // Disable dark mode support
     indicator.indicatorView.controlSize = NSControlSizeRegular;
     [indicator.indicatorView sizeToFit];
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: 

### Pull Request Description

iOS 13 and macOS 10.14 come with the dark mode supports. See WWDC session: [Implementing Dark Mode on iOS](https://developer.apple.com/videos/play/wwdc2019/214/)

Here in the session, the old [UIActivityIndicatorViewStyleWhite/WhiteLarge/Gray](https://developer.apple.com/documentation/uikit/uiactivityindicatorviewstyle?language=objc) has been deprecated. And does not change its color based on system appearance mode.

So, we can introduce the new API by following UIKit's new API. The `large` property translate to `UIActivityIndicatorViewStyleLarge`, the `medium` class property translate to `UIActivityIndicatorViewStyleMedium`.

For macOS, these property translate to `NSControlSize` with `regular` and `small`.

To supports this iOS 13 SDK symbol can build on Xcode 9 && Xcode 10, we also define them manually on Xcode 9 && Xcode 10 environment.