### PR TITLE
support custom button upon UIControl.

### DIFF
--- a/SDWebImage/UIButton+WebCache.h
+++ b/SDWebImage/UIButton+WebCache.h
@@ -12,10 +12,18 @@
 
 #import "SDWebImageManager.h"
 
+@protocol SDButtonInterface <NSObject>
+
+@optional
+- (void)setImage:(UIImage *_Nullable)image forState:(UIControlState)state;
+- (void)setBackgroundImage:(UIImage *_Nullable)image forState:(UIControlState)state;
+
+@end
+
 /**
  * Integrates SDWebImage async downloading and caching of remote images with UIButton.
  */
-@interface UIButton (WebCache)
+@interface UIControl (WebCache) <SDButtonInterface>
 
 #pragma mark - Image
 

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -35,7 +35,7 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
     return [NSString stringWithFormat:@"UIButtonBackgroundImageOperation%lu", (unsigned long)state];
 }
 
-@implementation UIButton (WebCache)
+@implementation UIControl (WebCache)
 
 #pragma mark - Image
 
@@ -112,7 +112,9 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
                              context:mutableContext
                        setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            @strongify(self);
-                           [self setImage:image forState:state];
+                           if ([self respondsToSelector:@selector(setImage:forState:)]) {
+                               [self setImage:image forState:state];
+                           }
                        }
                             progress:progressBlock
                            completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
@@ -197,7 +199,9 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
                              context:mutableContext
                        setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            @strongify(self);
-                           [self setBackgroundImage:image forState:state];
+                           if ([self respondsToSelector:@selector(setBackgroundImage:forState:)]) {
+                               [self setBackgroundImage:image forState:state];
+                           }
                        }
                             progress:progressBlock
                            completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

I have a custom button upon UIControl, named [SFButton](https://github.com/cntrump/sfbutton), It use like UIButton but not a UIButton class.

If SDWebImage can support UIControl with UIButton's setXXImage interfaces, I think it is useful 😁

