### PR TITLE
Using one global function to ensure we always sync all the UIImage category assocaited object status correctly inside our framework

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		3237F9E820161AE000A88143 /* NSImage+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 4397D2F51D0DE2DF00BB2784 /* NSImage+Compatibility.m */; };
 		3237F9EB20161AE000A88143 /* NSImage+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 4397D2F51D0DE2DF00BB2784 /* NSImage+Compatibility.m */; };
 		3240BB6523968FA1003BA07D /* SDFileAttributeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 325F7CC523893B2E00AEDFCC /* SDFileAttributeHelper.m */; };
+		3240BB6823968FE7003BA07D /* SDAssociatedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3240BB6623968FE6003BA07D /* SDAssociatedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3240BB6923968FE7003BA07D /* SDAssociatedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 3240BB6723968FE6003BA07D /* SDAssociatedObject.m */; };
+		3240BB6A23968FE7003BA07D /* SDAssociatedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 3240BB6723968FE6003BA07D /* SDAssociatedObject.m */; };
 		3244062C2296C5F400A36084 /* SDWebImageOptionsProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 324406292296C5F400A36084 /* SDWebImageOptionsProcessor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3244062D2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */; };
 		3244062E2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */; };
@@ -387,6 +390,8 @@
 		321E60A11F38E8F600405457 /* SDImageGIFCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDImageGIFCoder.m; path = Core/SDImageGIFCoder.m; sourceTree = "<group>"; };
 		321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+ForceDecode.h"; path = "Core/UIImage+ForceDecode.h"; sourceTree = "<group>"; };
 		321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+ForceDecode.m"; path = "Core/UIImage+ForceDecode.m"; sourceTree = "<group>"; };
+		3240BB6623968FE6003BA07D /* SDAssociatedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDAssociatedObject.h; sourceTree = "<group>"; };
+		3240BB6723968FE6003BA07D /* SDAssociatedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDAssociatedObject.m; sourceTree = "<group>"; };
 		324406292296C5F400A36084 /* SDWebImageOptionsProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageOptionsProcessor.h; path = Core/SDWebImageOptionsProcessor.h; sourceTree = "<group>"; };
 		3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageOptionsProcessor.m; path = Core/SDWebImageOptionsProcessor.m; sourceTree = "<group>"; };
 		32484757201775F600AF9E5A /* SDAnimatedImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDAnimatedImageView.m; path = Core/SDAnimatedImageView.m; sourceTree = "<group>"; };
@@ -631,6 +636,8 @@
 			children = (
 				32B5CC5E222F89C2005EB74E /* SDAsyncBlockOperation.h */,
 				32B5CC5F222F89C2005EB74E /* SDAsyncBlockOperation.m */,
+				3240BB6623968FE6003BA07D /* SDAssociatedObject.h */,
+				3240BB6723968FE6003BA07D /* SDAssociatedObject.m */,
 				325C460622339426004CAE11 /* SDWeakProxy.h */,
 				325C460722339426004CAE11 /* SDWeakProxy.m */,
 				32E6730F235765B500DB4987 /* SDDisplayLink.h */,
@@ -886,6 +893,7 @@
 				326E2F2E236F0B23006F847F /* SDAnimatedImagePlayer.h in Headers */,
 				807A122A1F89636300EC2A9B /* SDImageCodersManager.h in Headers */,
 				3244062C2296C5F400A36084 /* SDWebImageOptionsProcessor.h in Headers */,
+				3240BB6823968FE7003BA07D /* SDAssociatedObject.h in Headers */,
 				4A2CAE211AB4BB7000B6BC39 /* SDWebImageManager.h in Headers */,
 				4A2CAE1F1AB4BB6C00B6BC39 /* SDImageCache.h in Headers */,
 				4A2CAE351AB4BB7500B6BC39 /* UIImageView+WebCache.h in Headers */,
@@ -1124,6 +1132,7 @@
 				32E67313235765B500DB4987 /* SDDisplayLink.m in Sources */,
 				4A2CAE2E1AB4BB7500B6BC39 /* UIImage+GIF.m in Sources */,
 				326E2F35236F1D58006F847F /* SDDeviceHelper.m in Sources */,
+				3240BB6A23968FE7003BA07D /* SDAssociatedObject.m in Sources */,
 				80B6DF822142B44400BCB334 /* NSButton+WebCache.m in Sources */,
 				32D3CDCF21DDE87300C4DB49 /* UIImage+MemoryCacheCost.m in Sources */,
 				329F1241223FAD3400B309FD /* SDInternalMacros.m in Sources */,
@@ -1196,6 +1205,7 @@
 				32E67312235765B500DB4987 /* SDDisplayLink.m in Sources */,
 				53761309155AD0D5005750A4 /* SDImageCache.m in Sources */,
 				326E2F34236F1D58006F847F /* SDDeviceHelper.m in Sources */,
+				3240BB6923968FE7003BA07D /* SDAssociatedObject.m in Sources */,
 				80B6DF832142B44500BCB334 /* NSButton+WebCache.m in Sources */,
 				32D3CDCE21DDE87300C4DB49 /* UIImage+MemoryCacheCost.m in Sources */,
 				329F1240223FAD3400B309FD /* SDInternalMacros.m in Sources */,

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -12,7 +12,7 @@
 #import "NSData+ImageContentType.h"
 #import "SDAnimatedImageRep.h"
 #import "UIImage+ForceDecode.h"
-#import "UIImage+Metadata.h"
+#import "SDAssociatedObject.h"
 
 #if SD_UIKIT || SD_WATCH
 static const size_t kBytesPerPixel = 4;
@@ -291,8 +291,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     UIImage *decodedImage = [[UIImage alloc] initWithCGImage:imageRef scale:image.scale orientation:image.imageOrientation];
     CGImageRelease(imageRef);
+    SDImageCopyAssociatedObject(image, decodedImage);
     decodedImage.sd_isDecoded = YES;
-    decodedImage.sd_imageFormat = image.sd_imageFormat;
     return decodedImage;
 #endif
 }
@@ -425,8 +425,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         if (destImage == nil) {
             return image;
         }
+        SDImageCopyAssociatedObject(image, destImage);
         destImage.sd_isDecoded = YES;
-        destImage.sd_imageFormat = image.sd_imageFormat;
         return destImage;
     }
 #endif

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -10,6 +10,7 @@
 #import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 #import "UIImage+ExtendedCacheData.h"
+#import "SDAssociatedObject.h"
 
 #pragma mark - Image scale
 
@@ -111,9 +112,7 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
         scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
     }
-    scaledImage.sd_isIncremental = image.sd_isIncremental;
-    scaledImage.sd_imageFormat = image.sd_imageFormat;
-    scaledImage.sd_extendedObject = image.sd_extendedObject;
+    SDImageCopyAssociatedObject(image, scaledImage);
     
     return scaledImage;
 }

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -10,7 +10,7 @@
 #import "SDImageCache.h"
 #import "SDWebImageDownloader.h"
 #import "UIImage+Metadata.h"
-#import "UIImage+ExtendedCacheData.h"
+#import "SDAssociatedObject.h"
 #import "SDWebImageError.h"
 #import "SDInternalMacros.h"
 
@@ -376,9 +376,7 @@ static id<SDImageLoader> _defaultImageLoader;
                         cacheData = (imageWasTransformed ? nil : originalData);
                     }
                     // keep the original image format and extended data
-                    transformedImage.sd_isIncremental = originalImage.sd_isIncremental;
-                    transformedImage.sd_imageFormat = originalImage.sd_imageFormat;
-                    transformedImage.sd_extendedObject = originalImage.sd_extendedObject;
+                    SDImageCopyAssociatedObject(originalImage, transformedImage);
                     [self storeImage:transformedImage imageData:cacheData forKey:cacheKey cacheType:storeCacheType waitStoreCache:waitStoreCache completion:^{
                         [self callCompletionBlockForOperation:operation completion:completedBlock image:transformedImage data:originalData error:nil cacheType:SDImageCacheTypeNone finished:finished url:url];
                     }];

--- a/SDWebImage/Private/SDAssociatedObject.h
+++ b/SDWebImage/Private/SDAssociatedObject.h
@@ -1,0 +1,14 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import "SDWebImageCompat.h"
+
+/// Copy the associated object from source image to target image. The associated object including all the category read/write properties.
+/// @param source source
+/// @param target target
+FOUNDATION_EXPORT void SDImageCopyAssociatedObject(UIImage * _Nullable source, UIImage * _Nullable target);

--- a/SDWebImage/Private/SDAssociatedObject.m
+++ b/SDWebImage/Private/SDAssociatedObject.m
@@ -1,0 +1,29 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import "SDAssociatedObject.h"
+#import "UIImage+Metadata.h"
+#import "UIImage+ExtendedCacheData.h"
+#import "UIImage+MemoryCacheCost.h"
+#import "UIImage+ForceDecode.h"
+
+void SDImageCopyAssociatedObject(UIImage * _Nullable source, UIImage * _Nullable target) {
+    if (!source || !target) {
+        return;
+    }
+    // Image Metadata
+    target.sd_isIncremental = source.sd_isIncremental;
+    target.sd_imageLoopCount = source.sd_imageLoopCount;
+    target.sd_imageFormat = source.sd_imageFormat;
+    // Force Decode
+    target.sd_isDecoded = source.sd_isDecoded;
+    // Extended Cache Data
+    target.sd_extendedObject = source.sd_extendedObject;
+    // Memory Cache Cost
+    target.sd_memoryCost = source.sd_memoryCost;
+}

--- a/SDWebImage/Private/SDAssociatedObject.m
+++ b/SDWebImage/Private/SDAssociatedObject.m
@@ -24,6 +24,4 @@ void SDImageCopyAssociatedObject(UIImage * _Nullable source, UIImage * _Nullable
     target.sd_isDecoded = source.sd_isDecoded;
     // Extended Cache Data
     target.sd_extendedObject = source.sd_extendedObject;
-    // Memory Cache Cost
-    target.sd_memoryCost = source.sd_memoryCost;
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: 

### Pull Request Description

This can help to sync the status. For example, some information (like format, extended object) will lose during the force decoding, or scaled with image key. These information is useful to process, and should be keep.

Using a global function can ensure we always get the correct value on.
