### PR TITLE
Revert animated heic coder from default coder list due to Apple's performance issue

### DIFF
--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -52,7 +52,8 @@
                                                                                target:self
                                                                                action:@selector(flushCache)];
         
-        [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
+        [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]]; // For WebP static/animated image
+        [[SDImageCodersManager sharedManager] addCoder:[SDImageHEICCoder sharedCoder]]; // For HEIC static/animated image. Animated image is new introduced in iOS 13, but it contains performance issue for now.
         
         // HTTP NTLM auth example
         // Add your NTLM image url to the array below and replace the credentials

--- a/SDWebImage/Core/SDImageCodersManager.h
+++ b/SDWebImage/Core/SDImageCodersManager.h
@@ -17,10 +17,10 @@
  
  Note: the `coders` getter will return the coders in their reversed order
  Example:
- - by default we internally set coders = `IOCoder`, `GIFCoder`, `APNGCoder`, 'HEICCoder' (iOS 11+)
- - calling `coders` will return `@[IOCoder, GIFCoder, APNGCoder, HEICCoder]`
+ - by default we internally set coders = `IOCoder`, `GIFCoder`, `APNGCoder`
+ - calling `coders` will return `@[IOCoder, GIFCoder, APNGCoder]`
  - call `[addCoder:[MyCrazyCoder new]]`
- - calling `coders` now returns `@[IOCoder, GIFCoder, APNGCoder, HEICCoder, MyCrazyCoder]`
+ - calling `coders` now returns `@[IOCoder, GIFCoder, APNGCoder, MyCrazyCoder]`
  
  Coders
  ------

--- a/SDWebImage/Core/SDImageCodersManager.m
+++ b/SDWebImage/Core/SDImageCodersManager.m
@@ -37,9 +37,6 @@
     if (self = [super init]) {
         // initialize with default coders
         _imageCoders = [NSMutableArray arrayWithArray:@[[SDImageIOCoder sharedCoder], [SDImageGIFCoder sharedCoder], [SDImageAPNGCoder sharedCoder]]];
-        if (@available(iOS 11, macOS 10.14, tvOS 11, watchOS 4, *)) {
-            [_imageCoders addObject:[SDImageHEICCoder sharedCoder]];
-        }
         _codersLock = dispatch_semaphore_create(1);
     }
     return self;

--- a/SDWebImage/Core/SDImageHEICCoder.h
+++ b/SDWebImage/Core/SDImageHEICCoder.h
@@ -14,6 +14,7 @@
  Image/IO provide the static HEIC (.heic) support in iOS 11/macOS 10.13/tvOS 11/watchOS 4+.
  Image/IO provide the animated HEIC (.heics) support in iOS 13/macOS 10.15/tvOS 13/watchOS 6+.
  See https://nokiatech.github.io/heif/technical.html for the standard.
+ @note This coder is not in the default coder list for now, since HEIC animated image is really rare, and Apple's implementation still contains performance issues. You can enable if you need this.
  @note If you need to support lower firmware version for HEIF, you can have a try at https://github.com/SDWebImage/SDWebImageHEIFCoder
  */
 @interface SDImageHEICCoder : SDImageIOAnimatedCoder <SDProgressiveImageCoder, SDAnimatedImageCoder>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2849

### Pull Request Description

Current HEIC decoding speed for Image/IO is really slow, and when using in the `UIImageView`, it may block the main UI Thread for seconds level time. 

Since HEIC animated image is really rare on the Internet, maybe we can just remove this from the default coder list, to invesigate future performance enhancement from Apple.

Note the static HEIC decoding does not get effected, because `SDImageIOCoder` support this as well.

