### PR TITLE
Fix warnings when deployment target version set to iOS 13+

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -19,7 +19,7 @@
 
 #if SD_MAC
 #import <CoreVideo/CoreVideo.h>
-static CVReturn renderCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext);
+static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext);
 #endif
 
 static NSUInteger SDDeviceTotalMemory() {
@@ -314,7 +314,7 @@ static NSUInteger SDDeviceFreeMemory() {
         if (error) {
             return NULL;
         }
-        CVDisplayLinkSetOutputCallback(_displayLink, renderCallback, (__bridge void *)self);
+        CVDisplayLinkSetOutputCallback(_displayLink, DisplayLinkCallback, (__bridge void *)self);
     }
     return _displayLink;
 }
@@ -792,7 +792,7 @@ static NSUInteger SDDeviceFreeMemory() {
 @end
 
 #if SD_MAC
-static CVReturn renderCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext) {
+static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext) {
     // CVDisplayLink callback is not on main queue
     SDAnimatedImageView *imageView = (__bridge SDAnimatedImageView *)displayLinkContext;
     __weak SDAnimatedImageView *weakImageView = imageView;

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -580,7 +580,7 @@ static NSUInteger SDDeviceFreeMemory() {
 }
 
 #if SD_MAC
-- (void)displayDidRefresh:(CVDisplayLinkRef)displayLink duration:(NSTimeInterval)duration
+- (void)displayDidRefresh:(CVDisplayLinkRef)displayLink
 #else
 - (void)displayDidRefresh:(CADisplayLink *)displayLink
 #endif
@@ -590,9 +590,16 @@ static NSUInteger SDDeviceFreeMemory() {
     if (!self.shouldAnimate) {
         return;
     }
-    
-#if SD_UIKIT
+    // Calculate refresh duration
+#if SD_MAC
+    CVTimeStamp nowTime;
+    CVDisplayLinkGetCurrentTime(displayLink, &nowTime);
+    NSTimeInterval duration = (double)nowTime.videoRefreshPeriod / ((double)nowTime.videoTimeScale * nowTime.rateScalar);
+#else
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSTimeInterval duration = displayLink.duration * displayLink.frameInterval;
+#pragma clang diagnostic pop
 #endif
     NSUInteger totalFrameCount = self.totalFrameCount;
     NSUInteger currentFrameIndex = self.currentFrameIndex;
@@ -786,13 +793,11 @@ static NSUInteger SDDeviceFreeMemory() {
 
 #if SD_MAC
 static CVReturn renderCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext) {
-    // Calculate refresh duration
-    NSTimeInterval duration = (double)inOutputTime->videoRefreshPeriod / ((double)inOutputTime->videoTimeScale * inOutputTime->rateScalar);
     // CVDisplayLink callback is not on main queue
     SDAnimatedImageView *imageView = (__bridge SDAnimatedImageView *)displayLinkContext;
     __weak SDAnimatedImageView *weakImageView = imageView;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [weakImageView displayDidRefresh:displayLink duration:duration];
+        [weakImageView displayDidRefresh:displayLink];
     });
     return kCVReturnSuccess;
 }

--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -269,6 +269,8 @@
 
 #define SD_MAX_FILE_EXTENSION_LENGTH (NAME_MAX - CC_MD5_DIGEST_LENGTH * 2 - 1)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static inline NSString * _Nonnull SDDiskCacheFileNameForKey(NSString * _Nullable key) {
     const char *str = key.UTF8String;
     if (str == NULL) {
@@ -287,5 +289,6 @@ static inline NSString * _Nonnull SDDiskCacheFileNameForKey(NSString * _Nullable
                           r[11], r[12], r[13], r[14], r[15], ext.length == 0 ? @"" : [NSString stringWithFormat:@".%@", ext]];
     return filename;
 }
+#pragma clang diagnostic pop
 
 @end

--- a/SDWebImage/Core/SDWebImageIndicator.m
+++ b/SDWebImage/Core/SDWebImageIndicator.m
@@ -47,10 +47,13 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 }
 
 #if SD_UIKIT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)commonInit {
     self.indicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
     self.indicatorView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
 }
+#pragma clang diagnostic pop
 #endif
 
 #if SD_MAC
@@ -85,6 +88,8 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 
 @implementation SDWebImageActivityIndicator (Conveniences)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (SDWebImageActivityIndicator *)grayIndicator {
     SDWebImageActivityIndicator *indicator = [SDWebImageActivityIndicator new];
 #if SD_UIKIT
@@ -168,6 +173,7 @@ static NSInteger UIActivityIndicatorViewStyleLarge = 101;
 #endif
     return indicator;
 }
+#pragma clang diagnostic pop
 
 @end
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: Fix #2859

### Pull Request Description

Just for fixing the warnings. All of them can not been solved with new API changes, reason:

+ `CC_MD5`
We can not change the algorithm to generate filename. This is a major break. And I don't think it's a deprecated, it's like a advice. Even Apple remove the `CC_MD5` method, we still need to write our own MD5 hash algorithm, this can not been changed.

+ `UIActivityIndicatorViewStyleWhite`
We can not change this. Because unlike Apple done for dark mode. If the user use `.whiteLarge` indicator, it's always white and large, whatever in dark / light mode (Read our documentation). It's different from Apple's design. But actually, these symbols can been removed in SDWebImage 6.0.0.
For the automatically dark mode support, use `.medium`, `.large` indicator which is introduced in SDWebImage 5.1.0 instead.

+ `frameInterval`
We can not change this. The animation use this to calculate the `last frame duration in real world`. But not means we need to render more frames or something related to this refresh rate changes. For example, GIF is 100 frames in 10s, 120Hz does not means we should play 200 frames in 10s. We're not the game which can insert transition frame 😅 
Actually, If your external screen refresh rate is 30Hz, the `duration` will be 32ms, the `frameInterval` is still 1, so result in 32ms, this is correct. When using the `preferredFramesPerSecond`, we can not get the same result. This also applied for iPad Pro's promotion display.