### PR TITLE
Fix macOS SDWebImageIndicator center layout issue when indicator was initialized with 0 frame

### DIFF
--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -324,9 +324,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
     }
     // Center the indicator view
 #if SD_MAC
-    CGPoint center = CGPointMake(NSMidX(self.bounds), NSMidY(self.bounds));
-    NSRect frame = view.frame;
-    view.frame = NSMakeRect(center.x - NSMidX(frame), center.y - NSMidY(frame), NSWidth(frame), NSHeight(frame));
+    [view setFrameOrigin:CGPointMake(round((NSWidth(self.bounds) - NSWidth(view.frame)) / 2), round((NSHeight(self.bounds) - NSHeight(view.frame)) / 2))];
 #else
     view.center = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See example layout:

![image](https://user-images.githubusercontent.com/6919743/67630128-84adc980-f8bd-11e9-970d-33d6b53a3d04.png)

![image](https://user-images.githubusercontent.com/6919743/67630129-87102380-f8bd-11e9-9685-9605cdb0ae41.png)

This stackoverflow answer explain the issue and solution is better: https://stackoverflow.com/questions/4681176/how-to-align-a-subview-to-the-center-of-a-parent-nsview