### PR TITLE
Provide a script target to directly build all SDWebImage framework and generate all in one XCFramework from Xcode 11

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -6,6 +6,21 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		326CA50C22BA14EF0033A92F /* SDWebImage XCFramework */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 326CA50F22BA14EF0033A92F /* Build configuration list for PBXAggregateTarget "SDWebImage XCFramework" */;
+			buildPhases = (
+				326CA51322BA1A270033A92F /* Build Frameworks */,
+				326CA51422BA25F70033A92F /* Create XCFramework */,
+			);
+			dependencies = (
+			);
+			name = "SDWebImage XCFramework";
+			productName = "SDWebImage XCFramework";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		320CAE172086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320CAE1B2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
@@ -906,6 +921,10 @@
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Dailymotion;
 				TargetAttributes = {
+					326CA50C22BA14EF0033A92F = {
+						CreatedOnToolsVersion = 11.0;
+						ProvisioningStyle = Automatic;
+					};
 					4A2CADFE1AB4BB5300B6BC39 = {
 						CreatedOnToolsVersion = 6.3;
 					};
@@ -927,6 +946,7 @@
 				53761307155AD0D5005750A4 /* SDWebImage static */,
 				4A2CADFE1AB4BB5300B6BC39 /* SDWebImage */,
 				80B6DF862142B71600BCB334 /* SDWebImageMapKit */,
+				326CA50C22BA14EF0033A92F /* SDWebImage XCFramework */,
 			);
 		};
 /* End PBXProject section */
@@ -947,6 +967,60 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		326CA51322BA1A270033A92F /* Build Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/build/iphoneos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/iphonesimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/macosx/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/appletvos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/appletvsimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/watchos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/watchsimulator/SDWebImage.xcarchive",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "mkdir -p $(SRCROOT)/build\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nxcodebuild archive -sdk \"${CURRENT_PLATFORM}\" -scheme SDWebImage -archivePath \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive\" SKIP_INSTALL=NO\ndone\n";
+		};
+		326CA51422BA25F70033A92F /* Create XCFramework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/build/iphoneos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/iphonesimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/macosx/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/appletvos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/appletvsimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/watchos/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/watchsimulator/SDWebImage.xcarchive",
+			);
+			name = "Create XCFramework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/build/SDWebImage.xcframework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "declare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCOMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/Products/Library/Frameworks/SDWebImage.framework\"\ndone\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4A2CADFA1AB4BB5300B6BC39 /* Sources */ = {
@@ -1094,6 +1168,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		326CA50D22BA14EF0033A92F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		326CA50E22BA14EF0033A92F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		4A2CAE131AB4BB5400B6BC39 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1163,6 +1253,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		326CA50F22BA14EF0033A92F /* Build configuration list for PBXAggregateTarget "SDWebImage XCFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				326CA50D22BA14EF0033A92F /* Debug */,
+				326CA50E22BA14EF0033A92F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4A2CAE121AB4BB5400B6BC39 /* Build configuration list for PBXNativeTarget "SDWebImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -982,17 +982,17 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/build/iphoneos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/iphonesimulator/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/macosx/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/appletvos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/appletvsimulator/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/watchos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/watchsimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/iphoneos/SDWebImage.framework",
+				"$(SRCROOT)/build/iphonesimulator/SDWebImage.framework",
+				"$(SRCROOT)/build/macosx/SDWebImage.framework",
+				"$(SRCROOT)/build/appletvos/SDWebImage.framework",
+				"$(SRCROOT)/build/appletvsimulator/SDWebImage.framework",
+				"$(SRCROOT)/build/watchos/SDWebImage.framework",
+				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p $(SRCROOT)/build\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nxcodebuild archive -sdk \"${CURRENT_PLATFORM}\" -scheme SDWebImage -archivePath \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive\" SKIP_INSTALL=NO\ndone\n";
+			shellScript = "mkdir -p $(SRCROOT)/build\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCONFIGURATION=\"Release\"\nif [[ $CURRENT_PLATFORM == *\"simulator\" ]]; then\nCONFIGURATION=\"Debug\"\nfi\nxcodebuild -sdk \"${CURRENT_PLATFORM}\" -scheme SDWebImage -configuration $CONFIGURATION CONFIGURATION_BUILD_DIR=\"${SRCROOT}/build/${CURRENT_PLATFORM}/\" SKIP_INSTALL=NO\ndone\n";
 		};
 		326CA51422BA25F70033A92F /* Create XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1002,13 +1002,13 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/build/iphoneos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/iphonesimulator/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/macosx/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/appletvos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/appletvsimulator/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/watchos/SDWebImage.xcarchive",
-				"$(SRCROOT)/build/watchsimulator/SDWebImage.xcarchive",
+				"$(SRCROOT)/build/iphoneos/SDWebImage.framework",
+				"$(SRCROOT)/build/iphonesimulator/SDWebImage.framework",
+				"$(SRCROOT)/build/macosx/SDWebImage.framework",
+				"$(SRCROOT)/build/appletvos/SDWebImage.framework",
+				"$(SRCROOT)/build/appletvsimulator/SDWebImage.framework",
+				"$(SRCROOT)/build/watchos/SDWebImage.framework",
+				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
 			);
 			name = "Create XCFramework";
 			outputFileListPaths = (
@@ -1018,7 +1018,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "declare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCOMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/Products/Library/Frameworks/SDWebImage.framework\"\ndone\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
+			shellScript = "XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')\nXCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')\nif [ $XCODE_VERSION_MAJOR -lt 11 ]\nthen\necho \"Xcode 10 does not support xcframework. You can still use the individual framework for each platform.\"\nexit 0\nfi\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCOMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.framework\"\ndone\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -1018,7 +1018,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')\nXCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')\nif [ $XCODE_VERSION_MAJOR -lt 11 ]\nthen\necho \"Xcode 10 does not support xcframework. You can still use the individual framework for each platform.\"\nexit 0\nfi\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCOMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.framework\"\ndone\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
+			shellScript = "XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')\nXCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')\nif [ $XCODE_VERSION_MAJOR -lt 11 ]\nthen\necho \"Xcode 10 does not support xcframework. You can still use the individual framework for each platform.\"\nopen -a Finder \"${SRCROOT}/build/\"\nexit 0\nfi\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\nCOMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.framework\"\ndone\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage XCFramework.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage XCFramework.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
-   version = "1.3">
+   LastUpgradeVersion = "1100"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4A2CADFE1AB4BB5300B6BC39"
-               BuildableName = "SDWebImage.framework"
-               BlueprintName = "SDWebImage"
+               BlueprintIdentifier = "326CA50C22BA14EF0033A92F"
+               BuildableName = "SDWebImage XCFramework"
+               BlueprintName = "SDWebImage XCFramework"
                ReferencedContainer = "container:SDWebImage.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -27,8 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      <TestPlans>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -40,15 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4A2CADFE1AB4BB5300B6BC39"
-            BuildableName = "SDWebImage.framework"
-            BlueprintName = "SDWebImage"
-            ReferencedContainer = "container:SDWebImage.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -59,9 +50,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4A2CADFE1AB4BB5300B6BC39"
-            BuildableName = "SDWebImage.framework"
-            BlueprintName = "SDWebImage"
+            BlueprintIdentifier = "326CA50C22BA14EF0033A92F"
+            BuildableName = "SDWebImage XCFramework"
+            BlueprintName = "SDWebImage XCFramework"
             ReferencedContainer = "container:SDWebImage.xcodeproj">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2762 

### Pull Request Description

See WWDC Session: https://developer.apple.com/videos/play/wwdc2019/416/
Xcode Release Notes: [New Features - XCFramework](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_beta_2_release_notes#3318304)

Xcode 11 supports a new frameworks format, `xcframework`. Which is like a bundle for all platforms and architecture. This can help for integration user, to just use one file. This can solve the tied steps tocollect 7 different frameworks, zip and unzip them for users, provide a notes to let users distinguish which framework is for which platform && CPU architecture, etc.

I think it's a good way for users to use framework. So we can provide a build script to help create one.

This script is available on `SDWebImage XCFramework` target, just select this target, click `Run` or Command + R. Then drink a cup of tea. If finished, your Finder will open and select the final `xcframework` file.

You can also find individual Xcode Archive framework inside the same directory. Use those single `framework` as you want as well.

#### Click to build all in on framework

![image](https://user-images.githubusercontent.com/6919743/59751071-779b2100-92b2-11e9-80ae-aff1a5c497e8.png)


#### The built XCFramework and all 7 platform Archive

![image](https://user-images.githubusercontent.com/6919743/59750588-9e0c8c80-92b1-11e9-914d-e3fcfc8fad68.png)

#### Using in Xcode 11, drag and drop, don't need to distinguish which framework is for which

![image](https://user-images.githubusercontent.com/6919743/59750941-3571df80-92b2-11e9-8fa9-264b0a9d4cc1.png)

Note: When the #2743 is supported. This build script need to be updated to include the UIKit for Mac framework as well. At that time we'll have 8 indivisual `framework`, I think this feature it's good :)

