### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ DerivedData
 #
 Pods/
 Podfile.lock
+
+# SwiftPM
+.build

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ script:
     - echo Check if the library described by the podspec can be built
     - pod lib lint --allow-warnings --skip-tests # Will run test below
 
+    - echo Build the SwiftPM
+    - swift build
+    - rm -rf ~/.build
+
     - echo Build as static library
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage static' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage static' -sdk watchsimulator -configuration Debug | xcpretty -c

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SDWebImage",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "SDWebImage",
+            targets: ["SDWebImage"]),
+        .library(
+            name: "SDWebImageMapKit",
+            targets: ["SDWebImageMapKit"])
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "SDWebImage",
+            dependencies: [],
+            path: "SDWebImage",
+            exclude: ["Private", "MapKit"],
+            cSettings: [
+                .headerSearchPath("."),
+                .headerSearchPath("Private")
+            ]
+        ),
+        .target(
+            name: "SDWebImageMapKit",
+            dependencies: ["SDWebImage"],
+            path: "SDWebImage",
+            sources: ["MapKit/MKAnnotationView+WebCache.h", "MapKit/MKAnnotationView+WebCache.m"],
+            publicHeadersPath: "MapKit",
+            cSettings: [
+                .headerSearchPath("."),
+                .headerSearchPath("Private")
+            ]
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
             name: "SDWebImageMapKit",
             dependencies: ["SDWebImage"],
             path: "SDWebImage",
-            sources: ["MapKit/MKAnnotationView+WebCache.h", "MapKit/MKAnnotationView+WebCache.m"],
+            sources: ["MapKit"],
             publicHeadersPath: "MapKit",
             cSettings: [
                 .headerSearchPath("."),


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/) // Will Add some wiki in [Installation-Guide](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide) part, if this been merged.
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2751

### Pull Request Description

Xcode 11 introduce the support for Swift Package Manager (SwiftPM). Today I check the SwiftPM's documentation, it supports for not only Swift files, but also the C/C++ files.

So, since SDWebImage is written in Objective-C, it should be supported. And I did this. The `Package.swift` is like the `Podfile`, a rule to define the compile and target. See the full documentation for [Package.swift syntax](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md)

See the screenshot for usage under Xcode 11 Beta, and using [Accio](https://github.com/JamitLabs/Accio) to integrate with iOS project target.

#### Swift Build (Generate Some Obj files and .a .dylib)
![image](https://user-images.githubusercontent.com/6919743/59502926-b192ae80-8ed1-11e9-8786-e91a669e78fb.png)

#### Accio Install
![image](https://user-images.githubusercontent.com/6919743/59502954-c111f780-8ed1-11e9-8949-1070d092c78d.png)

#### SwiftPM Dependency
![image](https://user-images.githubusercontent.com/6919743/59503016-e7d02e00-8ed1-11e9-82c9-85134c87923e.png)


#### Build
![image](https://user-images.githubusercontent.com/6919743/59503021-eacb1e80-8ed1-11e9-81c5-b621811c5ae3.png)

