### PR TITLE
Fix SDAnimatedImage on macOS use extra aniamtes property check, which is not intuitive and cause extra setup before usage

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -531,7 +531,7 @@ static NSUInteger SDDeviceFreeMemory() {
 - (void)updateShouldAnimate
 {
 #if SD_MAC
-    BOOL isVisible = self.window && self.superview && ![self isHidden] && self.alphaValue > 0.0 && self.animates;
+    BOOL isVisible = self.window && self.superview && ![self isHidden] && self.alphaValue > 0.0;
 #else
     BOOL isVisible = self.window && self.superview && ![self isHidden] && self.alpha > 0.0;
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: https://github.com/SDWebImage/SDWebImageSwiftUI/pull/30

### Pull Request Description

This strange check will cause the following code does not work as expected. It's better to remove this one, which match the exisiting SDAniamtedImageView on iOS/tvOS behavior.

Example:

```swift
let animatedImage: SDAnimatedImage
view.animates = false //  User may use a Binding Value to toggle to this false value
view.image = animatedImage
view.animates = true // This does not start animation totally on macOS
```

Same code below works on iOS/tvOS, which is not a good design across these platforms with the same meaning API.

```swift
let animatedImage: SDAnimatedImage
view.stopAnimating() //  User may use a Binding Value to toggle to this false value
view.image = animatedImage
view.startAnimating() // This work on iOS
```
