### PR TITLE
Support to clear frame buffer or reset frame index when stopped for SDAnimatedImageView

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -58,6 +58,20 @@
  */
 @property (nonatomic, assign) BOOL shouldIncrementalLoad;
 
+/**
+ Whether or not to clear the frame buffer cache when animation stopped. See `maxBufferSize`
+ This is useful when you want to limit the memory usage during frequently visibility changes (such as image view inside a list view, then push and pop)
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL clearBufferWhenStopped;
+
+/**
+ Whether or not to reset the current frame index when animation stopped.
+ For some of use case, you may want to reset the frame index to 0 when stop, but some other want to keep the current frame index.
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
+
 #if SD_UIKIT
 /**
  You can specify a runloop mode to let it rendering.

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -149,21 +149,15 @@ static NSUInteger SDDeviceFreeMemory() {
     self.animatedImage = nil;
     self.totalFrameCount = 0;
     self.totalLoopCount = 0;
-    self.currentFrame = nil;
-    self.currentFrameIndex = 0;
-    self.currentLoopCount = 0;
-    self.currentTime = 0;
-    self.bufferMiss = NO;
+    // reset current state
+    [self resetCurrentFrameIndex];
     self.shouldAnimate = NO;
     self.isProgressive = NO;
     self.maxBufferCount = 0;
     self.animatedImageScale = 1;
     [_fetchQueue cancelAllOperations];
-    _fetchQueue = nil;
-    SD_LOCK(self.lock);
-    [_frameBuffer removeAllObjects];
-    _frameBuffer = nil;
-    SD_UNLOCK(self.lock);
+    // clear buffer cache
+    [self clearFrameBuffer];
 }
 
 - (void)resetProgressiveImage
@@ -177,6 +171,23 @@ static NSUInteger SDDeviceFreeMemory() {
     self.maxBufferCount = 0;
     self.animatedImageScale = 1;
     // preserve buffer cache
+}
+
+- (void)resetCurrentFrameIndex
+{
+    self.currentFrame = nil;
+    self.currentFrameIndex = 0;
+    self.currentLoopCount = 0;
+    self.currentTime = 0;
+    self.bufferMiss = NO;
+}
+
+- (void)clearFrameBuffer
+{
+    SD_LOCK(self.lock);
+    [_frameBuffer removeAllObjects];
+    _frameBuffer = nil;
+    SD_UNLOCK(self.lock);
 }
 
 #pragma mark - Accessors
@@ -466,6 +477,12 @@ static NSUInteger SDDeviceFreeMemory() {
 #else
         _displayLink.paused = YES;
 #endif
+        if (self.resetFrameIndexWhenStopped) {
+            [self resetCurrentFrameIndex];
+        }
+        if (self.clearBufferWhenStopped) {
+            [self clearFrameBuffer];
+        }
     } else {
 #if SD_UIKIT
         [super stopAnimating];

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -186,7 +186,6 @@ static NSUInteger SDDeviceFreeMemory() {
 {
     SD_LOCK(self.lock);
     [_frameBuffer removeAllObjects];
-    _frameBuffer = nil;
     SD_UNLOCK(self.lock);
 }
 

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -321,7 +321,11 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+#if SD_UIKIT
         [imageView stopAnimating];
+#else
+        imageView.animates = NO;
+#endif
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
         
@@ -355,7 +359,11 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+#if SD_UIKIT
         [imageView stopAnimating];
+#else
+        imageView.animates = NO;
+#endif
         expect(imageView.frameBuffer.count).equal(0);
         expect(imageView.currentFrameIndex).equal(0);
         

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -16,6 +16,7 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 @interface SDAnimatedImageView ()
 
 @property (nonatomic, assign) BOOL isProgressive;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, UIImage *> *frameBuffer;
 
 @end
 
@@ -206,6 +207,7 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #else
             imageView.animates = NO;
 #endif
+            [imageView removeFromSuperview];
             [expectation fulfill];
         }
     }];
@@ -295,6 +297,72 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
         expect([image isKindOfClass:[SDAnimatedImage class]]).beTruthy();
         [expectation fulfill];
     }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test25AnimatedImageStopAnimatingNormal {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView stopAnimating normal behavior"];
+    
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    
+#if SD_UIKIT
+    [self.window addSubview:imageView];
+#else
+    [self.window.contentView addSubview:imageView];
+#endif
+    // This APNG duration is 2s
+    SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
+    imageView.image = image;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // 0.5s is not finished, frame index should not be 0
+        expect(imageView.frameBuffer.count).beGreaterThan(0);
+        expect(imageView.currentFrameIndex).beGreaterThan(0);
+    });
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [imageView stopAnimating];
+        expect(imageView.frameBuffer.count).beGreaterThan(0);
+        expect(imageView.currentFrameIndex).beGreaterThan(0);
+        
+        [imageView removeFromSuperview];
+        [expectation fulfill];
+    });
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test25AnimatedImageStopAnimatingClearBuffer {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView stopAnimating clear buffer when stopped"];
+    
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    imageView.clearBufferWhenStopped = YES;
+    imageView.resetFrameIndexWhenStopped = YES;
+    
+#if SD_UIKIT
+    [self.window addSubview:imageView];
+#else
+    [self.window.contentView addSubview:imageView];
+#endif
+    // This APNG duration is 2s
+    SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
+    imageView.image = image;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // 0.5s is not finished, frame index should not be 0
+        expect(imageView.frameBuffer.count).beGreaterThan(0);
+        expect(imageView.currentFrameIndex).beGreaterThan(0);
+    });
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [imageView stopAnimating];
+        expect(imageView.frameBuffer.count).equal(0);
+        expect(imageView.currentFrameIndex).equal(0);
+        
+        [imageView removeFromSuperview];
+        [expectation fulfill];
+    });
+    
     [self waitForExpectationsWithCommonTimeout];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2814 

### Pull Request Description

This PR including the two new properties for `SDAnimatedIamge`

+ `clearBufferWhenStopped`: This will clear the internal frame buffer when animating stopped.
+ `resetFrameIndexWhenStopped`: This will reset the image view 's frame into 0 when animating stopped.


### Reason
`clearBufferWhenStopped` is used to reduce the memory pressure for massive SDAnimatedImageView playing. Because when a imageView was disappear from screen (such as pop or push in list view), it stop the animation, but still keeping the internal buffer cache. This cache can be purged to reduce total usage. (The default value is NO, It's still useful, if you don't want to effect the frame rate or lag when the imageView appear again)

`resetFrameIndexWhenStopped` is used to solve the problem, that we have no any syntax to represent the 3 different animation control:

+ startAnimating
+ stopAnimating
+ pauseAnimating

Since this class is subclass of `UIImageView/NSImageView`, it does not have the API for pause. So we introduce the `resetFrameIndexWhenStopped` instead. When this options is OFF, you can use `stopAnimating` as pause; ON for terminate.
