### PR TITLE
Change that the `sd_imageProgress` property to not auto-create instance by framework

### DIFF
--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -35,7 +35,7 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
  * The current image loading progress associated to the view. The unit count is the received size and excepted size of download.
  * The `totalUnitCount` and `completedUnitCount` will be reset to 0 after a new image loading start (change from current queue). And they will be set to `SDWebImageProgressUnitCountUnknown` if the progressBlock not been called but the image loading success to mark the progress finished (change from main queue).
  * @note You can use Key-Value Observing on the progress, but you should take care that the change to progress is from a background queue during download(the same as progressBlock). If you want to using KVO and update the UI, make sure to dispatch on the main queue. And it's recommand to use some KVO libs like KVOController because it's more safe and easy to use.
- * @note The getter will create a progress instance if the value is nil. You can also set a custom progress instance and let it been updated during image loading
+ * @note The getter will create a progress instance if the value is nil. But by default, we don't create one. If you need to use Key-Value Observing, you must trigger the getter or set a custom progresss instance before the loading start. The default value is nil.
  * @note Note that because of the limitations of categories this property can get out of sync if you update the progress directly.
  */
 @property (nonatomic, strong, null_resettable) NSProgress *sd_imageProgress;

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -70,8 +70,10 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
     if (url) {
         // reset the progress
         NSProgress *imageProgress = objc_getAssociatedObject(self, @selector(sd_imageProgress));
-        imageProgress.totalUnitCount = 0;
-        imageProgress.completedUnitCount = 0;
+        if (imageProgress) {
+            imageProgress.totalUnitCount = 0;
+            imageProgress.completedUnitCount = 0;
+        }
         
 #if SD_UIKIT || SD_MAC
         // check and start image indicator
@@ -85,8 +87,10 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
         }
         
         SDImageLoaderProgressBlock combinedProgressBlock = ^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
-            imageProgress.totalUnitCount = expectedSize;
-            imageProgress.completedUnitCount = receivedSize;
+            if (imageProgress) {
+                imageProgress.totalUnitCount = expectedSize;
+                imageProgress.completedUnitCount = receivedSize;
+            }
 #if SD_UIKIT || SD_MAC
             if ([imageIndicator respondsToSelector:@selector(updateIndicatorProgress:)]) {
                 double progress = 0;
@@ -108,7 +112,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             @strongify(self);
             if (!self) { return; }
             // if the progress not been updated, mark it to complete state
-            if (finished && !error && imageProgress.totalUnitCount == 0 && imageProgress.completedUnitCount == 0) {
+            if (imageProgress && finished && !error && imageProgress.totalUnitCount == 0 && imageProgress.completedUnitCount == 0) {
                 imageProgress.totalUnitCount = SDWebImageProgressUnitCountUnknown;
                 imageProgress.completedUnitCount = SDWebImageProgressUnitCountUnknown;
             }

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -69,8 +69,9 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
     
     if (url) {
         // reset the progress
-        self.sd_imageProgress.totalUnitCount = 0;
-        self.sd_imageProgress.completedUnitCount = 0;
+        NSProgress *imageProgress = objc_getAssociatedObject(self, @selector(sd_imageProgress));
+        imageProgress.totalUnitCount = 0;
+        imageProgress.completedUnitCount = 0;
         
 #if SD_UIKIT || SD_MAC
         // check and start image indicator
@@ -83,15 +84,16 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             manager = [SDWebImageManager sharedManager];
         }
         
-        @weakify(self);
         SDImageLoaderProgressBlock combinedProgressBlock = ^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
-            @strongify(self);
-            NSProgress *imageProgress = self.sd_imageProgress;
             imageProgress.totalUnitCount = expectedSize;
             imageProgress.completedUnitCount = receivedSize;
 #if SD_UIKIT || SD_MAC
             if ([imageIndicator respondsToSelector:@selector(updateIndicatorProgress:)]) {
-                double progress = imageProgress.fractionCompleted;
+                double progress = 0;
+                if (expectedSize != 0) {
+                    progress = (double)receivedSize / expectedSize;
+                }
+                progress = MAX(MIN(progress, 1), 0); // 0.0 - 1.0
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [imageIndicator updateIndicatorProgress:progress];
                 });
@@ -101,13 +103,14 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                 progressBlock(receivedSize, expectedSize, targetURL);
             }
         };
+        @weakify(self);
         id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options context:context progress:combinedProgressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             @strongify(self);
             if (!self) { return; }
             // if the progress not been updated, mark it to complete state
-            if (finished && !error && self.sd_imageProgress.totalUnitCount == 0 && self.sd_imageProgress.completedUnitCount == 0) {
-                self.sd_imageProgress.totalUnitCount = SDWebImageProgressUnitCountUnknown;
-                self.sd_imageProgress.completedUnitCount = SDWebImageProgressUnitCountUnknown;
+            if (finished && !error && imageProgress.totalUnitCount == 0 && imageProgress.completedUnitCount == 0) {
+                imageProgress.totalUnitCount = SDWebImageProgressUnitCountUnknown;
+                imageProgress.completedUnitCount = SDWebImageProgressUnitCountUnknown;
             }
             
 #if SD_UIKIT || SD_MAC


### PR DESCRIPTION
Instead, let users to use KVO and trigger the creation, improve the performance and fix potential issue for most of common usage.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2755 

### Pull Request Description

The [Image Progress](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#image-progress-430) feature was introduced in v4.3, which is aim for advanced user to use a single `NSProgress` object to observe the loading progress, instead of the default progressBlock. Because `NSProgress` supports many method such as hierarchy.

However, since most of users does not use this API, and our current implementation, always create the `NSProgress` instance for any View Category loading, which may impact the performance a little.

I think we can just disable the auto-create logic. If users need KVO, they can still use this without any code changes. (because they will trigger the `sd_imageProgress` getter method and create one). Only the potential usage who read the `fractionCompleted` without KVO may get effected (really rare use case)

This can also help for some rare issue such as #2755. If people use KVO, they're responsible for this potential issue.
