### PR TITLE
Feature response modifier data decrypter

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -63,6 +63,10 @@
 		325312CA200F09910046BF1E /* SDWebImageTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 325312C6200F09910046BF1E /* SDWebImageTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		325312CE200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D0200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
+		32542763235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */; };
+		32542764235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */; };
+		32542765235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */; };
+		325427662355783C0042BAA4 /* SDWebImageDownloaderResponseModifier.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */; };
 		3257EAFA21898AED0097B271 /* SDImageGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257EAF721898AED0097B271 /* SDImageGraphics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3257EAFC21898AED0097B271 /* SDImageGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257EAF821898AED0097B271 /* SDImageGraphics.m */; };
 		3257EAFD21898AED0097B271 /* SDImageGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257EAF821898AED0097B271 /* SDImageGraphics.m */; };
@@ -280,6 +284,7 @@
 			dstPath = include/SDWebImage;
 			dstSubfolderSpec = 16;
 			files = (
+				325427662355783C0042BAA4 /* SDWebImageDownloaderResponseModifier.h in Copy Headers */,
 				3298655F233723220071958B /* SDImageHEICCoder.h in Copy Headers */,
 				32C78E3823336FC800C6B7F8 /* SDImageIOAnimatedCoder.h in Copy Headers */,
 				32E5690822B1FFCA00CBABC6 /* SDWebImageOptionsProcessor.h in Copy Headers */,
@@ -370,6 +375,8 @@
 		324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDefine.m; path = Core/SDWebImageDefine.m; sourceTree = "<group>"; };
 		325312C6200F09910046BF1E /* SDWebImageTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageTransition.h; path = Core/SDWebImageTransition.h; sourceTree = "<group>"; };
 		325312C7200F09910046BF1E /* SDWebImageTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageTransition.m; path = Core/SDWebImageTransition.m; sourceTree = "<group>"; };
+		32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderResponseModifier.h; path = Core/SDWebImageDownloaderResponseModifier.h; sourceTree = "<group>"; };
+		32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloaderResponseModifier.m; path = Core/SDWebImageDownloaderResponseModifier.m; sourceTree = "<group>"; };
 		3257EAF721898AED0097B271 /* SDImageGraphics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDImageGraphics.h; path = Core/SDImageGraphics.h; sourceTree = "<group>"; };
 		3257EAF821898AED0097B271 /* SDImageGraphics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDImageGraphics.m; path = Core/SDImageGraphics.m; sourceTree = "<group>"; };
 		325C460022339330004CAE11 /* SDImageAssetManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDImageAssetManager.h; sourceTree = "<group>"; };
@@ -757,6 +764,8 @@
 				32B9B536206ED4230026769D /* SDWebImageDownloaderConfig.m */,
 				32F21B4F20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h */,
 				32F21B5020788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m */,
+				32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */,
+				32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */,
 				321B377D2083290D00C0EA77 /* SDImageLoader.h */,
 				321B377E2083290D00C0EA77 /* SDImageLoader.m */,
 				321B377F2083290E00C0EA77 /* SDImageLoadersManager.h */,
@@ -833,6 +842,7 @@
 				4A2CAE181AB4BB6400B6BC39 /* SDWebImageCompat.h in Headers */,
 				4A2CAE331AB4BB7500B6BC39 /* UIImageView+HighlightedWebCache.h in Headers */,
 				328BB6C32082581100760D6C /* SDDiskCache.h in Headers */,
+				32542763235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h in Headers */,
 				4A2CAE1D1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.h in Headers */,
 				4A2CAE2B1AB4BB7500B6BC39 /* UIButton+WebCache.h in Headers */,
 				4A2CAE251AB4BB7000B6BC39 /* SDWebImagePrefetcher.h in Headers */,
@@ -1073,6 +1083,7 @@
 				3298655E2337230C0071958B /* SDImageHEICCoder.m in Sources */,
 				32F7C0802030719600873181 /* UIImage+Transform.m in Sources */,
 				327054DC206CD8B3006EA328 /* SDImageAPNGCoder.m in Sources */,
+				32542765235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */,
 				325312D0200F09910046BF1E /* SDWebImageTransition.m in Sources */,
 				321E609C1F38E8ED00405457 /* SDImageIOCoder.m in Sources */,
 				4A2CAE261AB4BB7000B6BC39 /* SDWebImagePrefetcher.m in Sources */,
@@ -1138,6 +1149,7 @@
 				3298655D2337230C0071958B /* SDImageHEICCoder.m in Sources */,
 				321E609A1F38E8ED00405457 /* SDImageIOCoder.m in Sources */,
 				327054DA206CD8B3006EA328 /* SDImageAPNGCoder.m in Sources */,
+				32542764235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */,
 				325312CE200F09910046BF1E /* SDWebImageTransition.m in Sources */,
 				5376130C155AD0D5005750A4 /* SDWebImageManager.m in Sources */,
 				5376130D155AD0D5005750A4 /* SDWebImagePrefetcher.m in Sources */,

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -63,7 +63,7 @@
 		325312CA200F09910046BF1E /* SDWebImageTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 325312C6200F09910046BF1E /* SDWebImageTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		325312CE200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D0200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
-		32542763235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */; };
+		32542763235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32542764235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */; };
 		32542765235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */; };
 		325427662355783C0042BAA4 /* SDWebImageDownloaderResponseModifier.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */; };

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		324DF4B6200A14DC008A84CC /* SDWebImageDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 324DF4B2200A14DC008A84CC /* SDWebImageDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		324DF4BA200A14DC008A84CC /* SDWebImageDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */; };
 		324DF4BC200A14DC008A84CC /* SDWebImageDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */; };
+		3250C9EE2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 3250C9EC2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3250C9EF2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250C9ED2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m */; };
+		3250C9F02355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3250C9ED2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m */; };
+		3250C9F12355E3DF0093A896 /* SDWebImageDownloaderDecryptor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3250C9EC2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h */; };
 		325312CA200F09910046BF1E /* SDWebImageTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 325312C6200F09910046BF1E /* SDWebImageTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		325312CE200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D0200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
@@ -284,6 +288,7 @@
 			dstPath = include/SDWebImage;
 			dstSubfolderSpec = 16;
 			files = (
+				3250C9F12355E3DF0093A896 /* SDWebImageDownloaderDecryptor.h in Copy Headers */,
 				325427662355783C0042BAA4 /* SDWebImageDownloaderResponseModifier.h in Copy Headers */,
 				3298655F233723220071958B /* SDImageHEICCoder.h in Copy Headers */,
 				32C78E3823336FC800C6B7F8 /* SDImageIOAnimatedCoder.h in Copy Headers */,
@@ -373,6 +378,8 @@
 		3248475C201775F600AF9E5A /* SDAnimatedImageView+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SDAnimatedImageView+WebCache.m"; path = "Core/SDAnimatedImageView+WebCache.m"; sourceTree = "<group>"; };
 		324DF4B2200A14DC008A84CC /* SDWebImageDefine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageDefine.h; path = Core/SDWebImageDefine.h; sourceTree = "<group>"; };
 		324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDefine.m; path = Core/SDWebImageDefine.m; sourceTree = "<group>"; };
+		3250C9EC2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderDecryptor.h; path = Core/SDWebImageDownloaderDecryptor.h; sourceTree = "<group>"; };
+		3250C9ED2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloaderDecryptor.m; path = Core/SDWebImageDownloaderDecryptor.m; sourceTree = "<group>"; };
 		325312C6200F09910046BF1E /* SDWebImageTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageTransition.h; path = Core/SDWebImageTransition.h; sourceTree = "<group>"; };
 		325312C7200F09910046BF1E /* SDWebImageTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageTransition.m; path = Core/SDWebImageTransition.m; sourceTree = "<group>"; };
 		32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderResponseModifier.h; path = Core/SDWebImageDownloaderResponseModifier.h; sourceTree = "<group>"; };
@@ -766,6 +773,8 @@
 				32F21B5020788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m */,
 				32542761235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.h */,
 				32542762235576E20042BAA4 /* SDWebImageDownloaderResponseModifier.m */,
+				3250C9EC2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h */,
+				3250C9ED2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m */,
 				321B377D2083290D00C0EA77 /* SDImageLoader.h */,
 				321B377E2083290D00C0EA77 /* SDImageLoader.m */,
 				321B377F2083290E00C0EA77 /* SDImageLoadersManager.h */,
@@ -864,6 +873,7 @@
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
 				3248476B201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				32D122322080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
+				3250C9EE2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.h in Headers */,
 				32F7C0862030719600873181 /* UIImage+Transform.h in Headers */,
 				321E60C01F38E91700405457 /* UIImage+ForceDecode.h in Headers */,
 				329F1243223FAD3400B309FD /* SDInternalMacros.h in Headers */,
@@ -1064,6 +1074,7 @@
 				325C46232233A02E004CAE11 /* UIColor+HexString.m in Sources */,
 				321E60C61F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				3244062E2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */,
+				3250C9F02355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */,
 				328BB6A42081FED200760D6C /* SDWebImageCacheKeyFilter.m in Sources */,
 				4A2CAE2E1AB4BB7500B6BC39 /* UIImage+GIF.m in Sources */,
 				80B6DF822142B44400BCB334 /* NSButton+WebCache.m in Sources */,
@@ -1130,6 +1141,7 @@
 				325C46222233A02E004CAE11 /* UIColor+HexString.m in Sources */,
 				321E60C41F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				3244062D2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */,
+				3250C9EF2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */,
 				328BB6A22081FED200760D6C /* SDWebImageCacheKeyFilter.m in Sources */,
 				53761309155AD0D5005750A4 /* SDImageCache.m in Sources */,
 				80B6DF832142B44500BCB334 /* NSButton+WebCache.m in Sources */,

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -234,7 +234,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextAnimat
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadRequestModifier;
 
 /**
- A id<SDWebImageDownloaderResponseModifier> instance to modify the image download response and download data. It's used for downloader to modify the original response and data from URL and options. This can be used for image data decryption, such as Gzipped image. If you provide one, it will ignore the `responseModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderResponseModifier>)
+ A id<SDWebImageDownloaderResponseModifier> instance to modify the image download response and download data. It's used for downloader to modify the original response and data from URL and options. This can be used for image data decryption, such as Base64 encoded image. If you provide one, it will ignore the `responseModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderResponseModifier>)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadResponseModifier;
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -234,9 +234,14 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextAnimat
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadRequestModifier;
 
 /**
- A id<SDWebImageDownloaderResponseModifier> instance to modify the image download response and download data. It's used for downloader to modify the original response and data from URL and options. This can be used for image data decryption, such as Base64 encoded image. If you provide one, it will ignore the `responseModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderResponseModifier>)
+ A id<SDWebImageDownloaderResponseModifier> instance to modify the image download response. It's used for downloader to modify the original response from URL and options.  If you provide one, it will ignore the `responseModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderResponseModifier>)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadResponseModifier;
+
+/**
+ A id<SDWebImageContextDownloadDecryptor> instance to decrypt the image download data. This can be used for image data decryption, such as Base64 encoded image. If you provide one, it will ignore the `decryptor` in downloader and use provided one instead. (id<SDWebImageContextDownloadDecryptor>)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadDecryptor;
 
 /**
  A id<SDWebImageCacheKeyFilter> instance to convert an URL into a cache key. It's used when manager need cache key to use image cache. If you provide one, it will ignore the `cacheKeyFilter` in manager and use provided one instead. (id<SDWebImageCacheKeyFilter>)

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -234,6 +234,11 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextAnimat
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadRequestModifier;
 
 /**
+ A id<SDWebImageDownloaderResponseModifier> instance to modify the image download response and download data. It's used for downloader to modify the original response and data from URL and options. This can be used for image data decryption, such as Gzipped image. If you provide one, it will ignore the `responseModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderResponseModifier>)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextDownloadResponseModifier;
+
+/**
  A id<SDWebImageCacheKeyFilter> instance to convert an URL into a cache key. It's used when manager need cache key to use image cache. If you provide one, it will ignore the `cacheKeyFilter` in manager and use provided one instead. (id<SDWebImageCacheKeyFilter>)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextCacheKeyFilter;

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -126,5 +126,6 @@ SDWebImageContextOption const SDWebImageContextStoreCacheType = @"storeCacheType
 SDWebImageContextOption const SDWebImageContextOriginalStoreCacheType = @"originalStoreCacheType";
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";
 SDWebImageContextOption const SDWebImageContextDownloadRequestModifier = @"downloadRequestModifier";
+SDWebImageContextOption const SDWebImageContextDownloadResponseModifier = @"downloadResponseModifier";
 SDWebImageContextOption const SDWebImageContextCacheKeyFilter = @"cacheKeyFilter";
 SDWebImageContextOption const SDWebImageContextCacheSerializer = @"cacheSerializer";

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -127,5 +127,6 @@ SDWebImageContextOption const SDWebImageContextOriginalStoreCacheType = @"origin
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";
 SDWebImageContextOption const SDWebImageContextDownloadRequestModifier = @"downloadRequestModifier";
 SDWebImageContextOption const SDWebImageContextDownloadResponseModifier = @"downloadResponseModifier";
+SDWebImageContextOption const SDWebImageContextDownloadDecryptor = @"downloadDecryptor";
 SDWebImageContextOption const SDWebImageContextCacheKeyFilter = @"cacheKeyFilter";
 SDWebImageContextOption const SDWebImageContextCacheSerializer = @"cacheSerializer";

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -150,7 +150,7 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 @property (nonatomic, strong, nullable) id<SDWebImageDownloaderRequestModifier> requestModifier;
 
 /**
- * Set the response modifier to modify the original download response or download data before decoding.  This can be used for image data decryption, such as Gzipped image.
+ * Set the response modifier to modify the original download response or download data before decoding.  This can be used for image data decryption, such as Base64 encoded image.
  * This request modifier method will be called for each downloading image response. Return the original response or data means no modication. Return nil from either response or data, will mark this download failed, pay attention to this.
  * Defaults to nil, means does not modify the original download response or download data.
  * @note If you want to modify single response, consider using `SDWebImageContextDownloadResponseModifier` context option.

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -143,7 +143,7 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 
 /**
  * Set the request modifier to modify the original download request before image load.
- * This request modifier method will be called for each downloading image request. Return the original request means no modication. Return nil will cancel the download request.
+ * This request modifier method will be called for each downloading image request. Return the original request means no modification. Return nil will cancel the download request.
  * Defaults to nil, means does not modify the original download request.
  * @note If you want to modify single request, consider using `SDWebImageContextDownloadRequestModifier` context option.
  */
@@ -151,7 +151,7 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 
 /**
  * Set the response modifier to modify the original download response or download data before decoding.  This can be used for image data decryption, such as Base64 encoded image.
- * This request modifier method will be called for each downloading image response. Return the original response or data means no modication. Return nil from either response or data, will mark this download failed, pay attention to this.
+ * This request modifier method will be called for each downloading image response. Return the original response or data means no modification. Return nil from either response or data, will mark this download failed.
  * Defaults to nil, means does not modify the original download response or download data.
  * @note If you want to modify single response, consider using `SDWebImageContextDownloadResponseModifier` context option.
  */

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -13,6 +13,7 @@
 #import "SDWebImageDownloaderConfig.h"
 #import "SDWebImageDownloaderRequestModifier.h"
 #import "SDWebImageDownloaderResponseModifier.h"
+#import "SDWebImageDownloaderDecryptor.h"
 #import "SDImageLoader.h"
 
 /// Downloader options
@@ -150,12 +151,21 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 @property (nonatomic, strong, nullable) id<SDWebImageDownloaderRequestModifier> requestModifier;
 
 /**
- * Set the response modifier to modify the original download response or download data before decoding.  This can be used for image data decryption, such as Base64 encoded image.
- * This request modifier method will be called for each downloading image response. Return the original response or data means no modification. Return nil from either response or data, will mark this download failed.
- * Defaults to nil, means does not modify the original download response or download data.
+ * Set the response modifier to modify the original download response during image load.
+ * This request modifier method will be called for each downloading image response. Return the original response means no modification. Return nil will mark current download as cancelled.
+ * Defaults to nil, means does not modify the original download response.
  * @note If you want to modify single response, consider using `SDWebImageContextDownloadResponseModifier` context option.
  */
 @property (nonatomic, strong, nullable) id<SDWebImageDownloaderResponseModifier> responseModifier;
+
+/**
+ * Set the decryptor to decrypt the original download data before image decoding. This can be used for encrypted image data, like Base64.
+ * This decryptor method will be called for each downloading image data. Return the original data means no modification. Return nil will mark this download failed.
+ * Defaults to nil, means does not modify the original download data.
+ * @note When using decryptor, progressive decoding will be disabled, to avoid data corrupt issue.
+ * @note If you want to decrypt single download data, consider using `SDWebImageContextDownloadDecryptor` context option.
+ */
+@property (nonatomic, strong, nullable) id<SDWebImageDownloaderDecryptor> decryptor;
 
 /**
  * The configuration in use by the internal NSURLSession. If you want to provide a custom sessionConfiguration, use `SDWebImageDownloaderConfig.sessionConfiguration` and create a new downloader instance.

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -12,6 +12,7 @@
 #import "SDWebImageOperation.h"
 #import "SDWebImageDownloaderConfig.h"
 #import "SDWebImageDownloaderRequestModifier.h"
+#import "SDWebImageDownloaderResponseModifier.h"
 #import "SDImageLoader.h"
 
 /// Downloader options
@@ -147,6 +148,14 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
  * @note If you want to modify single request, consider using `SDWebImageContextDownloadRequestModifier` context option.
  */
 @property (nonatomic, strong, nullable) id<SDWebImageDownloaderRequestModifier> requestModifier;
+
+/**
+ * Set the response modifier to modify the original download response or download data before decoding.  This can be used for image data decryption, such as Gzipped image.
+ * This request modifier method will be called for each downloading image response. Return the original response or data means no modication. Return nil from either response or data, will mark this download failed, pay attention to this.
+ * Defaults to nil, means does not modify the original download response or download data.
+ * @note If you want to modify single response, consider using `SDWebImageContextDownloadResponseModifier` context option.
+ */
+@property (nonatomic, strong, nullable) id<SDWebImageDownloaderResponseModifier> responseModifier;
 
 /**
  * The configuration in use by the internal NSURLSession. If you want to provide a custom sessionConfiguration, use `SDWebImageDownloaderConfig.sessionConfiguration` and create a new downloader instance.

--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -272,6 +272,15 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     SD_LOCK(self.HTTPHeadersLock);
     mutableRequest.allHTTPHeaderFields = self.HTTPHeaders;
     SD_UNLOCK(self.HTTPHeadersLock);
+    
+    // Context Option
+    SDWebImageMutableContext *mutableContext;
+    if (context) {
+        mutableContext = [context mutableCopy];
+    } else {
+        mutableContext = [NSMutableDictionary dictionary];
+    }
+    
     // Request Modifier
     id<SDWebImageDownloaderRequestModifier> requestModifier;
     if ([context valueForKey:SDWebImageContextDownloadRequestModifier]) {
@@ -299,17 +308,22 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     } else {
         responseModifier = self.responseModifier;
     }
-    
     if (responseModifier) {
-        SDWebImageMutableContext *mutableContext;
-        if (context) {
-            mutableContext = [context mutableCopy];
-        } else {
-            mutableContext = [NSMutableDictionary dictionary];
-        }
         mutableContext[SDWebImageContextDownloadResponseModifier] = responseModifier;
-        context = [mutableContext copy];
     }
+    // Decryptor
+    id<SDWebImageDownloaderDecryptor> decryptor;
+    if ([context valueForKey:SDWebImageContextDownloadDecryptor]) {
+        decryptor = [context valueForKey:SDWebImageContextDownloadDecryptor];
+    } else {
+        decryptor = self.decryptor;
+    }
+    if (decryptor) {
+        mutableContext[SDWebImageContextDownloadDecryptor] = decryptor;
+    }
+    
+    context = [mutableContext copy];
+    
     // Operation Class
     Class operationClass = self.config.operationClass;
     if (operationClass && [operationClass isSubclassOfClass:[NSOperation class]] && [operationClass conformsToProtocol:@protocol(SDWebImageDownloaderOperation)]) {

--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -272,6 +272,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     SD_LOCK(self.HTTPHeadersLock);
     mutableRequest.allHTTPHeaderFields = self.HTTPHeaders;
     SD_UNLOCK(self.HTTPHeadersLock);
+    // Request Modifier
     id<SDWebImageDownloaderRequestModifier> requestModifier;
     if ([context valueForKey:SDWebImageContextDownloadRequestModifier]) {
         requestModifier = [context valueForKey:SDWebImageContextDownloadRequestModifier];
@@ -291,6 +292,25 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     } else {
         request = [mutableRequest copy];
     }
+    // Response Modifier
+    id<SDWebImageDownloaderResponseModifier> responseModifier;
+    if ([context valueForKey:SDWebImageContextDownloadResponseModifier]) {
+        responseModifier = [context valueForKey:SDWebImageContextDownloadResponseModifier];
+    } else {
+        responseModifier = self.responseModifier;
+    }
+    
+    if (responseModifier) {
+        SDWebImageMutableContext *mutableContext;
+        if (context) {
+            mutableContext = [context mutableCopy];
+        } else {
+            mutableContext = [NSMutableDictionary dictionary];
+        }
+        mutableContext[SDWebImageContextDownloadResponseModifier] = responseModifier;
+        context = [mutableContext copy];
+    }
+    // Operation Class
     Class operationClass = self.config.operationClass;
     if (operationClass && [operationClass isSubclassOfClass:[NSOperation class]] && [operationClass conformsToProtocol:@protocol(SDWebImageDownloaderOperation)]) {
         // Custom operation class

--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
@@ -19,8 +19,8 @@ We can use a block to specify the downloader decryptor. But Using protocol can m
 
 /// Decrypt the original download data and return a new data. You can use this to decrypt the data using your perfereed algorithm.
 /// @param data The original download data
-/// @param response The URL response for data. If you modifiy the original URL response via response modifier, the modified version will be here . This arg is nullable.
-/// @note If nil is returned, the image download will marked as failed with error `SDWebImageErrorBadImageData`
+/// @param response The URL response for data. If you modifiy the original URL response via response modifier, the modified version will be here. This arg is nullable.
+/// @note If nil is returned, the image download will be marked as failed with error `SDWebImageErrorBadImageData`
 - (nullable NSData *)decryptedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
@@ -1,0 +1,44 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import <Foundation/Foundation.h>
+#import "SDWebImageCompat.h"
+
+typedef NSData * _Nullable (^SDWebImageDownloaderDecryptorBlock)(NSData * _Nonnull data, NSURLResponse * _Nullable response);
+
+/**
+This is the protocol for downloader decryptor. Which decrypt the original encrypted data before decoding. Note progressive decoding is not compatible for decryptor.
+We can use a block to specify the downloader decryptor. But Using protocol can make this extensible, and allow Swift user to use it easily instead of using `@convention(block)` to store a block into context options.
+*/
+@protocol SDWebImageDownloaderDecryptor <NSObject>
+
+/// Decrypt the original download data and return a new data. You can use this to decrypt the data using your perfereed algorithm.
+/// @param data The original download data
+/// @param response The URL response for data. If you modifiy the original URL response via response modifier, the modified version will be here . This arg is nullable.
+/// @note If nil is returned, the image download will marked as failed with error `SDWebImageErrorBadImageData`
+- (nullable NSData *)decryptedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response;
+
+@end
+
+/**
+A downloader response modifier class with block.
+*/
+@interface SDWebImageDownloaderDecryptor : NSObject <SDWebImageDownloaderDecryptor>
+
+- (nonnull instancetype)initWithBlock:(nonnull SDWebImageDownloaderDecryptorBlock)block;
++ (nonnull instancetype)decryptorWithBlock:(nonnull SDWebImageDownloaderDecryptorBlock)block;
+
+@end
+
+/// Convenience way to create decryptor for common data encryption.
+@interface SDWebImageDownloaderDecryptor (Conveniences)
+
+/// Base64 Encoded image data decryptor
+@property (class, readonly, nonnull) SDWebImageDownloaderDecryptor *base64Decryptor;
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.m
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.m
@@ -1,0 +1,55 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import "SDWebImageDownloaderDecryptor.h"
+
+@interface SDWebImageDownloaderDecryptor ()
+
+@property (nonatomic, copy, nonnull) SDWebImageDownloaderDecryptorBlock block;
+
+@end
+
+@implementation SDWebImageDownloaderDecryptor
+
+- (instancetype)initWithBlock:(SDWebImageDownloaderDecryptorBlock)block {
+    self = [super init];
+    if (self) {
+        self.block = block;
+    }
+    return self;
+}
+
++ (instancetype)decryptorWithBlock:(SDWebImageDownloaderDecryptorBlock)block {
+    SDWebImageDownloaderDecryptor *decryptor = [[SDWebImageDownloaderDecryptor alloc] initWithBlock:block];
+    return decryptor;
+}
+
+- (nullable NSData *)decryptedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response {
+    if (!self.block) {
+        return nil;
+    }
+    return self.block(data, response);
+}
+
+@end
+
+@implementation SDWebImageDownloaderDecryptor (Conveniences)
+
++ (SDWebImageDownloaderDecryptor *)base64Decryptor {
+    static SDWebImageDownloaderDecryptor *decryptor;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        decryptor = [SDWebImageDownloaderDecryptor decryptorWithBlock:^NSData * _Nullable(NSData * _Nonnull data, NSURLResponse * _Nullable response) {
+            NSData *modifiedData = [[NSData alloc] initWithBase64EncodedData:data options:NSDataBase64DecodingIgnoreUnknownCharacters];
+            return modifiedData;
+        }];
+    });
+    return decryptor;
+}
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -77,6 +77,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
         _request = [request copy];
         _options = options;
         _context = [context copy];
+        _responseModifier = context[SDWebImageContextDownloadResponseModifier];
         _callbackBlocks = [NSMutableArray new];
         _executing = NO;
         _finished = NO;

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -17,6 +17,9 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
  */
 @protocol SDWebImageDownloaderRequestModifier <NSObject>
 
+/// Modify the original URL request and return a new one instead. You can modify the HTTP header, cachePolicy, etc for this URL.
+/// @param request The original URL request for image loading
+/// @note If return nil, the URL request will be cancelled.
 - (nullable NSURLRequest *)modifiedRequestWithRequest:(nonnull NSURLRequest *)request;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -32,3 +32,12 @@ typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSDa
 + (nonnull instancetype)responseModifierWithResponseBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(nonnull SDWebImageDownloaderResponseModifierDataBlock)dataBlock;
 
 @end
+
+
+/// Convenience way to create response modifier for common data encryption.
+@interface SDWebImageDownloaderResponseModifier (Conveniences)
+
+/// Base64 Encoded image data
+@property (class, readonly, nonnull) SDWebImageDownloaderResponseModifier *base64ResponseModifier;
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -10,19 +10,12 @@
 #import "SDWebImageCompat.h"
 
 typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(NSURLResponse * _Nonnull response);
-typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSData * _Nonnull data, NSURLResponse * _Nullable response);
 
 /**
  This is the protocol for downloader response modifier.
  We can use a block to specify the downloader response modifier. But Using protocol can make this extensible, and allow Swift user to use it easily instead of using `@convention(block)` to store a block into context options.
  */
 @protocol SDWebImageDownloaderResponseModifier <NSObject>
-
-/// Modify the original download data and return a new data. You can use this to decrypt the data using your perfereed algorithm.
-/// @param data The original download data
-/// @param response The URL response for data. If you modifiy the original URL response via the method below, the modified version will be here . This arg is nullable.
-/// @note If nil is returned, the image download will marked as failed with error `SDWebImageErrorBadImageData`
-- (nullable NSData *)modifiedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response;
 
 /// Modify the original URL response and return a new response. You can use this to check MIME-Type, mock server response, etc.
 /// @param response The original URL response, note for HTTP request it's actually a `NSHTTPURLResponse` instance
@@ -36,16 +29,7 @@ typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSDa
  */
 @interface SDWebImageDownloaderResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
 
-- (nonnull instancetype)initWithResponseBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(nonnull SDWebImageDownloaderResponseModifierDataBlock)dataBlock;
-+ (nonnull instancetype)responseModifierWithResponseBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(nonnull SDWebImageDownloaderResponseModifierDataBlock)dataBlock;
-
-@end
-
-
-/// Convenience way to create response modifier for common data encryption.
-@interface SDWebImageDownloaderResponseModifier (Conveniences)
-
-/// Base64 Encoded image data decrypter
-@property (class, readonly, nonnull) SDWebImageDownloaderResponseModifier *base64ResponseModifier;
+- (nonnull instancetype)initWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
++ (nonnull instancetype)responseModifierWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <Foundation/Foundation.h>
+#import "SDWebImageCompat.h"
+
+typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(NSURLResponse * _Nonnull response);
+typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSData * _Nonnull data, NSURLResponse * _Nullable response);
+
+/**
+ This is the protocol for downloader response modifier.
+ We can use a block to specify the downloader response modifier. But Using protocol can make this extensible, and allow Swift user to use it easily instead of using `@convention(block)` to store a block into context options.
+ */
+@protocol SDWebImageDownloaderResponseModifier <NSObject>
+
+- (nullable NSData *)modifiedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response;
+- (nullable NSURLResponse *)modifiedResponseWithResponse:(nonnull NSURLResponse *)response;
+
+@end
+
+/**
+ A downloader response modifier class with block.
+ */
+@interface SDWebImageDownloaderResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
+
+- (nonnull instancetype)initWithResponseBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(nonnull SDWebImageDownloaderResponseModifierDataBlock)dataBlock;
++ (nonnull instancetype)responseModifierWithResponseBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(nonnull SDWebImageDownloaderResponseModifierDataBlock)dataBlock;
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -18,7 +18,15 @@ typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSDa
  */
 @protocol SDWebImageDownloaderResponseModifier <NSObject>
 
+/// Modify the original download data and return a new data. You can use this to decrypt the data using your perfereed algorithm.
+/// @param data The original download data
+/// @param response The URL response for data. If you modifiy the original URL response via the method below, the modified version will be here . This arg is nullable.
+/// @note If nil is returned, the image download will marked as failed with error `SDWebImageErrorBadImageData`
 - (nullable NSData *)modifiedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response;
+
+/// Modify the original URL response and return a new response. You can use this to check MIME-Type, mock server response, etc.
+/// @param response The original URL response, note for HTTP request it's actually a `NSHTTPURLResponse` instance
+/// @note If nil is returned, the image download will marked as cancelled with error `SDWebImageErrorInvalidDownloadResponse`
 - (nullable NSURLResponse *)modifiedResponseWithResponse:(nonnull NSURLResponse *)response;
 
 @end
@@ -37,7 +45,7 @@ typedef NSData * _Nullable (^SDWebImageDownloaderResponseModifierDataBlock)(NSDa
 /// Convenience way to create response modifier for common data encryption.
 @interface SDWebImageDownloaderResponseModifier (Conveniences)
 
-/// Base64 Encoded image data
+/// Base64 Encoded image data decrypter
 @property (class, readonly, nonnull) SDWebImageDownloaderResponseModifier *base64ResponseModifier;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -1,0 +1,49 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+
+#import "SDWebImageDownloaderResponseModifier.h"
+
+@interface SDWebImageDownloaderResponseModifier ()
+
+@property (nonatomic, copy, nonnull) SDWebImageDownloaderResponseModifierBlock responseBlock;
+@property (nonatomic, copy, nonnull) SDWebImageDownloaderResponseModifierDataBlock dataBlock;
+
+@end
+
+@implementation SDWebImageDownloaderResponseModifier
+
+- (instancetype)initWithResponseBlock:(SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(SDWebImageDownloaderResponseModifierDataBlock)dataBlock {
+    self = [super init];
+    if (self) {
+        self.responseBlock = responseBlock;
+        self.dataBlock = dataBlock;
+    }
+    return self;
+}
+
++ (instancetype)responseModifierWithResponseBlock:(SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(SDWebImageDownloaderResponseModifierDataBlock)dataBlock {
+    SDWebImageDownloaderResponseModifier *responseModifier = [[SDWebImageDownloaderResponseModifier alloc] initWithResponseBlock:responseBlock dataBlock:dataBlock];
+    return responseModifier;
+}
+
+- (nullable NSData *)modifiedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response {
+    if (!self.dataBlock) {
+        return nil;
+    }
+    return self.dataBlock(data, response);
+}
+
+- (nullable NSURLResponse *)modifiedResponseWithResponse:(nonnull NSURLResponse *)response {
+    if (!self.responseBlock) {
+        return nil;
+    }
+    return self.responseBlock(response);
+}
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -47,3 +47,21 @@
 }
 
 @end
+
+
+@implementation SDWebImageDownloaderResponseModifier (Conveniences)
+
++ (SDWebImageDownloaderResponseModifier *)base64ResponseModifier {
+    static SDWebImageDownloaderResponseModifier *responseModifier;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        responseModifier = [SDWebImageDownloaderResponseModifier responseModifierWithResponseBlock:^NSURLResponse * _Nullable(NSURLResponse * _Nonnull response) {
+            return response;
+        } dataBlock:^NSData * _Nullable(NSData * _Nonnull data, NSURLResponse * _Nullable response) {
+            return [[NSData alloc] initWithBase64EncodedData:data options:NSDataBase64DecodingIgnoreUnknownCharacters];
+        }];
+    });
+    return responseModifier;
+}
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -58,7 +58,8 @@
         responseModifier = [SDWebImageDownloaderResponseModifier responseModifierWithResponseBlock:^NSURLResponse * _Nullable(NSURLResponse * _Nonnull response) {
             return response;
         } dataBlock:^NSData * _Nullable(NSData * _Nonnull data, NSURLResponse * _Nullable response) {
-            return [[NSData alloc] initWithBase64EncodedData:data options:NSDataBase64DecodingIgnoreUnknownCharacters];
+            NSData *modifiedData = [[NSData alloc] initWithBase64EncodedData:data options:NSDataBase64DecodingIgnoreUnknownCharacters];
+            return modifiedData;
         }];
     });
     return responseModifier;

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -11,58 +11,30 @@
 
 @interface SDWebImageDownloaderResponseModifier ()
 
-@property (nonatomic, copy, nonnull) SDWebImageDownloaderResponseModifierBlock responseBlock;
-@property (nonatomic, copy, nonnull) SDWebImageDownloaderResponseModifierDataBlock dataBlock;
+@property (nonatomic, copy, nonnull) SDWebImageDownloaderResponseModifierBlock block;
 
 @end
 
 @implementation SDWebImageDownloaderResponseModifier
 
-- (instancetype)initWithResponseBlock:(SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(SDWebImageDownloaderResponseModifierDataBlock)dataBlock {
+- (instancetype)initWithBlock:(SDWebImageDownloaderResponseModifierBlock)block {
     self = [super init];
     if (self) {
-        self.responseBlock = responseBlock;
-        self.dataBlock = dataBlock;
+        self.block = block;
     }
     return self;
 }
 
-+ (instancetype)responseModifierWithResponseBlock:(SDWebImageDownloaderResponseModifierBlock)responseBlock dataBlock:(SDWebImageDownloaderResponseModifierDataBlock)dataBlock {
-    SDWebImageDownloaderResponseModifier *responseModifier = [[SDWebImageDownloaderResponseModifier alloc] initWithResponseBlock:responseBlock dataBlock:dataBlock];
++ (instancetype)responseModifierWithBlock:(SDWebImageDownloaderResponseModifierBlock)block {
+    SDWebImageDownloaderResponseModifier *responseModifier = [[SDWebImageDownloaderResponseModifier alloc] initWithBlock:block];
     return responseModifier;
-}
-
-- (nullable NSData *)modifiedDataWithData:(nonnull NSData *)data response:(nullable NSURLResponse *)response {
-    if (!self.dataBlock) {
-        return nil;
-    }
-    return self.dataBlock(data, response);
 }
 
 - (nullable NSURLResponse *)modifiedResponseWithResponse:(nonnull NSURLResponse *)response {
-    if (!self.responseBlock) {
+    if (!self.block) {
         return nil;
     }
-    return self.responseBlock(response);
-}
-
-@end
-
-
-@implementation SDWebImageDownloaderResponseModifier (Conveniences)
-
-+ (SDWebImageDownloaderResponseModifier *)base64ResponseModifier {
-    static SDWebImageDownloaderResponseModifier *responseModifier;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        responseModifier = [SDWebImageDownloaderResponseModifier responseModifierWithResponseBlock:^NSURLResponse * _Nullable(NSURLResponse * _Nonnull response) {
-            return response;
-        } dataBlock:^NSData * _Nullable(NSData * _Nonnull data, NSURLResponse * _Nullable response) {
-            NSData *modifiedData = [[NSData alloc] initWithBase64EncodedData:data options:NSDataBase64DecodingIgnoreUnknownCharacters];
-            return modifiedData;
-        }];
-    });
-    return responseModifier;
+    return self.block(response);
 }
 
 @end

--- a/SDWebImage/Core/SDWebImageError.h
+++ b/SDWebImage/Core/SDWebImageError.h
@@ -21,6 +21,6 @@ typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
     SDWebImageErrorCacheNotModified = 1002, // The remote location specify that the cached image is not modified, such as the HTTP response 304 code. It's useful for `SDWebImageRefreshCached`
     SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error occur when operation initialized
     SDWebImageErrorInvalidDownloadStatusCode = 2001, // The image download response a invalid status code. You can check the status code in error's userInfo under `SDWebImageErrorDownloadStatusCodeKey`
-    SDWebImageErrorInvalidDownloadResponse = 2002, // When using response modifier, the modified download response is nil and marked as cancelled.
     SDWebImageErrorCancelled = 2002, // The image loading operation is cancelled before finished, during either async disk cache query, or waiting before actual network request. For actual network request error, check `NSURLErrorDomain` error domain and code.
+    SDWebImageErrorInvalidDownloadResponse = 2003, // When using response modifier, the modified download response is nil and marked as cancelled.
 };

--- a/SDWebImage/Core/SDWebImageError.h
+++ b/SDWebImage/Core/SDWebImageError.h
@@ -21,5 +21,6 @@ typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
     SDWebImageErrorCacheNotModified = 1002, // The remote location specify that the cached image is not modified, such as the HTTP response 304 code. It's useful for `SDWebImageRefreshCached`
     SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error occur when operation initialized
     SDWebImageErrorInvalidDownloadStatusCode = 2001, // The image download response a invalid status code. You can check the status code in error's userInfo under `SDWebImageErrorDownloadStatusCodeKey`
+    SDWebImageErrorInvalidDownloadResponse = 2002, // When using response modifier, the modified download response is nil and marked as cancelled.
     SDWebImageErrorCancelled = 2002, // The image loading operation is cancelled before finished, during either async disk cache query, or waiting before actual network request. For actual network request error, check `NSURLErrorDomain` error domain and code.
 };

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -543,7 +543,7 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test24ThatDownloadRequestModifierWorks {
+- (void)test24ThatDownloadResponseModifierWorks {
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Download response modifier for webURL"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Download response modifier invalid response"];
     

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -36,6 +36,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDWebImageDownloaderConfig.h>
 #import <SDWebImage/SDWebImageDownloaderOperation.h>
 #import <SDWebImage/SDWebImageDownloaderRequestModifier.h>
+#import <SDWebImage/SDWebImageDownloaderResponseModifier.h>
 #import <SDWebImage/SDImageLoader.h>
 #import <SDWebImage/SDImageLoadersManager.h>
 #import <SDWebImage/UIButton+WebCache.h>

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -37,6 +37,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDWebImageDownloaderOperation.h>
 #import <SDWebImage/SDWebImageDownloaderRequestModifier.h>
 #import <SDWebImage/SDWebImageDownloaderResponseModifier.h>
+#import <SDWebImage/SDWebImageDownloaderDecryptor.h>
 #import <SDWebImage/SDImageLoader.h>
 #import <SDWebImage/SDImageLoadersManager.h>
 #import <SDWebImage/UIButton+WebCache.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2254 #2809

### Pull Request Description

See the Feature Request draft: #2809

This PR implements the draft, with a new protocol `SDWebImageDownloaderResponseModifier`. Support to both modify the downloaded data, as well as HTTP Response (new from draft).

The data decryptor protocol, now with the `URLResponse` input arg. This change it's because for real application, sometimes you need the HTTP response from server, like HTTP MIME-Type, to detect which algorithm to use, and the HTTP response header have also have [Content-Encoding](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Content-Encoding) file, to let Client choose the algorithm.

I think add this one can make it possible for further usage, like complicated algorithm such as AES, or even custom algorithm. Not limited at simple usage, like just Base64, etc. (Though we provide a really simple wrapper to use Base64 Encoded data image).

