### PR TITLE
Fix the macOS SDAnimatedImageRep to match Netscape standard of GIF loop count, which should use 1 when there are no loop count information

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageRep.h
+++ b/SDWebImage/Core/SDAnimatedImageRep.h
@@ -11,7 +11,8 @@
 #if SD_MAC
 
 /**
- A subclass of `NSBitmapImageRep` to fix that GIF loop count issue because `NSBitmapImageRep` will reset `NSImageCurrentFrameDuration` by using `kCGImagePropertyGIFDelayTime` but not `kCGImagePropertyGIFUnclampedDelayTime`.
+ A subclass of `NSBitmapImageRep` to fix that GIF duration issue because `NSBitmapImageRep` will reset `NSImageCurrentFrameDuration` by using `kCGImagePropertyGIFDelayTime` but not `kCGImagePropertyGIFUnclampedDelayTime`.
+ This also fix the GIF loop count issue, which will use the Netscape standard (See http://www6.uniovi.es/gifanim/gifabout.htm)  to only place once when the `kCGImagePropertyGIFLoopCount` is nil. This is what modern browser's behavior.
  Built in GIF coder use this instead of `NSBitmapImageRep` for better GIF rendering. If you do not want this, only enable `SDImageIOCoder`, which just call `NSImage` API and actually use `NSBitmapImageRep` for GIF image.
  This also support APNG format using `SDImageAPNGCoder`. Which provide full alpha-channel support and the correct duration match the `kCGImagePropertyAPNGUnclampedDelayTime`.
  */

--- a/SDWebImage/Core/SDAnimatedImageRep.m
+++ b/SDWebImage/Core/SDAnimatedImageRep.m
@@ -50,7 +50,10 @@
         }
         if (CFStringCompare(type, kUTTypeGIF, 0) == kCFCompareEqualTo) {
             // GIF
-            // Do nothing because NSBitmapImageRep support it
+            // Fix the `NSBitmapImageRep` GIF loop count calculation issue
+            // Which will use 0 when there are no loop count information metadata in GIF data
+            NSUInteger loopCount = [SDImageGIFCoder imageLoopCountWithSource:imageSource];
+            [self setProperty:NSImageLoopCount withValue:@(loopCount)];
         } else if (CFStringCompare(type, kUTTypePNG, 0) == kCFCompareEqualTo) {
             // APNG
             // Do initilize about frame count, current frame/duration and loop count

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -103,12 +103,7 @@
     NSString * testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestLoopCount" ofType:@"gif"];
     NSData *testImageData = [NSData dataWithContentsOfFile:testImagePath];
     UIImage *image = [SDImageGIFCoder.sharedCoder decodedImageWithData:testImageData options:nil];
-#if SD_MAC
-    // TODO, macOS's `NSBitmapImageRep` treate this loop count as 0, this need to be fixed in next PR.
-    expect(image.sd_imageLoopCount).equal(0);
-#else
     expect(image.sd_imageLoopCount).equal(1);
-#endif
 }
 
 - (void)test13ThatHEICWorks {

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -189,8 +189,6 @@
 
 - (void)test16ThatImageIOAnimatedCoderAbstractClass {
     SDImageIOAnimatedCoder *coder = [[SDImageIOAnimatedCoder alloc] init];
-    NSString * testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"png"];
-    NSData *testImageData = [NSData dataWithContentsOfFile:testImagePath];
     @try {
         [coder canEncodeToFormat:SDImageFormatPNG];
         XCTFail("Should throw exception");


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2846 #2155

### Pull Request Description

See #2155.

This fix the macOS's GIF loop count behavior. When the GIF compressed data does not have any loop count extension metadata.

The standard is here: http://www6.uniovi.es/gifanim/gifabout.htm

