### PR TITLE
Add missing nullable and nonnull attributes

### DIFF
--- a/SDWebImage/Core/NSImage+Compatibility.m
+++ b/SDWebImage/Core/NSImage+Compatibility.m
@@ -14,7 +14,7 @@
 
 @implementation NSImage (Compatibility)
 
-- (CGImageRef)CGImage {
+- (nullable CGImageRef)CGImage {
     NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
     CGImageRef cgImage = [self CGImageForProposedRect:&imageRect context:nil hints:nil];
     return cgImage;
@@ -40,7 +40,7 @@
     return scale;
 }
 
-- (instancetype)initWithCGImage:(CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation {
+- (instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation {
     NSBitmapImageRep *imageRep;
     if (orientation != kCGImagePropertyOrientationUp) {
         // AppKit design is different from UIKit. Where CGImage based image rep does not respect to any orientation. Only data based image rep which contains the EXIF metadata can automatically detect orientation.
@@ -65,7 +65,7 @@
     return self;
 }
 
-- (instancetype)initWithData:(NSData *)data scale:(CGFloat)scale {
+- (instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale {
     NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithData:data];
     if (!imageRep) {
         return nil;

--- a/SDWebImage/Core/UIImage+ForceDecode.m
+++ b/SDWebImage/Core/UIImage+ForceDecode.m
@@ -21,18 +21,18 @@
     objc_setAssociatedObject(self, @selector(sd_isDecoded), @(sd_isDecoded), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-+ (UIImage *)sd_decodedImageWithImage:(UIImage *)image {
++ (nullable UIImage *)sd_decodedImageWithImage:(nullable UIImage *)image {
     if (!image) {
         return nil;
     }
     return [SDImageCoderHelper decodedImageWithImage:image];
 }
 
-+ (UIImage *)sd_decodedAndScaledDownImageWithImage:(UIImage *)image {
++ (nullable UIImage *)sd_decodedAndScaledDownImageWithImage:(nullable UIImage *)image {
     return [self sd_decodedAndScaledDownImageWithImage:image limitBytes:0];
 }
 
-+ (UIImage *)sd_decodedAndScaledDownImageWithImage:(UIImage *)image limitBytes:(NSUInteger)bytes {
++ (nullable UIImage *)sd_decodedAndScaledDownImageWithImage:(nullable UIImage *)image limitBytes:(NSUInteger)bytes {
     if (!image) {
         return nil;
     }

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -211,7 +211,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return image;
 }
 
-- (nullable UIImage *)sd_roundedCornerImageWithRadius:(CGFloat)cornerRadius corners:(SDRectCorner)corners borderWidth:(CGFloat)borderWidth borderColor:(UIColor *)borderColor {
+- (nullable UIImage *)sd_roundedCornerImageWithRadius:(CGFloat)cornerRadius corners:(SDRectCorner)corners borderWidth:(CGFloat)borderWidth borderColor:(nullable UIColor *)borderColor {
     if (!self.CGImage) return nil;
     SDGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
     CGContextRef context = SDGraphicsGetCurrentContext();

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -182,7 +182,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     }
 }
 
-- (UIImage *)sd_resizedImageWithSize:(CGSize)size scaleMode:(SDImageScaleMode)scaleMode {
+- (nullable UIImage *)sd_resizedImageWithSize:(CGSize)size scaleMode:(SDImageScaleMode)scaleMode {
     if (size.width <= 0 || size.height <= 0) return nil;
     SDGraphicsBeginImageContextWithOptions(size, NO, self.scale);
     [self sd_drawInRect:CGRectMake(0, 0, size.width, size.height) withScaleMode:scaleMode clipsToBounds:NO];
@@ -191,7 +191,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return image;
 }
 
-- (UIImage *)sd_croppedImageWithRect:(CGRect)rect {
+- (nullable UIImage *)sd_croppedImageWithRect:(CGRect)rect {
     if (!self.CGImage) return nil;
     rect.origin.x *= self.scale;
     rect.origin.y *= self.scale;
@@ -211,7 +211,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return image;
 }
 
-- (UIImage *)sd_roundedCornerImageWithRadius:(CGFloat)cornerRadius corners:(SDRectCorner)corners borderWidth:(CGFloat)borderWidth borderColor:(UIColor *)borderColor {
+- (nullable UIImage *)sd_roundedCornerImageWithRadius:(CGFloat)cornerRadius corners:(SDRectCorner)corners borderWidth:(CGFloat)borderWidth borderColor:(UIColor *)borderColor {
     if (!self.CGImage) return nil;
     SDGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
     CGContextRef context = SDGraphicsGetCurrentContext();
@@ -253,7 +253,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return image;
 }
 
-- (UIImage *)sd_rotatedImageWithAngle:(CGFloat)angle fitSize:(BOOL)fitSize {
+- (nullable UIImage *)sd_rotatedImageWithAngle:(CGFloat)angle fitSize:(BOOL)fitSize {
     if (!self.CGImage) return nil;
     size_t width = (size_t)CGImageGetWidth(self.CGImage);
     size_t height = (size_t)CGImageGetHeight(self.CGImage);
@@ -290,7 +290,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return img;
 }
 
-- (UIImage *)sd_flippedImageWithHorizontal:(BOOL)horizontal vertical:(BOOL)vertical {
+- (nullable UIImage *)sd_flippedImageWithHorizontal:(BOOL)horizontal vertical:(BOOL)vertical {
     if (!self.CGImage) return nil;
     size_t width = (size_t)CGImageGetWidth(self.CGImage);
     size_t height = (size_t)CGImageGetHeight(self.CGImage);
@@ -327,7 +327,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 
 #pragma mark - Image Blending
 
-- (UIImage *)sd_tintedImageWithColor:(UIColor *)tintColor {
+- (nullable UIImage *)sd_tintedImageWithColor:(nonnull UIColor *)tintColor {
     if (!self.CGImage) return nil;
     if (!tintColor.CGColor) return nil;
     
@@ -359,7 +359,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return image;
 }
 
-- (UIColor *)sd_colorAtPoint:(CGPoint)point {
+- (nullable UIColor *)sd_colorAtPoint:(CGPoint)point {
     if (!self) {
         return nil;
     }
@@ -403,7 +403,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
     return SDGetColorFromPixel(pixel, bitmapInfo);
 }
 
-- (NSArray<UIColor *> *)sd_colorsWithRect:(CGRect)rect {
+- (nullable NSArray<UIColor *> *)sd_colorsWithRect:(CGRect)rect {
     if (!self) {
         return nil;
     }
@@ -467,7 +467,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #pragma mark - Image Effect
 
 // We use vImage to do box convolve for performance and support for watchOS. However, you can just use `CIFilter.CIBoxBlur`. For other blur effect, use any filter in `CICategoryBlur`
-- (UIImage *)sd_blurredImageWithRadius:(CGFloat)blurRadius {
+- (nullable UIImage *)sd_blurredImageWithRadius:(CGFloat)blurRadius {
     if (self.size.width < 1 || self.size.height < 1) {
         return nil;
     }
@@ -561,7 +561,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 }
 
 #if SD_UIKIT || SD_MAC
-- (UIImage *)sd_filteredImageWithFilter:(CIFilter *)filter {
+- (nullable UIImage *)sd_filteredImageWithFilter:(CIFilter *)filter {
     if (!self.CGImage) return nil;
     
     CIContext *context = [CIContext context];

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -561,7 +561,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 }
 
 #if SD_UIKIT || SD_MAC
-- (nullable UIImage *)sd_filteredImageWithFilter:(CIFilter *)filter {
+- (nullable UIImage *)sd_filteredImageWithFilter:(nonnull CIFilter *)filter {
     if (!self.CGImage) return nil;
     
     CIContext *context = [CIContext context];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Hello.
Thank you for your library.
I found out that in some *.m-files `nullable` and `nonnull` attributes are missing. I know that this is not an issue because these attributes are using in the corresponding headers files. I just want to keep the same code style for all files. 
