### PR TITLE
Fix the case when SDAnimatedImageView dealloc on the fetch queue, will cause it trigger the UIKit/AppKit method on non-main queue and captured by UI Main Thread Checker

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -683,7 +683,12 @@ static NSUInteger SDDeviceFreeMemory() {
     if (!fetchFrame && !bufferFull && self.fetchQueue.operationCount == 0) {
         // Prefetch next frame in background queue
         UIImage<SDAnimatedImage> *animatedImage = self.animatedImage;
+        @weakify(self);
         NSOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
+            @strongify(self);
+            if (!self) {
+                return;
+            }
             UIImage *frame = [animatedImage animatedImageFrameAtIndex:fetchFrameIndex];
 
             BOOL isAnimating = NO;
@@ -697,6 +702,10 @@ static NSUInteger SDDeviceFreeMemory() {
                 self.frameBuffer[@(fetchFrameIndex)] = frame;
                 SD_UNLOCK(self.lock);
             }
+            // Ensure when self dealloc, it dealloced on the main queue (UIKit/AppKit rule)
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self class];
+            });
         }];
         [self.fetchQueue addOperation:operation];
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: 

### Pull Request Description

This PR fix the test case failed of `test25AnimatedImageStopAnimatingNormalnormalte`. See the master's test result:

https://travis-ci.org/SDWebImage/SDWebImage/builds/578814353

It's because the UI Main Thread Checker found this code called on non-main queue:

```
Test Case '-[SDAnimatedImageTest test25AnimatedImageStopAnimatingNormal]' started.
=================================================================
Main Thread Checker: UI API called on a background thread: -[NSImageView setAnimates:]
PID: 11614, TID: 690311, Thread name: (none), Queue name: NSOperationQueue 0x10b3688d0 (QOS: UNSPECIFIED), QoS: 0
Backtrace:
4   SDWebImage                          0x0000000101ccbdf0 -[SDAnimatedImageView setAnimates:] + 80
5   AppKit                              0x00007fff32bbf0d1 -[NSImageView dealloc] + 33
6   SDWebImage                          0x0000000101ccb244 -[SDAnimatedImageView dealloc] + 148
7   SDWebImage                          0x0000000101ccd778 __destroy_helper_block_e8_32s40s + 40
8   libsystem_blocks.dylib              0x00007fff6131fbf3 _Block_release + 105
9   Foundation                          0x00007fff37645ba9 -[NSBlockOperation dealloc] + 57
10  Foundation                          0x00007fff37733e51 __destroy_helper_block_e8_32o40o + 23
11  libsystem_blocks.dylib              0x00007fff6131fbf3 _Block_release + 105
12  libdispatch.dylib                   0x00007fff6128963d _dispatch_client_callout + 8
13  libdispatch.dylib                   0x00007fff6128bde6 _dispatch_continuation_pop + 414
14  libdispatch.dylib                   0x00007fff6128b4a3 _dispatch_async_redirect_invoke + 703
15  libdispatch.dylib                   0x00007fff612973bc _dispatch_root_queue_drain + 324
16  libdispatch.dylib                   0x00007fff61297b46 _dispatch_worker_thread2 + 90
17  libsystem_pthread.dylib             0x00007fff614c96b3 _pthread_wqthread + 583
18  libsystem_pthread.dylib             0x00007fff614c93fd start_wqthread + 13
```


To fix this, this PR do two things:

1. Use weak-strong dance to avoid extra process when self is dealloced. This can help to reduce the life cycle for `SDAnimatedImageView` (the fetch queue operation when image view dealloced is useless)
2. Use a dummy main queue check to ensure it will always been retained on the main queue to release.

After this changes, the UI Main Thread Checker can been passed.

Both UIKit/AppKit UIImageView/NSImageView has internal logic when dealloc, so it should be called only on main queue.

![image](https://user-images.githubusercontent.com/6919743/64157779-e6c3f280-ce69-11e9-8180-7d1855b766c2.png)
![image](https://user-images.githubusercontent.com/6919743/64157827-00fdd080-ce6a-11e9-9d6c-24b4d8666ddf.png)


