### PR TITLE
Revert the change for APNG constants fix for iOS 8 devices which cause crash

### DIFF
--- a/SDWebImage/Core/SDImageAPNGCoder.m
+++ b/SDWebImage/Core/SDImageAPNGCoder.m
@@ -14,19 +14,14 @@
 #endif
 
 // iOS 8 Image/IO framework binary does not contains these APNG contants, so we define them. Thanks Apple :)
-static NSString * kSDCGImagePropertyAPNGLoopCount = @"LoopCount";
-static NSString * kSDCGImagePropertyAPNGDelayTime = @"DelayTime";
-static NSString * kSDCGImagePropertyAPNGUnclampedDelayTime = @"UnclampedDelayTime";
+// We can not use runtime @available check for this issue, because it's a global symbol and should be loaded during launch time by dyld. So hack if the min deployment target version < iOS 9.0, whatever it running on iOS 9+ or not.
+#if (__IPHONE_OS_VERSION_MIN_REQUIRED && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
+const CFStringRef kCGImagePropertyAPNGLoopCount = (__bridge CFStringRef)@"LoopCount";
+const CFStringRef kCGImagePropertyAPNGDelayTime = (__bridge CFStringRef)@"DelayTime";
+const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef)@"UnclampedDelayTime";
+#endif
 
 @implementation SDImageAPNGCoder
-
-+ (void)initialize {
-    if (@available(iOS 9, *)) {
-        kSDCGImagePropertyAPNGLoopCount = (__bridge NSString *)kCGImagePropertyAPNGLoopCount;
-        kSDCGImagePropertyAPNGDelayTime = (__bridge NSString *)kCGImagePropertyAPNGDelayTime;
-        kSDCGImagePropertyAPNGUnclampedDelayTime = (__bridge NSString *)kCGImagePropertyAPNGUnclampedDelayTime;
-    }
-}
 
 + (instancetype)sharedCoder {
     static SDImageAPNGCoder *coder;
@@ -52,15 +47,15 @@ static NSString * kSDCGImagePropertyAPNGUnclampedDelayTime = @"UnclampedDelayTim
 }
 
 + (NSString *)unclampedDelayTimeProperty {
-    return kSDCGImagePropertyAPNGUnclampedDelayTime;
+    return (__bridge NSString *)kCGImagePropertyAPNGUnclampedDelayTime;
 }
 
 + (NSString *)delayTimeProperty {
-    return kSDCGImagePropertyAPNGDelayTime;
+    return (__bridge NSString *)kCGImagePropertyAPNGDelayTime;
 }
 
 + (NSString *)loopCountProperty {
-    return kSDCGImagePropertyAPNGLoopCount;
+    return (__bridge NSString *)kCGImagePropertyAPNGLoopCount;
 }
 
 + (NSUInteger)defaultLoopCount {


### PR DESCRIPTION
use previous deployment target macro check instead of runtime firmware version check

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2862 

### Pull Request Description

This fix the regression of that #2862

