### PR TITLE
Add `SDWebImageWaitStoreCache`, which wait for all the async disk cache written finished and then callback, useful for advanced user who want to touch the cache right in completion block

### DIFF
--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -184,6 +184,14 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * Note this options is not compatible with `SDWebImageDecodeFirstFrameOnly`, which always produce a UIImage/NSImage.
      */
     SDWebImageMatchAnimatedImageClass = 1 << 21,
+    
+    /**
+     * By default, when we load the image from network, the image will be written to the cache (memory and disk, controlled by your `storeCacheType` context option)
+     * This maybe an asynchronously operation and the final `SDInternalCompletionBlock` callback does not gurantee the disk cache written is finished and may cause logic error. (For example, you modify the disk data just in completion block, however, the disk cache is not ready)
+     * If you need to process with the disk cache in the completion block, you should use this option to ensure the disk cache already been written when callback.
+     * Note if you use this when using the custom cache serializer, or using the transformer, we will also wait until the output image data written is finished.
+     */
+    SDWebImageWaitStoreCache = 1 << 22,
 };
 
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

### Background

Sometime, user may want to touch the disk cache right in the manager/UIImageView category completion block. However, the current code does not gurantee the callback is after the cache written. You may get the wrong logic if you assume disk cache is ready.

This PR introduce a option `SDWebImageWaitStoreCache` to ensure we callback completion block, **Only after we already written everything finished**, solve this problem and use case.

See the same use case and issue in [Kingfisher](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#waiting-for-cache-finishing).

