### PR TITLE
Expose the memoryCache and diskCache object on `SDImageCache`, Make it useful for user who have custom property beyond `SDImageCacheConfig`

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -11,6 +11,8 @@
 #import "SDWebImageDefine.h"
 #import "SDImageCacheConfig.h"
 #import "SDImageCacheDefine.h"
+#import "SDMemoryCache.h"
+#import "SDDiskCache.h"
 
 /// Image Cache Options
 typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
@@ -60,6 +62,21 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  *  The property is copy so change of currrent config will not accidentally affect other cache's config.
  */
 @property (nonatomic, copy, nonnull, readonly) SDImageCacheConfig *config;
+
+/**
+ * The memory cache implementation object used for current image cache.
+ * By default we use `SDMemoryCache` class, you can also use this to call your own implementation class method.
+ * @note To customize this class, check `SDImageCacheConfig.memoryCacheClass` property.
+ */
+@property (nonatomic, strong, readonly, nonnull) id<SDMemoryCache> memoryCache;
+
+/**
+ * The disk cache implementation object used for current image cache.
+ * By default we use `SDMemoryCache` class, you can also use this to call your own implementation class method.
+ * @note To customize this class, check `SDImageCacheConfig.diskCacheClass` property.
+ * @warning When calling method about read/write in disk cache, be sure to either make your disk cache implementation IO-safe or using the same access queue to avoid issues.
+ */
+@property (nonatomic, strong, readonly, nonnull) id<SDDiskCache> diskCache;
 
 /**
  *  The disk cache's root path

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -7,8 +7,6 @@
  */
 
 #import "SDImageCache.h"
-#import "SDMemoryCache.h"
-#import "SDDiskCache.h"
 #import "NSImage+Compatibility.h"
 #import "SDImageCodersManager.h"
 #import "SDImageTransformer.h"
@@ -20,8 +18,8 @@
 @interface SDImageCache ()
 
 #pragma mark - Properties
-@property (nonatomic, strong, nonnull) id<SDMemoryCache> memCache;
-@property (nonatomic, strong, nonnull) id<SDDiskCache> diskCache;
+@property (nonatomic, strong, readwrite, nonnull) id<SDMemoryCache> memoryCache;
+@property (nonatomic, strong, readwrite, nonnull) id<SDDiskCache> diskCache;
 @property (nonatomic, copy, readwrite, nonnull) SDImageCacheConfig *config;
 @property (nonatomic, copy, readwrite, nonnull) NSString *diskCachePath;
 @property (nonatomic, strong, nullable) dispatch_queue_t ioQueue;
@@ -71,7 +69,7 @@
         
         // Init the memory cache
         NSAssert([config.memoryCacheClass conformsToProtocol:@protocol(SDMemoryCache)], @"Custom memory cache class must conform to `SDMemoryCache` protocol");
-        _memCache = [[config.memoryCacheClass alloc] initWithConfig:_config];
+        _memoryCache = [[config.memoryCacheClass alloc] initWithConfig:_config];
         
         // Init the disk cache
         if (directory != nil) {
@@ -181,7 +179,7 @@
     // if memory cache is enabled
     if (toMemory && self.config.shouldCacheImagesInMemory) {
         NSUInteger cost = image.sd_memoryCost;
-        [self.memCache setObject:image forKey:key cost:cost];
+        [self.memoryCache setObject:image forKey:key cost:cost];
     }
     
     if (toDisk) {
@@ -219,7 +217,7 @@
         return;
     }
     NSUInteger cost = image.sd_memoryCost;
-    [self.memCache setObject:image forKey:key cost:cost];
+    [self.memoryCache setObject:image forKey:key cost:cost];
 }
 
 - (void)storeImageDataToDisk:(nullable NSData *)imageData
@@ -290,14 +288,14 @@
 }
 
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key {
-    return [self.memCache objectForKey:key];
+    return [self.memoryCache objectForKey:key];
 }
 
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key {
     UIImage *diskImage = [self diskImageForKey:key];
     if (diskImage && self.config.shouldCacheImagesInMemory) {
         NSUInteger cost = diskImage.sd_memoryCost;
-        [self.memCache setObject:diskImage forKey:key cost:cost];
+        [self.memoryCache setObject:diskImage forKey:key cost:cost];
     }
 
     return diskImage;
@@ -423,7 +421,7 @@
                 diskImage = [self diskImageForKey:key data:diskData options:options context:context];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
                     NSUInteger cost = diskImage.sd_memoryCost;
-                    [self.memCache setObject:diskImage forKey:key cost:cost];
+                    [self.memoryCache setObject:diskImage forKey:key cost:cost];
                 }
             }
             
@@ -465,7 +463,7 @@
     }
 
     if (fromMemory && self.config.shouldCacheImagesInMemory) {
-        [self.memCache removeObjectForKey:key];
+        [self.memoryCache removeObjectForKey:key];
     }
 
     if (fromDisk) {
@@ -488,7 +486,7 @@
         return;
     }
     
-    [self.memCache removeObjectForKey:key];
+    [self.memoryCache removeObjectForKey:key];
 }
 
 - (void)removeImageFromDiskForKey:(NSString *)key {
@@ -512,7 +510,7 @@
 #pragma mark - Cache clean Ops
 
 - (void)clearMemory {
-    [self.memCache removeAllObjects];
+    [self.memoryCache removeAllObjects];
 }
 
 - (void)clearDiskOnCompletion:(nullable SDWebImageNoParamsBlock)completion {

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -14,13 +14,6 @@
 static NSString *kTestImageKeyJPEG = @"TestImageKey.jpg";
 static NSString *kTestImageKeyPNG = @"TestImageKey.png";
 
-@interface SDImageCache ()
-
-@property (nonatomic, strong, nonnull) id<SDMemoryCache> memCache;
-@property (nonatomic, strong, nonnull) id<SDDiskCache> diskCache;
-
-@end
-
 @interface SDImageCacheTests : SDTestCase <NSFileManagerDelegate>
 
 @end
@@ -380,7 +373,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     config.memoryCacheClass = [SDWebImageTestMemoryCache class];
     NSString *nameSpace = @"SDWebImageTestMemoryCache";
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:nameSpace diskCacheDirectory:nil config:config];
-    SDWebImageTestMemoryCache *memCache = cache.memCache;
+    SDWebImageTestMemoryCache *memCache = cache.memoryCache;
     expect([memCache isKindOfClass:[SDWebImageTestMemoryCache class]]).to.beTruthy();
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2766 

### Pull Request Description

#### Propose
From 5.0, our SDImageCache have refactory to support customization. It has two level of customization

+ [Custom Image Cache](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#cache-protocol)
+ [Custom Memory/Disk Cache class](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#memory-cache)

However, there are some feedback about the second case, the `SDMemoryCache` protocol is OK, but if they have their own class, and have method or property beyond `SDMemoryCache`, they'll be sucked here. Because we have no public API to get the instance of memory cache class.

And our LRU Cache implementation #2766 will provide some custom properties (not existing on `SDImageCacheConfig`, it's tied to LRU Cache itself). So currently there are no good way to let user touch those properties.

#### Solution
By searching other image cache implementation, including

+ [Kingfisher](https://github.com/onevcat/Kingfisher/blob/master/Sources/Cache/ImageCache.swift)
+ [YYCache](https://github.com/ibireme/YYCache/blob/master/YYCache/YYCache.h)
+ [PINCache](https://github.com/pinterest/PINCache/blob/master/Source/PINCache.h)

They all provide both `memoryCache` and `diskCache` public API, allows you to grab and use that instance for detail method call.

I think we can follow the same design, by exposing the API for the memory cache and disk cache, and user who have custom memory cache implementation can convert to their own class to use API outside `SDMemoryProtocol`