### PR TITLE
Fix the SDDisplayLink issue of default value, add test cases

### DIFF
--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -80,14 +80,18 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 - (CFTimeInterval)duration {
 #if SD_MAC
     CVTimeStamp outputTime = self.outputTime;
-    NSTimeInterval duration = (double)outputTime.videoRefreshPeriod / ((double)outputTime.videoTimeScale * outputTime.rateScalar);
+    NSTimeInterval duration = 0;
+    double periodPerSecond = (double)outputTime.videoTimeScale * outputTime.rateScalar;
+    if (periodPerSecond > 0) {
+        duration = (double)outputTime.videoRefreshPeriod / periodPerSecond;
+    }
 #elif SD_IOS || SD_TV
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSTimeInterval duration = self.displayLink.duration * self.displayLink.frameInterval;
 #pragma clang diagnostic pop
 #else
-    NSTimeInterval duration;
+    NSTimeInterval duration = 0;
     if (self.displayLink.isValid && self.currentFireDate != 0) {
         NSTimeInterval nextFireDate = CFRunLoopTimerGetNextFireDate((__bridge CFRunLoopTimerRef)self.displayLink);
         duration = nextFireDate - self.currentFireDate;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding. Added `testSDDisplayLink`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2873 #2867 

### Pull Request Description

Fix `SDDisplayLink` initial value issues. Which should check for 0 division. Added test case for display link.