### PR TITLE
Fix the Clang Static Analysis warning of `addEntriesFromDictionary:` API

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -416,7 +416,9 @@ static id<SDImageLoader> _defaultImageLoader;
     }
     
     if (mutableContext.count > 0) {
-        [mutableContext addEntriesFromDictionary:context];
+        if (context) {
+            [mutableContext addEntriesFromDictionary:context];
+        }
         context = [mutableContext copy];
     }
     


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x]  I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2759 

### Pull Request Description

The Xcode 11 version Clang Static Analyzer report this warning because of `nullable pass to nonnull`. However, this `-[NSMutableDictionary addEntriesFromDictionary:]` is safe to call with nil. So this just fix for warning. The old version can still keep since this does not cause any runtime crash issue.
