### PR TITLE
Follow App Store submit rule, upgrade the minimum Xcode version to Xcode 10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@
  Platform Version        | e.g. 12.0 / 10.14.0 / 12.0 / 5.0
  SDWebImage Version      | e.g. 5.0.0 / 4.4.0
  Integration Method      | e.g. carthage / cocoapods / manually
- Xcode Version           | e.g. Xcode 10 / Xcode 9
+ Xcode Version           | e.g. Xcode 11 / Xcode 10
  Repro rate              | e.g. all the time (100%) / sometimes x% / only once
  Repro with our demo prj | e.g. does it happen with our demo project?
  Demo project link       | e.g. link to a demo project that highlights the issue

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo/LaunchScreen.storyboard
+++ b/Examples/SDWebImage Demo/LaunchScreen.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/Examples/SDWebImage OSX Demo/Base.lproj/Main.storyboard
+++ b/Examples/SDWebImage OSX Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -652,7 +652,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="400"/>
@@ -697,15 +697,21 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="WbV-Do-9qy"/>
                             </imageView>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NqE-Zi-qhY">
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="NqE-Zi-qhY">
                                 <rect key="frame" x="212" y="17" width="56" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="26" id="WoQ-RY-bSV"/>
+                                </constraints>
                                 <buttonCell key="cell" type="bevel" title="Clear" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyUpOrDown" inset="2" id="OYN-fG-Plb">
                                     <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="NqE-Zi-qhY" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="DYu-70-sO9"/>
+                            <constraint firstAttribute="bottom" secondItem="NqE-Zi-qhY" secondAttribute="bottom" constant="20" id="I0D-EI-mL0"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="clearCacheButton" destination="NqE-Zi-qhY" id="eoz-cU-wWs"/>

--- a/Examples/SDWebImage TV Demo/Base.lproj/Main.storyboard
+++ b/Examples/SDWebImage TV Demo/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13771" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14490.70" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="appleTV" orientation="landscape">
         <adaptation id="light"/>
     </device>
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/Examples/SDWebImage Watch Demo/Base.lproj/Interface.storyboard
+++ b/Examples/SDWebImage Watch Demo/Base.lproj/Interface.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="14490.70" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
+    <device id="watch38" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="10032"/>
+        <deployment identifier="watchOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="14490.21"/>
     </dependencies>
     <scenes>
         <!--Interface Controller-->

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can use those directly, or create similar components of your own.
 - tvOS 9.0 or later
 - watchOS 2.0 or later
 - macOS 10.10 or later
-- Xcode 9.0 or later
+- Xcode 10.0 or later
 
 #### Backwards compatibility
 

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage static.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImageMapKit.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImageMapKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage/SDWebImageIndicator.m
+++ b/SDWebImage/SDWebImageIndicator.m
@@ -18,7 +18,7 @@
 #if __IPHONE_13_0 || __TVOS_13_0 || __MAC_10_15
 // Xcode 11
 #else
-// Supports Xcode 9 && 10 users, for those users, define these enum
+// Supports Xcode 10 users, for those users, define these enum
 static NSInteger UIActivityIndicatorViewStyleMedium = 100;
 static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 #endif

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -26,12 +26,6 @@
 		327054E3206CEFF3006EA328 /* TestImageAnimated.apng in Resources */ = {isa = PBXBuildFile; fileRef = 327054E1206CEFF3006EA328 /* TestImageAnimated.apng */; };
 		327A418C211D660600495442 /* TestImage.heic in Resources */ = {isa = PBXBuildFile; fileRef = 327A418B211D660600495442 /* TestImage.heic */; };
 		327A418D211D660600495442 /* TestImage.heic in Resources */ = {isa = PBXBuildFile; fileRef = 327A418B211D660600495442 /* TestImage.heic */; };
-		328BAF292240C08E00FC70DD /* Test-Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF262240C08E00FC70DD /* Test-Shared.xcconfig */; };
-		328BAF2A2240C08E00FC70DD /* Test-Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF262240C08E00FC70DD /* Test-Shared.xcconfig */; };
-		328BAF2B2240C08E00FC70DD /* Test-Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF272240C08E00FC70DD /* Test-Release.xcconfig */; };
-		328BAF2C2240C08E00FC70DD /* Test-Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF272240C08E00FC70DD /* Test-Release.xcconfig */; };
-		328BAF2D2240C08E00FC70DD /* Test-Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF282240C08E00FC70DD /* Test-Debug.xcconfig */; };
-		328BAF2E2240C08E00FC70DD /* Test-Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 328BAF282240C08E00FC70DD /* Test-Debug.xcconfig */; };
 		328BB6DD20825E9800760D6C /* SDWebImageTestCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6DC20825E9800760D6C /* SDWebImageTestCache.m */; };
 		328BB6DE20825E9800760D6C /* SDWebImageTestCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6DC20825E9800760D6C /* SDWebImageTestCache.m */; };
 		32905E64211D786E00460FCF /* TestImage.heif in Resources */ = {isa = PBXBuildFile; fileRef = 32905E63211D786E00460FCF /* TestImage.heif */; };
@@ -325,7 +319,7 @@
 		DA248D461954721A00390AB0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				TargetAttributes = {
 					32B99E91203B2DF90017FD66 = {
 						CreatedOnToolsVersion = 9.2;
@@ -359,16 +353,13 @@
 			files = (
 				327054E3206CEFF3006EA328 /* TestImageAnimated.apng in Resources */,
 				32B99EA3203B31360017FD66 /* TestImage.gif in Resources */,
-				328BAF2C2240C08E00FC70DD /* Test-Release.xcconfig in Resources */,
 				324047452271956F007C53E1 /* TestEXIF.png in Resources */,
-				328BAF2E2240C08E00FC70DD /* Test-Debug.xcconfig in Resources */,
 				32B99EA4203B31360017FD66 /* TestImage.jpg in Resources */,
 				32B99EA6203B31360017FD66 /* TestImage.png in Resources */,
 				32B99EA2203B31360017FD66 /* MonochromeTestImage.jpg in Resources */,
 				32905E65211D786E00460FCF /* TestImage.heif in Resources */,
 				327A418D211D660600495442 /* TestImage.heic in Resources */,
 				32B99EA5203B31360017FD66 /* TestImageLarge.jpg in Resources */,
-				328BAF2A2240C08E00FC70DD /* Test-Shared.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,13 +367,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				328BAF2B2240C08E00FC70DD /* Test-Release.xcconfig in Resources */,
 				327A418C211D660600495442 /* TestImage.heic in Resources */,
-				328BAF292240C08E00FC70DD /* Test-Shared.xcconfig in Resources */,
 				5F7F38AD1AE2A77A00B0E330 /* TestImage.jpg in Resources */,
 				32905E64211D786E00460FCF /* TestImage.heif in Resources */,
 				43828A451DA67F9900000E62 /* TestImageLarge.jpg in Resources */,
-				328BAF2D2240C08E00FC70DD /* Test-Debug.xcconfig in Resources */,
 				433BBBB71D7EF8200086B6E9 /* TestImage.gif in Resources */,
 				DA248D61195472AA00390AB0 /* InfoPlist.strings in Resources */,
 				433BBBB91D7EF8260086B6E9 /* TestImage.png in Resources */,

--- a/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests Mac.xcscheme
+++ b/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2372 #2766 

### Pull Request Description

See the similar PR #2372

Xcode 11 is now available via WWDC 2019. And Xcode 9 is 2 years ago.

According to App Store Submit Rule. All the new or upgrade version for Apps MUST link iOS 12 SDK & Xcode 10. So it's time to drop Xcode 9.0 support. See: https://developer.apple.com/news/?id=03202019a

> Starting March 27, 2019, all new apps and app updates for iPhone or iPad, including universal apps, must be built with the iOS 12.1 SDK or later and support iPhone XS Max or the 12.9-inch iPad Pro (3rd generation). Screenshots for these devices will also be required. All new apps and app updates for Apple Watch will need to be built with the watchOS 5.1 SDK or later and support Apple Watch Series 4.

Beside this, Xcode 10 bring the support like `Using ARC Objective-C object in C struct filed`, `New Build System`, `Xcode 10 File List`, some of them can be helpful for us. Upgrating the developer toolchain version is easier than the minimum deployment target version as well.