### PR TITLE
Support using NSCache delegate with SDMemoryCache default implementation

### DIFF
--- a/SDWebImage/Core/SDMemoryCache.h
+++ b/SDWebImage/Core/SDMemoryCache.h
@@ -15,6 +15,7 @@
 @protocol SDMemoryCache <NSObject>
 
 @required
+
 /**
  Create a new memory cache instance with the specify cache config. You can check `maxMemoryCost` and `maxMemoryCount` used for memory cache.
 
@@ -25,7 +26,7 @@
 
 /**
  Returns the value associated with a given key.
- 
+
  @param key An object identifying the value. If nil, just return nil.
  @return The value associated with key, or nil if no value is associated with key.
  */
@@ -33,7 +34,7 @@
 
 /**
  Sets the value of the specified key in the cache (0 cost).
- 
+
  @param object The object to be stored in the cache. If nil, it calls `removeObjectForKey:`.
  @param key    The key with which to associate the value. If nil, this method has no effect.
  @discussion Unlike an NSMutableDictionary object, a cache does not copy the key
@@ -44,7 +45,7 @@
 /**
  Sets the value of the specified key in the cache, and associates the key-value
  pair with the specified cost.
- 
+
  @param object The object to store in the cache. If nil, it calls `removeObjectForKey`.
  @param key    The key with which to associate the value. If nil, this method has no effect.
  @param cost   The cost with which to associate the key-value pair.
@@ -55,7 +56,7 @@
 
 /**
  Removes the value of the specified key in the cache.
- 
+
  @param key The key identifying the value to be removed. If nil, this method has no effect.
  */
 - (void)removeObjectForKey:(nonnull id)key;

--- a/SDWebImage/Core/SDMemoryCache.m
+++ b/SDWebImage/Core/SDMemoryCache.m
@@ -30,6 +30,7 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 #if SD_UIKIT
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 #endif
+    self.delegate = nil;
 }
 
 - (instancetype)init {
@@ -54,14 +55,14 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
     SDImageCacheConfig *config = self.config;
     self.totalCostLimit = config.maxMemoryCost;
     self.countLimit = config.maxMemoryCount;
-    
+
     [config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCost)) options:0 context:SDMemoryCacheContext];
     [config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCount)) options:0 context:SDMemoryCacheContext];
-    
+
 #if SD_UIKIT
     self.weakCache = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsWeakMemory capacity:0];
     self.weakCacheLock = dispatch_semaphore_create(1);
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveMemoryWarning:)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Adds a needed `self.delegate = nil` line to `dealloc` in SDMemoryCache. This is the NSCacheDelegate from the superclass.

The only thing on this delegate protocol is `cache:willEvictObject:`, which is really helpful for debugging.  I found that when setting a delegate on SDMemoryCache, I'd get a crash in dealloc and this fixes it.
