### PR TITLE
Fix the macOS that SDAnimatedImageView does not works for imageScaling and imageAlignment properties

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -41,6 +41,8 @@
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png"]];
     // SDAnimatedImageView + Animated Image
     self.imageView4.sd_imageTransition = SDWebImageTransition.fadeTransition;
+    self.imageView4.imageScaling = NSImageScaleProportionallyUpOrDown;
+    self.imageView4.imageAlignment = NSImageAlignLeft; // supports NSImageView's layout properties
     [self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"] placeholderImage:nil options:SDWebImageForceTransition];
     
     self.clearCacheButton.target = self;

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -65,6 +65,7 @@ static NSUInteger SDDeviceFreeMemory() {
 #else
 @property (nonatomic, strong) CADisplayLink *displayLink;
 #endif
+@property (nonatomic) CALayer *imageViewLayer; // The actual rendering layer.
 
 @end
 
@@ -132,10 +133,6 @@ static NSUInteger SDDeviceFreeMemory() {
     self.shouldIncrementalLoad = YES;
 #if SD_MAC
     self.wantsLayer = YES;
-    // Default value from `NSImageView`
-    self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
-    self.imageScaling = NSImageScaleProportionallyDown;
-    self.imageAlignment = NSImageAlignCenter;
 #endif
 #if SD_UIKIT
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
@@ -194,7 +191,7 @@ static NSUInteger SDDeviceFreeMemory() {
 
 - (void)setImage:(UIImage *)image
 {
-    if (self.image == image) {
+    if (super.image == image) {
         return;
     }
     
@@ -246,11 +243,8 @@ static NSUInteger SDDeviceFreeMemory() {
         if (self.shouldAnimate) {
             [self startAnimating];
         }
-        
-        [self.layer setNeedsDisplay];
-#if SD_MAC
-        [self.layer displayIfNeeded]; // macOS's imageViewLayer may not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
-#endif
+
+        [self.imageViewLayer setNeedsDisplay];
     }
 }
 
@@ -555,7 +549,7 @@ static NSUInteger SDDeviceFreeMemory() {
     // We must use `image.class conformsToProtocol:` instead of `image conformsToProtocol:` here
     // Because UIKit on macOS, using internal hard-coded override method, which returns NO
     if ([image.class conformsToProtocol:@protocol(SDAnimatedImage)] && image.sd_isIncremental) {
-        UIImage *previousImage = self.image;
+        UIImage *previousImage = super.image;
         if ([previousImage.class conformsToProtocol:@protocol(SDAnimatedImage)] && previousImage.sd_isIncremental) {
             NSData *previousData = [((UIImage<SDAnimatedImage> *)previousImage) animatedImageData];
             NSData *currentData = [((UIImage<SDAnimatedImage> *)image) animatedImageData];
@@ -643,7 +637,7 @@ static NSUInteger SDDeviceFreeMemory() {
         self.currentFrame = currentFrame;
         self.currentFrameIndex = nextFrameIndex;
         self.bufferMiss = NO;
-        [self.layer setNeedsDisplay];
+        [self.imageViewLayer setNeedsDisplay];
     } else {
         self.bufferMiss = YES;
     }
@@ -714,42 +708,42 @@ static NSUInteger SDDeviceFreeMemory() {
 
 - (void)displayLayer:(CALayer *)layer
 {
-    if (_currentFrame) {
+    if (self.currentFrame) {
         layer.contentsScale = self.animatedImageScale;
-        layer.contents = (__bridge id)_currentFrame.CGImage;
+        layer.contents = (__bridge id)self.currentFrame.CGImage;
     }
 }
 
 #if SD_MAC
-// Layer-backed NSImageView optionally optimize to use a subview to do actual layer rendering.
-// When the optimization is turned on, it calls `updateLayer` instead of `displayLayer:` to update subview's layer.
-// When the optimization it turned off, this return nil and calls `displayLayer:` directly.
-- (CALayer *)imageViewLayer {
-    NSView *imageView = imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageView"));
+// NSImageView use a subview. We need this subview's layer for actual rendering.
+// Why using this design may because of properties like `imageAlignment` and `imageScaling`, which it's not available for UIImageView.contentMode (it's impossible to align left and keep aspect ratio at the same time)
+- (NSView *)imageView {
+    NSImageView *imageView = imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageView"));
     if (!imageView) {
         // macOS 10.14
         imageView = objc_getAssociatedObject(self, NSSelectorFromString(@"_imageSubview"));
     }
-    return imageView.layer;
+    return imageView;
 }
 
-- (void)updateLayer
-{
-    if (_currentFrame) {
-        [self displayLayer:self.imageViewLayer];
-    } else {
-        [super updateLayer];
+// on macOS, it's the imageView subview's layer (we use layer-hosting view to let CALayerDelegate works)
+- (CALayer *)imageViewLayer {
+    NSView *imageView = self.imageView;
+    if (!imageView) {
+        return nil;
     }
+    if (!_imageViewLayer) {
+        _imageViewLayer = [CALayer new];
+        _imageViewLayer.delegate = self;
+        imageView.layer = _imageViewLayer;
+        imageView.wantsLayer = YES;
+    }
+    return _imageViewLayer;
 }
-
-- (BOOL)wantsUpdateLayer {
-    // AppKit is different from UIKit, it need extra check before the layer is updated
-    // When we use the custom animation, the layer.setNeedsDisplay is directly called from display link (See `displayDidRefresh:`). However, for normal image rendering, we must implements and return YES to mark it need display
-    if (_currentFrame) {
-        return NO;
-    } else {
-        return YES;
-    }
+#else
+// on iOS, it's the imageView itself's layer
+- (CALayer *)imageViewLayer {
+    return self.layer;
 }
 
 #endif

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -191,7 +191,7 @@ static NSUInteger SDDeviceFreeMemory() {
 
 - (void)setImage:(UIImage *)image
 {
-    if (super.image == image) {
+    if (self.image == image) {
         return;
     }
     
@@ -549,7 +549,7 @@ static NSUInteger SDDeviceFreeMemory() {
     // We must use `image.class conformsToProtocol:` instead of `image conformsToProtocol:` here
     // Because UIKit on macOS, using internal hard-coded override method, which returns NO
     if ([image.class conformsToProtocol:@protocol(SDAnimatedImage)] && image.sd_isIncremental) {
-        UIImage *previousImage = super.image;
+        UIImage *previousImage = self.image;
         if ([previousImage.class conformsToProtocol:@protocol(SDAnimatedImage)] && previousImage.sd_isIncremental) {
             NSData *previousData = [((UIImage<SDAnimatedImage> *)previousImage) animatedImageData];
             NSData *currentData = [((UIImage<SDAnimatedImage> *)image) animatedImageData];

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -8,6 +8,7 @@
  */
 
 #import "SDTestCase.h"
+#import "SDInternalMacros.h"
 #import <KVOController/KVOController.h>
 
 static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop count
@@ -17,6 +18,8 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 
 @property (nonatomic, assign) BOOL isProgressive;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, UIImage *> *frameBuffer;
+@property (nonatomic, strong) dispatch_semaphore_t lock;
+
 
 @end
 
@@ -316,8 +319,10 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         // 0.5s is not finished, frame index should not be 0
+        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
+        SD_UNLOCK(imageView.lock);
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -326,8 +331,10 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #else
         imageView.animates = NO;
 #endif
+        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
+        SD_UNLOCK(imageView.lock);
         
         [imageView removeFromSuperview];
         [expectation fulfill];
@@ -354,8 +361,10 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         // 0.5s is not finished, frame index should not be 0
+        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
+        SD_UNLOCK(imageView.lock);
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -364,8 +373,10 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #else
         imageView.animates = NO;
 #endif
+        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).equal(0);
         expect(imageView.currentFrameIndex).equal(0);
+        SD_UNLOCK(imageView.lock);
         
         [imageView removeFromSuperview];
         [expectation fulfill];

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -8,7 +8,6 @@
  */
 
 #import "SDTestCase.h"
-#import "SDInternalMacros.h"
 #import <KVOController/KVOController.h>
 
 static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop count
@@ -18,8 +17,6 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 
 @property (nonatomic, assign) BOOL isProgressive;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, UIImage *> *frameBuffer;
-@property (nonatomic, strong) dispatch_semaphore_t lock;
-
 
 @end
 
@@ -319,10 +316,8 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         // 0.5s is not finished, frame index should not be 0
-        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
-        SD_UNLOCK(imageView.lock);
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -331,10 +326,8 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #else
         imageView.animates = NO;
 #endif
-        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
-        SD_UNLOCK(imageView.lock);
         
         [imageView removeFromSuperview];
         [expectation fulfill];
@@ -361,10 +354,8 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         // 0.5s is not finished, frame index should not be 0
-        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).beGreaterThan(0);
         expect(imageView.currentFrameIndex).beGreaterThan(0);
-        SD_UNLOCK(imageView.lock);
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -373,10 +364,8 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
 #else
         imageView.animates = NO;
 #endif
-        SD_LOCK(imageView.lock);
         expect(imageView.frameBuffer.count).equal(0);
         expect(imageView.currentFrameIndex).equal(0);
-        SD_UNLOCK(imageView.lock);
         
         [imageView removeFromSuperview];
         [expectation fulfill];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR fix the issue of `SDAnimatedImageView`, which does not works for the NSImageView's super class properties [imageAlignment](https://developer.apple.com/documentation/appkit/nsimageview/1404963-imagealignment) and [imageScaling](https://developer.apple.com/documentation/appkit/nsimageview/1404956-imagescaling).

These two properties is common used for AppKit developer, and I think they should be supported to help migrate animation from NSImageView to SDAnimatedImageView.

### Detailed Reason

The bug issue is because of previous SDAnimatedImageView implementation for layer rendering. At that time, I use the `self.layer` to render the frame CGImage on it. This works for normal cases, however, it does not support the layout behavior of NSImageView.

The NSImageView, use a subview (AppKit call it `NSImageViewSimpleImageView` class). The acutal image render is on that subview, instead of `NSImageView` itself. See the screenshot:

![image](https://user-images.githubusercontent.com/6919743/64066071-4d69c600-cc48-11e9-8dbe-06f70f7d171f.png)


This design can be useful, to support the imaegScaling and alignment like this:

+ imageScaling: aspect fit
+ alignment: left

Which can not be implemented by using the same design like UIKit's [UIImageView.contentMode](https://developer.apple.com/documentation/uikit/uiview/1622619-contentmode) or simple [CALayer.contentsGravity](https://developer.apple.com/documentation/quartzcore/calayer/1410872-contentsgravity), you can not keep aspect fit and align left at the same time, it always align in center.

So that means, if I want to fix this, I need to implements all this from the scratch (which is painful and ugly by writing many geometry calculation or affine transform code), or I need to find another better way instead of current solution.

### Solution

I update the implementation of SDAnimatedImageView on macOS. Now, it will use the subview's layer, instead of `self.layer` to do actual frame rendering. All of the layout behavior is controlled by AppKit and behave the same as NSImageView. Which looks good.

The subview's layer is provided by SDAnimatedImageView using a layer-hosting view, which can make it possible to receive the `CALayerDelegate`'s [displayLayer:](https://developer.apple.com/documentation/quartzcore/calayerdelegate/2097261-display) call, just as UIKit's code. Which is better than current one.

See the difference between this PR of the demo code:

```objective-c
self.imageView4.imageScaling = NSImageScaleProportionallyUpOrDown;
self.imageView4.imageAlignment = NSImageAlignLeft; // supports NSImageView's layout properties
[self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"] placeholderImage:nil options:SDWebImageForceTransition];
```

+ Bug behavior:

![image](https://user-images.githubusercontent.com/6919743/64066019-a71dc080-cc47-11e9-8f45-f82df2476be0.png)

+ Correct behavior:

![image](https://user-images.githubusercontent.com/6919743/64066020-ae44ce80-cc47-11e9-8c1f-6e384e54055c.png)


