### PR TITLE
Add a new option `SDWebImageMatchAnimatedImageClass`, to ensure we always match the custom image class instead of UIImage/NSImage class

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -46,7 +46,13 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from disk cache
      */
-    SDImageCachePreloadAllFrames = 1 << 6
+    SDImageCachePreloadAllFrames = 1 << 6,
+    /**
+     * By default, when you use `SDWebImageContextAnimatedImageClass` context option (like using `SDAnimatedImageView` which designed to use `SDAnimatedImage`), we may still use `UIImage` when the memory cache hit, or image decoder is not available, to behave as a fallback solution.
+     * Using this option, can ensure we always produce image with your provided class. If failed, a error with code `SDWebImageErrorBadImageData` will been used.
+     * Note this options is not compatible with `SDImageCacheDecodeFirstFrameOnly`, which always produce a UIImage/NSImage.
+     */
+    SDImageCacheMatchAnimatedImageClass = 1 << 7,
 };
 
 /**

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -393,7 +393,7 @@
             // Check image class matching
             Class animatedImageClass = image.class;
             Class desiredImageClass = context[SDWebImageContextAnimatedImageClass];
-            if (desiredImageClass && animatedImageClass && desiredImageClass != animatedImageClass) {
+            if (desiredImageClass && ![animatedImageClass isSubclassOfClass:desiredImageClass]) {
                 image = nil;
             }
         }

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -29,8 +29,16 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         // check whether we should use `SDAnimatedImage`
         if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
             image = [[animatedImageClass alloc] initWithData:imageData scale:scale options:coderOptions];
-            if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
-                [((id<SDAnimatedImage>)image) preloadAllFrames];
+            if (image) {
+                // Preload frames if supported
+                if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
+                    [((id<SDAnimatedImage>)image) preloadAllFrames];
+                }
+            } else {
+                // Check image class matching
+                if (options & SDWebImageMatchAnimatedImageClass) {
+                    return nil;
+                }
             }
         }
     }

--- a/SDWebImage/Core/SDImageLoader.m
+++ b/SDWebImage/Core/SDImageLoader.m
@@ -43,8 +43,16 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         Class animatedImageClass = context[SDWebImageContextAnimatedImageClass];
         if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
             image = [[animatedImageClass alloc] initWithData:imageData scale:scale options:coderOptions];
-            if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
-                [((id<SDAnimatedImage>)image) preloadAllFrames];
+            if (image) {
+                // Preload frames if supported
+                if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
+                    [((id<SDAnimatedImage>)image) preloadAllFrames];
+                }
+            } else {
+                // Check image class matching
+                if (options & SDWebImageMatchAnimatedImageClass) {
+                    return nil;
+                }
             }
         }
     }
@@ -120,6 +128,14 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         Class animatedImageClass = context[SDWebImageContextAnimatedImageClass];
         if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)] && [progressiveCoder conformsToProtocol:@protocol(SDAnimatedImageCoder)]) {
             image = [[animatedImageClass alloc] initWithAnimatedCoder:(id<SDAnimatedImageCoder>)progressiveCoder scale:scale];
+            if (image) {
+                // Progressive decoding does not preload frames
+            } else {
+                // Check image class matching
+                if (options & SDWebImageMatchAnimatedImageClass) {
+                    return nil;
+                }
+            }
         }
     }
     if (!image) {

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -176,7 +176,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. However, you can specify to preload all frames into memory to reduce CPU usage when the animated image is shared by lots of imageViews.
      * This will actually trigger `preloadAllAnimatedImageFrames` in the background queue(Disk Cache & Download only).
      */
-    SDWebImagePreloadAllFrames = 1 << 20
+    SDWebImagePreloadAllFrames = 1 << 20,
+    
+    /**
+     * By default, when you use `SDWebImageContextAnimatedImageClass` context option (like using `SDAnimatedImageView` which designed to use `SDAnimatedImage`), we may still use `UIImage` when the memory cache hit, or image decoder is not available to produce one exactlly matching your custom class as a fallback solution.
+     * Using this option, can ensure we always callback image with your provided class. If failed to produce one, a error with code `SDWebImageErrorBadImageData` will been used.
+     */
+    SDWebImageMatchAnimatedImageClass = 1 << 21,
 };
 
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -181,6 +181,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     /**
      * By default, when you use `SDWebImageContextAnimatedImageClass` context option (like using `SDAnimatedImageView` which designed to use `SDAnimatedImage`), we may still use `UIImage` when the memory cache hit, or image decoder is not available to produce one exactlly matching your custom class as a fallback solution.
      * Using this option, can ensure we always callback image with your provided class. If failed to produce one, a error with code `SDWebImageErrorBadImageData` will been used.
+     * Note this options is not compatible with `SDWebImageDecodeFirstFrameOnly`, which always produce a UIImage/NSImage.
      */
     SDWebImageMatchAnimatedImageClass = 1 << 21,
 };

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -83,7 +83,14 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from network
      */
-    SDWebImageDownloaderPreloadAllFrames = 1 << 11
+    SDWebImageDownloaderPreloadAllFrames = 1 << 11,
+    
+    /**
+     * By default, when you use `SDWebImageContextAnimatedImageClass` context option (like using `SDAnimatedImageView` which designed to use `SDAnimatedImage`), we may still use `UIImage` when the memory cache hit, or image decoder is not available, to behave as a fallback solution.
+     * Using this option, can ensure we always produce image with your provided class. If failed, a error with code `SDWebImageErrorBadImageData` will been used.
+     * Note this options is not compatible with `SDWebImageDownloaderDecodeFirstFrameOnly`, which always produce a UIImage/NSImage.
+     */
+    SDWebImageDownloaderMatchAnimatedImageClass = 1 << 12,
 };
 
 FOUNDATION_EXPORT NSNotificationName _Nonnull const SDWebImageDownloadStartNotification;

--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -536,6 +536,7 @@ didReceiveResponse:(NSURLResponse *)response
     if (options & SDWebImageAvoidDecodeImage) downloaderOptions |= SDWebImageDownloaderAvoidDecodeImage;
     if (options & SDWebImageDecodeFirstFrameOnly) downloaderOptions |= SDWebImageDownloaderDecodeFirstFrameOnly;
     if (options & SDWebImagePreloadAllFrames) downloaderOptions |= SDWebImageDownloaderPreloadAllFrames;
+    if (options & SDWebImageMatchAnimatedImageClass) downloaderOptions |= SDWebImageDownloaderMatchAnimatedImageClass;
     
     if (cachedImage && options & SDWebImageRefreshCached) {
         // force progressive off if image already cached but forced refreshing

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -475,6 +475,7 @@ didReceiveResponse:(NSURLResponse *)response
     if (downloadOptions & SDWebImageDownloaderDecodeFirstFrameOnly) options |= SDWebImageDecodeFirstFrameOnly;
     if (downloadOptions & SDWebImageDownloaderPreloadAllFrames) options |= SDWebImagePreloadAllFrames;
     if (downloadOptions & SDWebImageDownloaderAvoidDecodeImage) options |= SDWebImageAvoidDecodeImage;
+    if (downloadOptions & SDWebImageDownloaderMatchAnimatedImageClass) options |= SDWebImageMatchAnimatedImageClass;
     
     return options;
 }

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -367,6 +367,30 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     expect(fileManager.lastError).equal(targetError);
 }
 
+- (void)test41MatchAnimatedImageClassWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"MatchAnimatedImageClass option should work"];
+    UIImage *image = [[UIImage alloc] initWithContentsOfFile:self.testGIFPath];
+    
+    NSString *kAnimatedImageKey = @"kAnimatedImageKey";
+    
+    // Store UIImage into cache
+    [[SDImageCache sharedImageCache] storeImageToMemory:image forKey:kAnimatedImageKey];
+    
+    // `MatchAnimatedImageClass` will cause query failed because class does not match
+    [SDImageCache.sharedImageCache queryCacheOperationForKey:kAnimatedImageKey options:SDImageCacheMatchAnimatedImageClass context:@{SDWebImageContextAnimatedImageClass : SDAnimatedImage.class} done:^(UIImage * _Nullable image1, NSData * _Nullable data1, SDImageCacheType cacheType1) {
+        expect(image1).beNil();
+        // This should query success with UIImage
+        [SDImageCache.sharedImageCache queryCacheOperationForKey:kAnimatedImageKey options:0 context:@{SDWebImageContextAnimatedImageClass : SDAnimatedImage.class} done:^(UIImage * _Nullable image2, NSData * _Nullable data2, SDImageCacheType cacheType2) {
+            expect(image2).notTo.beNil();
+            expect(image2).equal(image);
+            
+            [expectation fulfill];
+        }];
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 #pragma mark - SDMemoryCache & SDDiskCache
 - (void)test42CustomMemoryCache {
     SDImageCacheConfig *config = [[SDImageCacheConfig alloc] init];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This may help for some rare case that user always need the specify image subclass (SDAnimatedImage) for their imageView (SDAnimatedImageView) instead of the built in one.

### Use case

For user, who mixed the `UIImageView` and `SDAnimatedImageView`, there is one case which may cause problem:

1. UIImageView query the `url1` which is GIF, get one `UIAnimatedImage`
2. SDAnimatedImageView then start to query `url1`, it hit the memory cache and get `UIAnimatedImage`
3. Now this `UIAnimatedImage` start to render on SDAnimatedImageView, which is not performent

This PR aim to solve this, which introduce a option. When the custom image class is not equal to queried image class (or downloaded one), we will reject this image and mark cache miss or download failed.

