### PR TITLE
Support to use the creation date and the change date to determine the disk cache expire date compare

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -146,11 +146,15 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
         case SDImageCacheConfigExpireTypeAccessDate:
             cacheContentDateKey = NSURLContentAccessDateKey;
             break;
-            
         case SDImageCacheConfigExpireTypeModificationDate:
             cacheContentDateKey = NSURLContentModificationDateKey;
             break;
-            
+        case SDImageCacheConfigExpireTypeCreationDate:
+            cacheContentDateKey = NSURLCreationDateKey;
+            break;
+        case SDImageCacheConfigExpireTypeChangeDate:
+            cacheContentDateKey = NSURLAttributeModificationDateKey;
+            break;
         default:
             break;
     }

--- a/SDWebImage/Core/SDImageCacheConfig.h
+++ b/SDWebImage/Core/SDImageCacheConfig.h
@@ -12,13 +12,21 @@
 /// Image Cache Expire Type
 typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
     /**
-     * When the image is accessed it will update this value
+     * When the image cache is accessed it will update this value
      */
     SDImageCacheConfigExpireTypeAccessDate,
     /**
-     * The image was obtained from the disk cache (Default)
+     * When the image cache is created or modified it will update this value (Default)
      */
-    SDImageCacheConfigExpireTypeModificationDate
+    SDImageCacheConfigExpireTypeModificationDate,
+    /**
+     * When the image cache is created it will update this value
+     */
+    SDImageCacheConfigExpireTypeCreationDate,
+    /**
+     * When the image cache is created, modified, renamed, file attribute updated (like permission, xattr)  it will update this value
+     */
+    SDImageCacheConfigExpireTypeChangeDate,
 };
 
 /**


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR add two extra date

+ `Creation Date`: Update only once, the creation date
+ `Change Date`: Any modification on file attribute, like naming, xattr (our `sd_extendedObject`), will update this value

