### PR TITLE
Performance - Using UIGraphicsImageRenderer on iOS 10+, save memory when image bitmap is RGB(-25%) or Grayscale(-75%)

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		3244062C2296C5F400A36084 /* SDWebImageOptionsProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 324406292296C5F400A36084 /* SDWebImageOptionsProcessor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3244062D2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */; };
 		3244062E2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */; };
+		3246A70323A567AC00FBEA10 /* SDGraphicsImageRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3246A70123A567AC00FBEA10 /* SDGraphicsImageRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3246A70423A567AC00FBEA10 /* SDGraphicsImageRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3246A70223A567AC00FBEA10 /* SDGraphicsImageRenderer.m */; };
+		3246A70523A567AC00FBEA10 /* SDGraphicsImageRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3246A70223A567AC00FBEA10 /* SDGraphicsImageRenderer.m */; };
 		3248475D201775F600AF9E5A /* SDAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32484757201775F600AF9E5A /* SDAnimatedImageView.m */; };
 		3248475F201775F600AF9E5A /* SDAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32484757201775F600AF9E5A /* SDAnimatedImageView.m */; };
 		32484765201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32484758201775F600AF9E5A /* SDAnimatedImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -121,6 +124,7 @@
 		328BB6CF2082581100760D6C /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 328BB6BF2082581100760D6C /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		328BB6D32082581100760D6C /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6C02082581100760D6C /* SDMemoryCache.m */; };
 		328BB6D52082581100760D6C /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6C02082581100760D6C /* SDMemoryCache.m */; };
+		328E9DE523A61DD30051C893 /* SDGraphicsImageRenderer.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3246A70123A567AC00FBEA10 /* SDGraphicsImageRenderer.h */; };
 		3290FA061FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3290FA0A1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
 		3290FA0C1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
@@ -308,6 +312,7 @@
 			dstPath = include/SDWebImage;
 			dstSubfolderSpec = 16;
 			files = (
+				328E9DE523A61DD30051C893 /* SDGraphicsImageRenderer.h in Copy Headers */,
 				325F7CCD2389467800AEDFCC /* UIImage+ExtendedCacheData.h in Copy Headers */,
 				326E2F36236F1E30006F847F /* SDAnimatedImagePlayer.h in Copy Headers */,
 				3250C9F12355E3DF0093A896 /* SDWebImageDownloaderDecryptor.h in Copy Headers */,
@@ -394,6 +399,8 @@
 		3240BB6723968FE6003BA07D /* SDAssociatedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDAssociatedObject.m; sourceTree = "<group>"; };
 		324406292296C5F400A36084 /* SDWebImageOptionsProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageOptionsProcessor.h; path = Core/SDWebImageOptionsProcessor.h; sourceTree = "<group>"; };
 		3244062A2296C5F400A36084 /* SDWebImageOptionsProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageOptionsProcessor.m; path = Core/SDWebImageOptionsProcessor.m; sourceTree = "<group>"; };
+		3246A70123A567AC00FBEA10 /* SDGraphicsImageRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDGraphicsImageRenderer.h; path = Core/SDGraphicsImageRenderer.h; sourceTree = "<group>"; };
+		3246A70223A567AC00FBEA10 /* SDGraphicsImageRenderer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDGraphicsImageRenderer.m; path = Core/SDGraphicsImageRenderer.m; sourceTree = "<group>"; };
 		32484757201775F600AF9E5A /* SDAnimatedImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDAnimatedImageView.m; path = Core/SDAnimatedImageView.m; sourceTree = "<group>"; };
 		32484758201775F600AF9E5A /* SDAnimatedImageView+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SDAnimatedImageView+WebCache.h"; path = "Core/SDAnimatedImageView+WebCache.h"; sourceTree = "<group>"; };
 		32484759201775F600AF9E5A /* SDAnimatedImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDAnimatedImageView.h; path = Core/SDAnimatedImageView.h; sourceTree = "<group>"; };
@@ -577,6 +584,8 @@
 				32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */,
 				3257EAF721898AED0097B271 /* SDImageGraphics.h */,
 				3257EAF821898AED0097B271 /* SDImageGraphics.m */,
+				3246A70123A567AC00FBEA10 /* SDGraphicsImageRenderer.h */,
+				3246A70223A567AC00FBEA10 /* SDGraphicsImageRenderer.m */,
 			);
 			name = Decoder;
 			sourceTree = "<group>";
@@ -905,6 +914,7 @@
 				4A2CAE1D1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.h in Headers */,
 				4A2CAE2B1AB4BB7500B6BC39 /* UIButton+WebCache.h in Headers */,
 				4A2CAE251AB4BB7000B6BC39 /* SDWebImagePrefetcher.h in Headers */,
+				3246A70323A567AC00FBEA10 /* SDGraphicsImageRenderer.h in Headers */,
 				328BB6CF2082581100760D6C /* SDMemoryCache.h in Headers */,
 				325C460F223394D8004CAE11 /* SDImageCachesManagerOperation.h in Headers */,
 				321E60881F38E8C800405457 /* SDImageCoder.h in Headers */,
@@ -1125,6 +1135,7 @@
 				3290FA0C1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				325C46232233A02E004CAE11 /* UIColor+HexString.m in Sources */,
 				325F7CCB238942AB00AEDFCC /* UIImage+ExtendedCacheData.m in Sources */,
+				3246A70523A567AC00FBEA10 /* SDGraphicsImageRenderer.m in Sources */,
 				321E60C61F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				3244062E2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */,
 				3250C9F02355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */,
@@ -1198,6 +1209,7 @@
 				3290FA0A1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				325C46222233A02E004CAE11 /* UIColor+HexString.m in Sources */,
 				321E60C41F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
+				3246A70423A567AC00FBEA10 /* SDGraphicsImageRenderer.m in Sources */,
 				3244062D2296C5F400A36084 /* SDWebImageOptionsProcessor.m in Sources */,
 				3250C9EF2355D9DA0093A896 /* SDWebImageDownloaderDecryptor.m in Sources */,
 				3240BB6523968FA1003BA07D /* SDFileAttributeHelper.m in Sources */,

--- a/SDWebImage/Core/SDGraphicsImageRenderer.h
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.h
@@ -1,0 +1,44 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import "SDWebImageCompat.h"
+
+typedef void (^SDGraphicsImageDrawingActions)(CGContextRef _Nonnull context);
+
+typedef NS_ENUM(NSInteger, SDGraphicsImageRendererFormatRange) {
+    SDGraphicsImageRendererFormatRangeUnspecified = -1,
+    SDGraphicsImageRendererFormatRangeAutomatic = 0,
+    SDGraphicsImageRendererFormatRangeExtended,
+    SDGraphicsImageRendererFormatRangeStandard
+};
+
+@interface SDGraphicsImageRendererFormat : NSObject
+
+@property (nonatomic) CGFloat scale;
+@property (nonatomic) BOOL opaque;
+
+/**
+ For iOS 12+, the value is from system API
+ For iOS 10-11, the value is from `prefersExtendedRange` property
+ For iOS 9, the value is `.unspecified`
+ */
+@property (nonatomic) SDGraphicsImageRendererFormatRange preferredRange;
+
+- (nonnull instancetype)init;
++ (nonnull instancetype)preferredFormat;
+
+@end
+
+@interface SDGraphicsImageRenderer : NSObject
+
+- (nonnull instancetype)initWithSize:(CGSize)size;
+- (nonnull instancetype)initWithSize:(CGSize)size format:(nonnull SDGraphicsImageRendererFormat *)format;
+
+- (nonnull UIImage *)imageWithActions:(nonnull NS_NOESCAPE SDGraphicsImageDrawingActions)actions;
+
+@end

--- a/SDWebImage/Core/SDGraphicsImageRenderer.h
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.h
@@ -10,10 +10,11 @@
 
 /**
  These following class are provided to use `UIGraphicsImageRenderer` with polyfill, which allows write cross-platform(AppKit/UIKit) code and avoid runtime version check.
- Compared to `UIGraphicsBeginImageContext`, `UIGraphicsImageRenderer` use dynamic bitmap info from your draw code to generate CGContext, not always use ARGB8888, which is more performant on RAM usage.
+ Compared to `UIGraphicsBeginImageContext`, `UIGraphicsImageRenderer` use dynamic bitmap from your draw code to generate CGContext, not always use ARGB8888, which is more performant on RAM usage.
+ Which means, if you draw CGImage/CIImage which contains grayscale only, the underlaying bitmap context use grayscale, it's managed by system and not a fixed type. (actually, the `kCGContextTypeAutomatic`)
  For usage, See more in Apple's documentation: https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer
  For UIKit on iOS/tvOS 10+, these method just use the same `UIGraphicsImageRenderer` API.
- For others (macOS/watchOS or iOS/tvOS 10-), these method use the `SDImageGraphics.h` to implements the same behavior.
+ For others (macOS/watchOS or iOS/tvOS 10-), these method use the `SDImageGraphics.h` to implements the same behavior (but without dynamic bitmap support)
 */
 
 typedef void (^SDGraphicsImageDrawingActions)(CGContextRef _Nonnull context);

--- a/SDWebImage/Core/SDGraphicsImageRenderer.h
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.h
@@ -8,8 +8,15 @@
 
 #import "SDWebImageCompat.h"
 
-typedef void (^SDGraphicsImageDrawingActions)(CGContextRef _Nonnull context);
+/**
+ These following class are provided to use `UIGraphicsImageRenderer` with polyfill, which allows write cross-platform(AppKit/UIKit) code and avoid runtime version check.
+ Compared to `UIGraphicsBeginImageContext`, `UIGraphicsImageRenderer` use dynamic bitmap info from your draw code to generate CGContext, not always use ARGB8888, which is more performant on RAM usage.
+ For usage, See more in Apple's documentation: https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer
+ For UIKit on iOS/tvOS 10+, these method just use the same `UIGraphicsImageRenderer` API.
+ For others (macOS/watchOS or iOS/tvOS 10-), these method use the `SDImageGraphics.h` to implements the same behavior.
+*/
 
+typedef void (^SDGraphicsImageDrawingActions)(CGContextRef _Nonnull context);
 typedef NS_ENUM(NSInteger, SDGraphicsImageRendererFormatRange) {
     SDGraphicsImageRendererFormatRangeUnspecified = -1,
     SDGraphicsImageRendererFormatRangeAutomatic = 0,
@@ -17,28 +24,49 @@ typedef NS_ENUM(NSInteger, SDGraphicsImageRendererFormatRange) {
     SDGraphicsImageRendererFormatRangeStandard
 };
 
+/// A set of drawing attributes that represent the configuration of an image renderer context.
 @interface SDGraphicsImageRendererFormat : NSObject
 
+/// The display scale of the image renderer context.
+/// The default value is equal to the scale of the main screen.
 @property (nonatomic) CGFloat scale;
+
+/// A Boolean value indicating whether the underlying Core Graphics context has an alpha channel.
+/// The default value is NO.
 @property (nonatomic) BOOL opaque;
 
-/**
- For iOS 12+, the value is from system API
- For iOS 10-11, the value is from `prefersExtendedRange` property
- For iOS 9, the value is `.unspecified`
- */
+/// Specifying whether the bitmap context should use extended color.
+/// For iOS 12+, the value is from system `preferredRange` property
+/// For iOS 10-11, the value is from system `prefersExtendedRange` property
+/// For iOS 9-, the value is `.standard`
 @property (nonatomic) SDGraphicsImageRendererFormatRange preferredRange;
 
+/// Init the default format. See each properties's default value.
 - (nonnull instancetype)init;
+
+/// Returns a new format best suited for the main screen’s current configuration.
 + (nonnull instancetype)preferredFormat;
 
 @end
 
+/// A graphics renderer for creating Core Graphics-backed images.
 @interface SDGraphicsImageRenderer : NSObject
 
+/// Creates an image renderer for drawing images of a given size.
+/// @param size The size of images output from the renderer, specified in points.
+/// @return An initialized image renderer.
 - (nonnull instancetype)initWithSize:(CGSize)size;
+
+/// Creates a new image renderer with a given size and format.
+/// @param size The size of images output from the renderer, specified in points.
+/// @param format A SDGraphicsImageRendererFormat object that encapsulates the format used to create the renderer context.
+/// @return An initialized image renderer.
 - (nonnull instancetype)initWithSize:(CGSize)size format:(nonnull SDGraphicsImageRendererFormat *)format;
 
+/// Creates an image by following a set of drawing instructions.
+/// @param actions A SDGraphicsImageDrawingActions block that, when invoked by the renderer, executes a set of drawing instructions to create the output image.
+/// @note You should not retain or use the context outside the block, it's non-escaping.
+/// @return A UIImage object created by the supplied drawing actions.
 - (nonnull UIImage *)imageWithActions:(nonnull NS_NOESCAPE SDGraphicsImageDrawingActions)actions;
 
 @end

--- a/SDWebImage/Core/SDGraphicsImageRenderer.m
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.m
@@ -124,9 +124,16 @@
             self.uiformat = uiformat;
         } else {
 #endif
-            self.scale = 1.0;
+#if SD_WATCH
+            CGFloat screenScale = [WKInterfaceDevice currentDevice].screenScale;
+#elif SD_UIKIT
+            CGFloat screenScale = [UIScreen mainScreen].scale;
+#elif SD_MAC
+            CGFloat screenScale = [NSScreen mainScreen].backingScaleFactor;
+#endif
+            self.scale = screenScale;
             self.opaque = NO;
-            self.preferredRange = SDGraphicsImageRendererFormatRangeUnspecified;
+            self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
 #if SD_UIKIT
         }
 #endif
@@ -160,7 +167,7 @@
 #endif
             self.scale = screenScale;
             self.opaque = NO;
-            self.preferredRange = SDGraphicsImageRendererFormatRangeUnspecified;
+            self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
 #if SD_UIKIT
         }
 #endif

--- a/SDWebImage/Core/SDGraphicsImageRenderer.m
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.m
@@ -1,0 +1,140 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+#import "SDGraphicsImageRenderer.h"
+#import "SDImageGraphics.h"
+
+@interface SDGraphicsImageRendererFormat ()
+@property (nonatomic, strong) UIGraphicsImageRendererFormat *uiformat API_AVAILABLE(ios(10.0));
+@end
+
+@implementation SDGraphicsImageRendererFormat
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        if (@available(iOS 10.0, *)) {
+            UIGraphicsImageRendererFormat *uiformat = [[UIGraphicsImageRendererFormat alloc] init];
+            self.uiformat = uiformat;
+            self.scale = uiformat.scale;
+            self.opaque = uiformat.opaque;
+            if (@available(iOS 12.0, *)) {
+                self.preferredRange = (SDGraphicsImageRendererFormatRange)uiformat.preferredRange;
+            } else {
+                if (uiformat.prefersExtendedRange) {
+                    self.preferredRange = SDGraphicsImageRendererFormatRangeExtended;
+                } else {
+                    self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
+                }
+            }
+        } else {
+            self.scale = 1.0;
+            self.opaque = NO;
+            self.preferredRange = SDGraphicsImageRendererFormatRangeUnspecified;
+        }
+    }
+    return self;
+}
+
+- (instancetype)initForMainScreen {
+    self = [super init];
+    if (self) {
+        if (@available(iOS 10.0, *)) {
+            UIGraphicsImageRendererFormat *uiformat;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+            // iOS 11.0.0 GM does have `preferredFormat`, but iOS 11 betas did not (argh!)
+            if ([UIGraphicsImageRenderer respondsToSelector:@selector(preferredFormat)]) {
+                uiformat = [UIGraphicsImageRendererFormat preferredFormat];
+            } else {
+                uiformat = [UIGraphicsImageRendererFormat defaultFormat];
+            }
+            self.uiformat = uiformat;
+            self.scale = uiformat.scale;
+            self.opaque = uiformat.opaque;
+            if (@available(iOS 12.0, *)) {
+                self.preferredRange = (SDGraphicsImageRendererFormatRange)uiformat.preferredRange;
+            } else {
+                if (uiformat.prefersExtendedRange) {
+                    self.preferredRange = SDGraphicsImageRendererFormatRangeExtended;
+                } else {
+                    self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
+                }
+            }
+#pragma clang diagnostic pop
+        } else {
+#if SD_WATCH
+            CGFloat screenScale = [WKInterfaceDevice currentDevice].screenScale;
+#elif SD_UIKIT
+            CGFloat screenScale = [UIScreen mainScreen].scale;
+#elif SD_MAC
+            CGFloat screenScale = [NSScreen mainScreen].backingScaleFactor;
+#endif
+            self.scale = screenScale;
+            self.opaque = NO;
+            self.preferredRange = SDGraphicsImageRendererFormatRangeUnspecified;
+        }
+    }
+    return self;
+}
+
++ (instancetype)preferredFormat {
+    SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] initForMainScreen];
+    return format;
+}
+
+@end
+
+@interface SDGraphicsImageRenderer ()
+@property (nonatomic, assign) CGSize size;
+@property (nonatomic, strong) SDGraphicsImageRendererFormat *format;
+@property (nonatomic, strong) UIGraphicsImageRenderer *uirenderer API_AVAILABLE(ios(10.0));
+@end
+
+@implementation SDGraphicsImageRenderer
+
+- (instancetype)initWithSize:(CGSize)size {
+    return [self initWithSize:size format:SDGraphicsImageRendererFormat.preferredFormat];
+}
+
+- (instancetype)initWithSize:(CGSize)size format:(SDGraphicsImageRendererFormat *)format {
+    NSParameterAssert(format);
+    self = [super init];
+    if (self) {
+        self.size = size;
+        self.format = format;
+        if (@available(iOS 10.0, *)) {
+            UIGraphicsImageRendererFormat *uiformat = format.uiformat;
+            self.uirenderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:uiformat];
+        }
+    }
+    return self;
+}
+
+- (UIImage *)imageWithActions:(NS_NOESCAPE SDGraphicsImageDrawingActions)actions {
+    NSParameterAssert(actions);
+    if (@available(iOS 10.0, *)) {
+        UIGraphicsImageDrawingActions uiactions = ^(UIGraphicsImageRendererContext *rendererContext) {
+            if (actions) {
+                actions(rendererContext.CGContext);
+            }
+        };
+        return [self.uirenderer imageWithActions:uiactions];
+    } else {
+        SDGraphicsBeginImageContextWithOptions(self.size, self.format.opaque, self.format.scale);
+        CGContextRef context = SDGraphicsGetCurrentContext();
+        if (actions) {
+            actions(context);
+        }
+        UIImage *image = SDGraphicsGetImageFromCurrentImageContext();
+        SDGraphicsEndImageContext();
+        return image;
+    }
+}
+
+@end

--- a/SDWebImage/Core/SDGraphicsImageRenderer.m
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.m
@@ -16,6 +16,104 @@
 @end
 
 @implementation SDGraphicsImageRendererFormat
+@synthesize scale = _scale;
+@synthesize opaque = _opaque;
+@synthesize preferredRange = _preferredRange;
+
+#pragma mark - Property
+- (CGFloat)scale {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        return self.uiformat.scale;
+    } else {
+        return _scale;
+    }
+#else
+    return _scale;
+#endif
+}
+
+- (void)setScale:(CGFloat)scale {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        self.uiformat.scale = scale;
+    } else {
+        _scale = scale;
+    }
+#else
+    _scale = scale;
+#endif
+}
+
+- (BOOL)opaque {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        return self.uiformat.opaque;
+    } else {
+        return _opaque;
+    }
+#else
+    return _opaque;
+#endif
+}
+
+- (void)setOpaque:(BOOL)opaque {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        self.uiformat.opaque = opaque;
+    } else {
+        _opaque = opaque;
+    }
+#else
+    _opaque = opaque;
+#endif
+}
+
+- (SDGraphicsImageRendererFormatRange)preferredRange {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        if (@available(iOS 12.0, tvOS 12.0, *)) {
+            return (SDGraphicsImageRendererFormatRange)self.uiformat.preferredRange;
+        } else {
+            BOOL prefersExtendedRange = self.uiformat.prefersExtendedRange;
+            if (prefersExtendedRange) {
+                return SDGraphicsImageRendererFormatRangeExtended;
+            } else {
+                return SDGraphicsImageRendererFormatRangeStandard;
+            }
+        }
+    } else {
+        return _preferredRange;
+    }
+#else
+    return _preferredRange;
+#endif
+}
+
+- (void)setPreferredRange:(SDGraphicsImageRendererFormatRange)preferredRange {
+#if SD_UIKIT
+    if (@available(iOS 10.0, tvOS 10.10, *)) {
+        if (@available(iOS 12.0, tvOS 12.0, *)) {
+            self.uiformat.preferredRange = (UIGraphicsImageRendererFormatRange)preferredRange;
+        } else {
+            switch (preferredRange) {
+                case SDGraphicsImageRendererFormatRangeExtended:
+                    self.uiformat.prefersExtendedRange = YES;
+                    break;
+                case SDGraphicsImageRendererFormatRangeStandard:
+                    self.uiformat.prefersExtendedRange = NO;
+                default:
+                    // Automatic means default
+                    break;
+            }
+        }
+    } else {
+        _preferredRange = preferredRange;
+    }
+#else
+    _preferredRange = preferredRange;
+#endif
+}
 
 - (instancetype)init {
     self = [super init];
@@ -24,17 +122,6 @@
         if (@available(iOS 10.0, tvOS 10.10, *)) {
             UIGraphicsImageRendererFormat *uiformat = [[UIGraphicsImageRendererFormat alloc] init];
             self.uiformat = uiformat;
-            self.scale = uiformat.scale;
-            self.opaque = uiformat.opaque;
-            if (@available(iOS 12.0, tvOS 12.0, *)) {
-                self.preferredRange = (SDGraphicsImageRendererFormatRange)uiformat.preferredRange;
-            } else {
-                if (uiformat.prefersExtendedRange) {
-                    self.preferredRange = SDGraphicsImageRendererFormatRangeExtended;
-                } else {
-                    self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
-                }
-            }
         } else {
 #endif
             self.scale = 1.0;
@@ -62,17 +149,6 @@
                 uiformat = [UIGraphicsImageRendererFormat defaultFormat];
             }
             self.uiformat = uiformat;
-            self.scale = uiformat.scale;
-            self.opaque = uiformat.opaque;
-            if (@available(iOS 12.0, tvOS 12.0, *)) {
-                self.preferredRange = (SDGraphicsImageRendererFormatRange)uiformat.preferredRange;
-            } else {
-                if (uiformat.prefersExtendedRange) {
-                    self.preferredRange = SDGraphicsImageRendererFormatRangeExtended;
-                } else {
-                    self.preferredRange = SDGraphicsImageRendererFormatRangeStandard;
-                }
-            }
         } else {
 #endif
 #if SD_WATCH

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -12,6 +12,7 @@
 #import "NSData+ImageContentType.h"
 #import "SDAnimatedImageRep.h"
 #import "UIImage+ForceDecode.h"
+#import "SDGraphicsImageRenderer.h"
 #import "SDAssociatedObject.h"
 
 #if SD_UIKIT || SD_WATCH
@@ -257,22 +258,26 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     BOOL hasAlpha = [self CGImageContainsAlpha:cgImage];
-    // iOS prefer BGRA8888 (premultiplied) or BGRX8888 bitmapInfo for screen rendering, which is same as `UIGraphicsBeginImageContext()` or `- [CALayer drawInContext:]`
-    // Though you can use any supported bitmapInfo (see: https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB ) and let Core Graphics reorder it when you call `CGContextDrawImage`
-    // But since our build-in coders use this bitmapInfo, this can have a little performance benefit
-    CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Host;
-    bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst;
-    CGContextRef context = CGBitmapContextCreate(NULL, newWidth, newHeight, 8, 0, [self colorSpaceGetDeviceRGB], bitmapInfo);
-    if (!context) {
-        return NULL;
-    }
     
-    // Apply transform
-    CGAffineTransform transform = SDCGContextTransformFromOrientation(orientation, CGSizeMake(newWidth, newHeight));
-    CGContextConcatCTM(context, transform);
-    CGContextDrawImage(context, CGRectMake(0, 0, width, height), cgImage); // The rect is bounding box of CGImage, don't swap width & height
-    CGImageRef newImageRef = CGBitmapContextCreateImage(context);
-    CGContextRelease(context);
+    // Using UIGraphicsRenderer on supported platforms, and use the main screeen's perferred format (like Wide Color)
+    SDGraphicsImageRendererFormat *format = [SDGraphicsImageRendererFormat preferredFormat];
+    format.scale = 1; // use pixel instead of point
+    format.opaque = !hasAlpha;
+    SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:CGSizeMake(newWidth, newHeight) format:format];
+    UIImage *newImage = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+        // Apply transform
+        CGAffineTransform transform = SDCGContextTransformFromOrientation(orientation, CGSizeMake(newWidth, newHeight));
+        CGContextConcatCTM(context, transform);
+#if SD_MAC
+        UIImage *drawImage = [[UIImage alloc] initWithCGImage:cgImage scale:1 orientation:kCGImagePropertyOrientationUp];
+#else
+        UIImage *drawImage = [[UIImage alloc] initWithCGImage:cgImage scale:1 orientation:UIImageOrientationUp];
+#endif
+        [drawImage drawInRect:CGRectMake(0, 0, width, height)]; // The rect is bounding box of CGImage, don't swap width & height
+    }];
+    CGImageRef newImageRef = newImage.CGImage;
+    // Retain the CGImage because this temp `newImage` will release after function return
+    CGImageRetain(newImageRef);
     
     return newImageRef;
 }

--- a/SDWebImage/Core/SDImageGraphics.h
+++ b/SDWebImage/Core/SDImageGraphics.h
@@ -13,6 +13,7 @@
  These following graphics context method are provided to easily write cross-platform(AppKit/UIKit) code.
  For UIKit, these methods just call the same method in `UIGraphics.h`. See the documentation for usage.
  For AppKit, these methods use `NSGraphicsContext` to create image context and match the behavior like UIKit.
+ @note If you don't care bitmap format (ARGB8888) and just draw image, use `SDGraphicsImageRenderer` instead. It's more performant on RAM usage.`
  */
 
 /// Returns the current graphics context.

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -257,8 +257,8 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 
 - (nullable UIImage *)sd_rotatedImageWithAngle:(CGFloat)angle fitSize:(BOOL)fitSize {
     if (!self.CGImage) return nil;
-    size_t width = (size_t)CGImageGetWidth(self.CGImage);
-    size_t height = (size_t)CGImageGetHeight(self.CGImage);
+    size_t width = self.size.width;
+    size_t height = self.size.height;
     CGRect newRect = CGRectApplyAffineTransform(CGRectMake(0, 0, width, height),
                                                 fitSize ? CGAffineTransformMakeRotation(angle) : CGAffineTransformIdentity);
     

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -269,9 +269,13 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
         CGContextSetShouldAntialias(context, true);
         CGContextSetAllowsAntialiasing(context, true);
         CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
-        // Use UIKit coordinate counterclockwise (⟲)
         CGContextTranslateCTM(context, +(newRect.size.width * 0.5), +(newRect.size.height * 0.5));
+#if SD_UIKIT
+        // Use UIKit coordinate system counterclockwise (⟲)
         CGContextRotateCTM(context, -angle);
+#else
+        CGContextRotateCTM(context, angle);
+#endif
         
         [self drawInRect:CGRectMake(-(width * 0.5), -(height * 0.5), width, height)];
     }];

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -73,7 +73,7 @@
     expect(CGSizeEqualToSize(rotatedImage.size, self.testImage.size)).beTruthy();
     // Fit size, may change size
     rotatedImage = [self.testImage sd_rotatedImageWithAngle:angle fitSize:YES];
-    CGSize rotatedSize = CGSizeMake(floor(300 * 1.414), floor(300 * 1.414)); // 45º, square length * sqrt(2)
+    CGSize rotatedSize = CGSizeMake(ceil(300 * 1.414), ceil(300 * 1.414)); // 45º, square length * sqrt(2)
     expect(CGSizeEqualToSize(rotatedImage.size, rotatedSize)).beTruthy();
     // Check image not inversion
     UIColor *leftCenterColor = [rotatedImage sd_colorAtPoint:CGPointMake(60, 175)];

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -65,6 +65,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDImageFrame.h>
 #import <SDWebImage/SDImageCoderHelper.h>
 #import <SDWebImage/SDImageGraphics.h>
+#import <SDWebImage/SDGraphicsImageRenderer.h>
 #import <SDWebImage/UIImage+GIF.h>
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added `testSDGraphicsImageRenderer`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

[UIGraphicsImageRenderer](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer?language=objc) was introduced in iOS 10+, it's a replacement for current [UIGraphicsBeginImageContext](https://developer.apple.com/documentation/uikit/1623922-uigraphicsbeginimagecontext?language=objc).

See related talk in [WWDC 2018 - Image and Graphics Best Practices](https://developer.apple.com/videos/play/wwdc2018/219/).

### Benefit
The UIGraphicsImageRenderer contains a smart feature, it does not use `CGBitmapContextCreate` for a fixed bitmap format (like ARGB8888, which always use 4 channels). Instead, it use a block-based API. It detect your draw code to choose which bitmap format to use. For example, if you draw a RGB CGImage on it, it just use RGB(save 25% RAM). If you draw a grayscale CIImage (CGImage seems not have grayscale?) on it, it use Gray only (save 75% RAM).

Which means, it's smart and modern to use for our all transformer code. To avoid always generate a ARGB8888 bitmap. I've replaced all of them using the UIGraphicsImageRenderer.

For another feature SDWebImage have, it's the background decode. It previouslly use `CGBitmapContextCreate` with either BGRA8888 or BGRX8888. But now, it can also be replaced. I test seems there are no huge benefit for this case, need more test for this case.