### PR TITLE
Feature supports to control the AnimatedImage View/Player 's play rate

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 use_frameworks!
 
 def all_example_pods

--- a/SDWebImage/Core/SDAnimatedImagePlayer.h
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.h
@@ -29,6 +29,14 @@
 /// Total loop count for animated image rendering. Default is animated image's loop count.
 @property (nonatomic, assign) NSUInteger totalLoopCount;
 
+/// The animation playback rate. Default is 1.0
+/// `1.0` means the normal speed.
+/// `0.0` means stopping the animation.
+/// `0.0-1.0` means the slow speed.
+/// `> 1.0` means the fast speed.
+/// `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
+@property (nonatomic, assign) double playRate;
+
 /// Provide a max buffer size by bytes. This is used to adjust frame buffer count and can be useful when the decoding cost is expensive (such as Animated WebP software decoding). Default is 0.
 /// `0` means automatically adjust by calculating current memory usage.
 /// `1` means without any buffer cache, each of frames will be decoded and then be freed after rendering. (Lowest Memory and Highest CPU)

--- a/SDWebImage/Core/SDAnimatedImagePlayer.h
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.h
@@ -35,7 +35,7 @@
 /// `0.0-1.0` means the slow speed.
 /// `> 1.0` means the fast speed.
 /// `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
-@property (nonatomic, assign) double playRate;
+@property (nonatomic, assign) double playbackRate;
 
 /// Provide a max buffer size by bytes. This is used to adjust frame buffer count and can be useful when the decoding cost is expensive (such as Animated WebP software decoding). Default is 0.
 /// `0` means automatically adjust by calculating current memory usage.

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -228,17 +228,18 @@
     NSUInteger currentFrameIndex = self.currentFrameIndex;
     NSUInteger nextFrameIndex = (currentFrameIndex + 1) % totalFrameCount;
     
+    NSTimeInterval playRate = self.playRate;
+    if (playRate <= 0) {
+        // Does not support <= 0 play rate
+        [self stopPlaying];
+        return;
+    }
+    
     // Check if we have the frame buffer firstly to improve performance
     if (!self.bufferMiss) {
         // Then check if timestamp is reached
         self.currentTime += duration;
         NSTimeInterval currentDuration = [self.animatedProvider animatedImageDurationAtIndex:currentFrameIndex];
-        NSTimeInterval playRate = self.playRate;
-        if (playRate <= 0) {
-            // Does not support <= 0 play rate
-            [self stopPlaying];
-            return;
-        }
         currentDuration = currentDuration / playRate;
         if (self.currentTime < currentDuration) {
             // Current frame timestamp not reached, return

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -44,6 +44,7 @@
         // Get the current frame and loop count.
         self.totalLoopCount = provider.animatedImageLoopCount;
         self.animatedProvider = provider;
+        self.playRate = 1.0;
 #if SD_UIKIT
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 #endif
@@ -232,12 +233,20 @@
         // Then check if timestamp is reached
         self.currentTime += duration;
         NSTimeInterval currentDuration = [self.animatedProvider animatedImageDurationAtIndex:currentFrameIndex];
+        NSTimeInterval playRate = self.playRate;
+        if (playRate <= 0) {
+            // Does not support <= 0 play rate
+            [self stopPlaying];
+            return;
+        }
+        currentDuration = currentDuration / playRate;
         if (self.currentTime < currentDuration) {
             // Current frame timestamp not reached, return
             return;
         }
         self.currentTime -= currentDuration;
         NSTimeInterval nextDuration = [self.animatedProvider animatedImageDurationAtIndex:nextFrameIndex];
+        nextDuration = nextDuration / playRate;
         if (self.currentTime > nextDuration) {
             // Do not skip frame
             self.currentTime = nextDuration;

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -44,7 +44,7 @@
         // Get the current frame and loop count.
         self.totalLoopCount = provider.animatedImageLoopCount;
         self.animatedProvider = provider;
-        self.playRate = 1.0;
+        self.playbackRate = 1.0;
 #if SD_UIKIT
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 #endif
@@ -228,8 +228,8 @@
     NSUInteger currentFrameIndex = self.currentFrameIndex;
     NSUInteger nextFrameIndex = (currentFrameIndex + 1) % totalFrameCount;
     
-    NSTimeInterval playRate = self.playRate;
-    if (playRate <= 0) {
+    NSTimeInterval playbackRate = self.playbackRate;
+    if (playbackRate <= 0) {
         // Does not support <= 0 play rate
         [self stopPlaying];
         return;
@@ -240,14 +240,14 @@
         // Then check if timestamp is reached
         self.currentTime += duration;
         NSTimeInterval currentDuration = [self.animatedProvider animatedImageDurationAtIndex:currentFrameIndex];
-        currentDuration = currentDuration / playRate;
+        currentDuration = currentDuration / playbackRate;
         if (self.currentTime < currentDuration) {
             // Current frame timestamp not reached, return
             return;
         }
         self.currentTime -= currentDuration;
         NSTimeInterval nextDuration = [self.animatedProvider animatedImageDurationAtIndex:nextFrameIndex];
-        nextDuration = nextDuration / playRate;
+        nextDuration = nextDuration / playbackRate;
         if (self.currentTime > nextDuration) {
             // Do not skip frame
             self.currentTime = nextDuration;

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -44,6 +44,15 @@
  */
 @property (nonatomic, assign) NSInteger animationRepeatCount;
 /**
+ The animation playback rate. Default is 1.0.
+ `1.0` means the normal speed.
+ `0.0` means stopping the animation.
+ `0.0-1.0` means the slow speed.
+ `> 1.0` means the fast speed.
+ `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
+ */
+@property (nonatomic, assign) double playRate;
+/**
  Provide a max buffer size by bytes. This is used to adjust frame buffer count and can be useful when the decoding cost is expensive (such as Animated WebP software decoding). Default is 0.
  `0` means automatically adjust by calculating current memory usage.
  `1` means without any buffer cache, each of frames will be decoded and then be freed after rendering. (Lowest Memory and Highest CPU)

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -51,7 +51,7 @@
  `> 1.0` means the fast speed.
  `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
  */
-@property (nonatomic, assign) double playRate;
+@property (nonatomic, assign) double playbackRate;
 /**
  Provide a max buffer size by bytes. This is used to adjust frame buffer count and can be useful when the decoding cost is expensive (such as Animated WebP software decoding). Default is 0.
  `0` means automatically adjust by calculating current memory usage.

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -18,7 +18,7 @@
 
 @interface SDAnimatedImageView () <CALayerDelegate> {
     BOOL _initFinished; // Extra flag to mark the `commonInit` is called
-    double _playRate;
+    double _playbackRate;
 }
 
 @property (nonatomic, strong, readwrite) UIImage *currentFrame;
@@ -93,7 +93,7 @@
     // So the properties which rely on this order, should using lazy-evaluation or do extra check in `setImage:`.
     self.shouldCustomLoopCount = NO;
     self.shouldIncrementalLoad = YES;
-    self.playRate = 1.0;
+    self.playbackRate = 1.0;
 #if SD_MAC
     self.wantsLayer = YES;
 #endif
@@ -150,7 +150,7 @@
         }
         
         // Play Rate
-        self.player.playRate = self.playRate;
+        self.player.playbackRate = self.playbackRate;
         
         // Setup handler
         @weakify(self);
@@ -196,18 +196,18 @@
     return self.player.runLoopMode;
 }
 
-- (void)setPlayRate:(double)playRate
+- (void)setPlaybackRate:(double)playbackRate
 {
-    _playRate = playRate;
-    self.player.playRate = playRate;
+    _playbackRate = playbackRate;
+    self.player.playbackRate = playbackRate;
 }
 
-- (double)playRate
+- (double)playbackRate
 {
     if (!_initFinished) {
         return 1.0; // Defaults to 1.0
     }
-    return _playRate;
+    return _playbackRate;
 }
 
 - (BOOL)shouldIncrementalLoad

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -18,6 +18,7 @@
 
 @interface SDAnimatedImageView () <CALayerDelegate> {
     BOOL _initFinished; // Extra flag to mark the `commonInit` is called
+    double _playRate;
 }
 
 @property (nonatomic, strong, readwrite) UIImage *currentFrame;
@@ -92,6 +93,7 @@
     // So the properties which rely on this order, should using lazy-evaluation or do extra check in `setImage:`.
     self.shouldCustomLoopCount = NO;
     self.shouldIncrementalLoad = YES;
+    self.playRate = 1.0;
 #if SD_MAC
     self.wantsLayer = YES;
 #endif
@@ -147,6 +149,9 @@
             self.player.totalLoopCount = self.animationRepeatCount;
         }
         
+        // Play Rate
+        self.player.playRate = self.playRate;
+        
         // Setup handler
         @weakify(self);
         self.player.animationFrameHandler = ^(NSUInteger index, UIImage * frame) {
@@ -189,6 +194,20 @@
 - (NSRunLoopMode)runLoopMode
 {
     return self.player.runLoopMode;
+}
+
+- (void)setPlayRate:(double)playRate
+{
+    _playRate = playRate;
+    self.player.playRate = playRate;
+}
+
+- (double)playRate
+{
+    if (!_initFinished) {
+        return 1.0; // Defaults to 1.0
+    }
+    return _playRate;
 }
 
 - (BOOL)shouldIncrementalLoad


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The play rate currently supports like this:

+ `1.0` means the normal speed.
+ `0.0` means stopping the animation.
+ `0.0-1.0` means the slow speed.
+ `> 1.0` means the fast speed.
+ `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)

Demo:

[video.mp4.zip](https://github.com/SDWebImage/SDWebImage/files/3809697/video.mp4.zip)

