### PR TITLE
Change the default value of accept request header

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -119,7 +119,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
             }
             headerDictionary[@"User-Agent"] = userAgent;
         }
-        headerDictionary[@"Accept"] = @"image/*;q=0.8";
+        headerDictionary[@"Accept"] = @"image/*,*/*;q=0.8";
         _HTTPHeaders = headerDictionary;
         _HTTPHeadersLock = dispatch_semaphore_create(1);
         _operationsLock = dispatch_semaphore_create(1);

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -37,7 +37,7 @@
 }
 
 - (void)test02ThatByDefaultDownloaderSetsTheAcceptHTTPHeader {
-    expect([[SDWebImageDownloader sharedDownloader] valueForHTTPHeaderField:@"Accept"]).to.match(@"image/\\*");
+    expect([[SDWebImageDownloader sharedDownloader] valueForHTTPHeaderField:@"Accept"]).to.match(@"image/\\*,\\*/\\*;q=0.8");
 }
 
 - (void)test03ThatSetAndGetValueForHTTPHeaderFieldWork {


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

If requested by the header `Accept: image/*` (current default value), some servers may not be able to respond normally. (HTTP Code : 406)

So, I think it's better to change the default value.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values#Values_for_an_image

As you can see above, the default value for Safari is `*/*`.

Please review it positively.
