### PR TITLE
A large number of crashes occur when IOS 13 users switch to the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [4.4.7 - 4.4 patch, on Jun 5th, 2019](https://github.com/rs/SDWebImage/releases/tag/4.4.7)
+See [all tickets marked for the 4.4.7 release](https://github.com/SDWebImage/SDWebImage/milestone/34)
+
+#### Fixes
+- Fix compatability for Xcode 11 #2744
+- Fix the SDAnimatedImageRep which use the deprecated API and cause compile issue on Xcode 11 #2745
+
+#### Feature
+- Define SDWebImageDownloader convenience method #2633
+
+#### Project
+- Update libwebp constraint to lower 2.0 #2628
+
 ## [4.4.6 - 4.4 patch, on Feb 26th, 2019](https://github.com/SDWebImage/SDWebImage/releases/tag/4.4.6)
 See [all tickets marked for the 4.4.6 release](https://github.com/SDWebImage/SDWebImage/milestone/33)
 

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SDWebImage'
-  s.version = '4.4.6'
+  s.version = '4.4.7'
 
   s.osx.deployment_target = '10.9'
   s.ios.deployment_target = '7.0'

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -42,6 +42,7 @@
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+    self.delegate = nil;
 }
 
 - (instancetype)initWithConfig:(SDImageCacheConfig *)config {

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -335,7 +335,7 @@ static char TAG_ACTIVITY_SHOW;
 }
 
 - (void)sd_setIndicatorStyle:(UIActivityIndicatorViewStyle)style{
-    objc_setAssociatedObject(self, &TAG_ACTIVITY_STYLE, [NSNumber numberWithInt:style], OBJC_ASSOCIATION_RETAIN);
+    objc_setAssociatedObject(self, &TAG_ACTIVITY_STYLE, [NSNumber numberWithInteger:style], OBJC_ASSOCIATION_RETAIN);
 }
 
 - (int)sd_getIndicatorStyle{

--- a/WebImage/Info.plist
+++ b/WebImage/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.4.6</string>
+	<string>4.4.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4.4.6</string>
+	<string>4.4.7</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
We use the sdwebimage 4.4.7 branch,stack:
=========================================
Incident Identifier: 4AD03491-3EE9-433F-B6D3-17987156E8F2
CrashReporter Key:   TODO
Hardware Model:      iPhone12,5
Process:         AAAAA [5437]
Path:            /private/var/containers/Bundle/Application/2AF16755-17B2-4F71-BBDC-7DFEFE48D58D/AAAAA.app/AAAAA
Identifier:      com.autohome
Version:         10.3.5 (163063)
Code Type:       ARM-64
Parent Process:  ??? [1]

Date/Time:       2019-11-23 06:40:46 +0000
OS Version:      iPhone OS 13.2.3 (17B111)
Report Version:  104

Exception Type:  SIGSEGV
Exception Codes: SEGV_ACCERR at 0x7377d4d10
Crashed Thread:  0

Thread 0 Crashed:
0   libobjc.A.dylib                     0x0000000185d5f38c objc_release + 28
1   libcache.dylib                      0x00000001bb4380d0 _value_entry_remove + 112
2   libcache.dylib                      0x00000001bb4360e0 _entry_remove + 148
3   libcache.dylib                      0x00000001bb436fb4 cache_remove_with_block + 264
4   CoreFoundation                      0x0000000186067058 __NSCacheApplicationDidEnterBackgroundCallBack + 140
5   CoreFoundation                      0x0000000185f832f4 __CFNotificationCenterAddObserver_block_invoke + 172
6   CoreFoundation                      0x0000000185f83ae0 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 28
7   CoreFoundation                      0x0000000185f83b30 ___CFXRegistrationPost1_block_invoke + 68
8   CoreFoundation                      0x0000000185f82e28 _CFXRegistrationPost1 + 396
9   CoreFoundation                      0x0000000185f82ac0 ___CFXNotificationPost_block_invoke + 108
10  CoreFoundation                      0x0000000185efba58 -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1424
11  CoreFoundation                      0x0000000185f823f0 _CFXNotificationPost + 1268
12  Foundation                          0x00000001862e4c1c -[NSNotificationCenter postNotificationName:object:userInfo:] + 64
13  UIKitCore                           0x000000018a117120 __47-[UIApplication _applicationDidEnterBackground]_block_invoke + 316
14  UIKitCore                           0x0000000189adbde4 +[UIViewController _performWithoutDeferringTransitionsAllowingAnimation:actions:] + 176
15  UIKitCore                           0x000000018a116ecc -[UIApplication _applicationDidEnterBackground] + 132
16  UIKitCore                           0x00000001898aa4d8 __101-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]_block_invoke_2 + 936
17  UIKitCore                           0x0000000189d59db0 _UIScenePerformActionsWithLifecycleActionMask + 112
18  UIKitCore                           0x00000001898aa094 __101-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]_block_invoke + 212
19  UIKitCore                           0x00000001898a9ac4 -[_UISceneLifecycleMultiplexer _performBlock:withApplicationOfDeactivationReasons:fromReasons:] + 304
20  UIKitCore                           0x00000001898a9eb0 -[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:] + 752
21  UIKitCore                           0x00000001898a9734 -[_UISceneLifecycleMultiplexer uiScene:transitionedFromState:withTransitionContext:] + 340
22  UIKitCore                           0x00000001898adee4 __186-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:]_block_invoke_2 + 196
23  UIKitCore                           0x0000000189d73c34 ___UISceneSettingsDiffActionPerformChangesWithTransitionContext_block_invoke + 28
24  UIKitCore                           0x0000000189c86eec +[BSAnimationSettings+ 5996268 (UIKit) tryAnimatingWithSettings:actions:completion:] + 868
25  UIKitCore                           0x0000000189d73bec _UISceneSettingsDiffActionPerformChangesWithTransitionContext + 260
26  UIKitCore                           0x00000001898adbfc __186-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:]_block_invoke + 152
27  UIKitCore                           0x0000000189d73ad4 _UISceneSettingsDiffActionPerformActionsWithDelayForTransitionContext + 108
28  UIKitCore                           0x00000001898ada58 -[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:] + 392
29  UIKitCore                           0x0000000189715b7c __64-[UIScene scene:didUpdateWithDiff:transitionContext:completion:]_block_invoke + 640
30  UIKitCore                           0x0000000189714640 -[UIScene _emitSceneSettingsUpdateResponseForCompletion:afterSceneUpdateWork:] + 256
31  UIKitCore                           0x00000001897158ac -[UIScene scene:didUpdateWithDiff:transitionContext:completion:] + 236
32  UIKitCore                           0x0000000189ca92ac -[UIApplicationSceneClientAgent scene:handleEvent:withCompletion:] + 480
33  FrontBoardServices                  0x000000018b1f69c8 -[FBSSceneImpl updater:didUpdateSettings:withDiff:transitionContext:completion:] + 560
34  FrontBoardServices                  0x000000018b21d0a8 __88-[FBSWorkspaceScenesClient sceneID:updateWithSettingsDiff:transitionContext:completion:]_block_invoke_2 + 136
35  FrontBoardServices                  0x000000018b200fa4 -[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 240
36  FrontBoardServices                  0x000000018b21cfc4 __88-[FBSWorkspaceScenesClient sceneID:updateWithSettingsDiff:transitionContext:completion:]_block_invoke + 200
37  libdispatch.dylib                   0x0000000185cd1fd8 _dispatch_client_callout + 20
38  libdispatch.dylib                   0x0000000185cd4d1c _dispatch_block_invoke_direct + 264
39  FrontBoardServices                  0x000000018b243304 __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 48
40  FrontBoardServices                  0x000000018b242fb0 -[FBSSerialQueue _queue_performNextIfPossible] + 432
41  FrontBoardServices                  0x000000018b24351c -[FBSSerialQueue _performNextFromRunLoopSource] + 32
42  CoreFoundation                      0x0000000185fa724c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
43  CoreFoundation                      0x0000000185fa71a0 __CFRunLoopDoSource0 + 84
44  CoreFoundation                      0x0000000185fa690c __CFRunLoopDoSources0 + 184
45  CoreFoundation                      0x0000000185fa17d8 __CFRunLoopRun + 1068
46  CoreFoundation                      0x0000000185fa1084 CFRunLoopRunSpecific + 480
47  GraphicsServices                    0x00000001901ef534 GSEventRunModal + 108
48  UIKitCore                           0x000000018a111670 UIApplicationMain + 1940
49  AAAAA                            0x0000000102ae1120 main + 20768 (main.m:14)
50  libdyld.dylib                       0x0000000185e20e18 start + 4
