### PR TITLE
Support the runloop mode control for macOS.  Which can be useful when user want to pause animation when drag the mouse, or presenting modal window

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -81,13 +81,12 @@
  */
 @property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
 
-#if SD_UIKIT
 /**
  You can specify a runloop mode to let it rendering.
- Default is NSRunLoopCommonModes on multi-core iOS device, NSDefaultRunLoopMode on single-core iOS device
+ Default is NSRunLoopCommonModes on multi-core device, NSDefaultRunLoopMode on single-core device
+ @note This is useful for some cases, for example, always specify NSDefaultRunLoopMode, if you want to pause the animation when user scroll (for Mac user, drag the mouse or touchpad)
  */
 @property (nonatomic, copy, nonnull) NSRunLoopMode runLoopMode;
-#endif
 @end
 
 #endif

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -18,6 +18,7 @@
 
 @interface SDAnimatedImageView () <CALayerDelegate> {
     BOOL _initFinished; // Extra flag to mark the `commonInit` is called
+    NSRunLoopMode _runLoopMode;
     double _playbackRate;
 }
 
@@ -149,6 +150,9 @@
             self.player.totalLoopCount = self.animationRepeatCount;
         }
         
+        // RunLoop Mode
+        self.player.runLoopMode = self.runLoopMode;
+        
         // Play Rate
         self.player.playbackRate = self.playbackRate;
         
@@ -188,12 +192,21 @@
 
 - (void)setRunLoopMode:(NSRunLoopMode)runLoopMode
 {
+    _runLoopMode = [runLoopMode copy];
     self.player.runLoopMode = runLoopMode;
 }
 
 - (NSRunLoopMode)runLoopMode
 {
-    return self.player.runLoopMode;
+    if (!_runLoopMode) {
+        _runLoopMode = [[self class] defaultRunLoopMode];
+    }
+    return _runLoopMode;
+}
+
++ (NSString *)defaultRunLoopMode {
+    // Key off `activeProcessorCount` (as opposed to `processorCount`) since the system could shut down cores in certain situations.
+    return [NSProcessInfo processInfo].activeProcessorCount > 1 ? NSRunLoopCommonModes : NSDefaultRunLoopMode;
 }
 
 - (void)setPlaybackRate:(double)playbackRate

--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -25,13 +25,13 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 #if SD_MAC
 @property (nonatomic, assign) CVDisplayLinkRef displayLink;
 @property (nonatomic, assign) CVTimeStamp outputTime;
-@property (nonatomic, strong) NSRunLoopMode runloopMode;
+@property (nonatomic, copy) NSRunLoopMode runloopMode;
 #elif SD_IOS || SD_TV
 @property (nonatomic, strong) CADisplayLink *displayLink;
 #else
 @property (nonatomic, strong) NSTimer *displayLink;
 @property (nonatomic, strong) NSRunLoop *runloop;
-@property (nonatomic, strong) NSRunLoopMode runloopMode;
+@property (nonatomic, copy) NSRunLoopMode runloopMode;
 @property (nonatomic, assign) NSTimeInterval currentFireDate;
 #endif
 
@@ -190,7 +190,8 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 #if SD_MAC
     // CVDisplayLink does not use runloop, but we can provide similar behavior for modes
     // May use `default` runloop to avoid extra callback when in `eventTracking` (mouse drag, scroll) or `modalPanel` (modal panel)
-    if (self.runloopMode && self.runloopMode != NSRunLoopCommonModes && ![self.runloopMode isEqualToString:NSRunLoop.mainRunLoop.currentMode]) {
+    NSString *runloopMode = self.runloopMode;
+    if (![runloopMode isEqualToString:NSRunLoopCommonModes] && ![runloopMode isEqualToString:NSRunLoop.mainRunLoop.currentMode]) {
         return;
     }
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This runloop mode can use used for the use case above. We can do this better for our Mac SDWebImage user.

Demo video:

[video2.mp4.zip](https://github.com/SDWebImage/SDWebImage/files/3810007/video2.mp4.zip)


