### PR TITLE
Support all transformer method on CIImage based UIImage/NSImage

### DIFF
--- a/SDWebImage/Core/NSImage+Compatibility.h
+++ b/SDWebImage/Core/NSImage+Compatibility.h
@@ -20,6 +20,10 @@ The underlying Core Graphics image object. This will actually use `CGImageForPro
  */
 @property (nonatomic, readonly, nullable) CGImageRef CGImage;
 /**
+ The underlying Core Image data. This will actually use `bestRepresentationForRect` with the image size to find the `NSCIImageRep`.
+ */
+@property (nonatomic, readonly, nullable) CIImage *CIImage;
+/**
  The scale factor of the image. This wil actually use `bestRepresentationForRect` with image size and pixel size to calculate the scale factor. If failed, use the default value 1.0. Should be greater than or equal to 1.0.
  */
 @property (nonatomic, readonly) CGFloat scale;
@@ -37,6 +41,16 @@ The underlying Core Graphics image object. This will actually use `CGImageForPro
  @return The image object
  */
 - (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
+
+/**
+ Initializes and returns an image object with the specified Core Image object. The representation is `NSCIImageRep`.
+ 
+ @param ciImage A Core Image image object
+ @param scale The image scale factor
+ @param orientation The orientation of the image data
+ @return The image object
+ */
+- (nonnull instancetype)initWithCIImage:(nonnull CIImage *)ciImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
 
 /**
  Returns an image object with the scale factor. The representation is created from the image data.

--- a/SDWebImage/Core/NSImage+Compatibility.m
+++ b/SDWebImage/Core/NSImage+Compatibility.m
@@ -20,6 +20,15 @@
     return cgImage;
 }
 
+- (nullable CIImage *)CIImage {
+    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
+    if (![imageRep isKindOfClass:NSCIImageRep.class]) {
+        return nil;
+    }
+    return ((NSCIImageRep *)imageRep).CIImage;
+}
+
 - (CGFloat)scale {
     CGFloat scale = 1;
     NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
@@ -50,6 +59,28 @@
         CGImageRelease(rotatedCGImage);
     } else {
         imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
+    }
+    if (scale < 1) {
+        scale = 1;
+    }
+    CGFloat pixelWidth = imageRep.pixelsWide;
+    CGFloat pixelHeight = imageRep.pixelsHigh;
+    NSSize size = NSMakeSize(pixelWidth / scale, pixelHeight / scale);
+    self = [self initWithSize:size];
+    if (self) {
+        imageRep.size = size;
+        [self addRepresentation:imageRep];
+    }
+    return self;
+}
+
+- (instancetype)initWithCIImage:(nonnull CIImage *)ciImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation {
+    NSCIImageRep *imageRep;
+    if (orientation != kCGImagePropertyOrientationUp) {
+        CIImage *rotatedCIImage = [ciImage imageByApplyingOrientation:orientation];
+        imageRep = [[NSCIImageRep alloc] initWithCIImage:rotatedCIImage];
+    } else {
+        imageRep = [[NSCIImageRep alloc] initWithCIImage:ciImage];
     }
     if (scale < 1) {
         scale = 1;

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -582,7 +582,8 @@ static inline CGImageRef _Nullable SDCGImageFromCIImage(CIImage * _Nonnull ciIma
     if (self.CIImage) {
         CIFilter *filter = [CIFilter filterWithName:@"CIGaussianBlur"];
         [filter setValue:self.CIImage forKey:kCIInputImageKey];
-        [filter setValue:@(blurRadius) forKey:kCIInputRadiusKey];
+        // Blur Radius use pixel count
+        [filter setValue:@(blurRadius / 2) forKey:kCIInputRadiusKey];
         CIImage *ciImage = filter.outputImage;
         ciImage = [ciImage imageByCroppingToRect:CGRectMake(0, 0, self.size.width, self.size.height)];
 #if SD_UIKIT

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -166,28 +166,6 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 
 #if SD_UIKIT || SD_MAC
 // Core Image Support
-static inline CIColor *SDCIColorFromUIColor(UIColor * _Nonnull color) {
-    CGFloat red, green, blue, alpha;
-#if SD_UIKIT
-    if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
-        [color getWhite:&red alpha:&alpha];
-        green = red;
-        blue = red;
-    }
-#else
-    @try {
-        [color getRed:&red green:&green blue:&blue alpha:&alpha];
-    }
-    @catch (NSException *exception) {
-        [color getWhite:&red alpha:&alpha];
-        green = red;
-        blue = red;
-    }
-#endif
-    CIColor *ciColor = [CIColor colorWithRed:red green:green blue:blue alpha:alpha];
-    return ciColor;
-}
-
 static inline CGImageRef _Nullable SDCGImageFromCIImage(CIImage * _Nonnull ciImage) {
     CGImageRef imageRef = NULL;
     if (@available(iOS 10, macOS 10.12, tvOS 10, *)) {
@@ -415,7 +393,7 @@ static inline CGImageRef _Nullable SDCGImageFromCIImage(CIImage * _Nonnull ciIma
     // CIImage shortcut
     if (self.CIImage) {
         CIImage *ciImage = self.CIImage;
-        CIImage *colorImage = [CIImage imageWithColor:SDCIColorFromUIColor(tintColor)];
+        CIImage *colorImage = [CIImage imageWithColor:[[CIColor alloc] initWithColor:tintColor]];
         colorImage = [colorImage imageByCroppingToRect:ciImage.extent];
         CIFilter *filter = [CIFilter filterWithName:@"CISourceAtopCompositing"];
         [filter setValue:colorImage forKey:kCIInputImageKey];

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -575,6 +575,7 @@ static inline CIColor *SDCIColorConvertFromUIColor(UIColor * _Nonnull color) {
         [filter setValue:self.CIImage forKey:kCIInputImageKey];
         [filter setValue:@(blurRadius) forKey:kCIInputRadiusKey];
         CIImage *ciImage = filter.outputImage;
+        ciImage = [ciImage imageByCroppingToRect:CGRectMake(0, 0, self.size.width, self.size.height)];
 #if SD_UIKIT
         UIImage *image = [UIImage imageWithCIImage:ciImage scale:self.scale orientation:self.imageOrientation];
 #else

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -605,8 +605,6 @@ static inline CGImageRef _Nullable SDCGImageFromCIImage(CIImage * _Nonnull ciIma
         [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
         imageRef = SDGraphicsGetImageFromCurrentImageContext().CGImage;
         SDGraphicsEndImageContext();
-    } else {
-        CGImageRetain(imageRef);
     }
     
     vImage_Buffer effect = {}, scratch = {};

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -182,7 +182,8 @@
     expect([leftColor.sd_hexString isEqualToString:expectedColor.sd_hexString]);
     // Check rounded corner operation not inversion the image
     UIColor *topCenterColor = [blurredImage sd_colorAtPoint:CGPointMake(150, 20)];
-    expect([topCenterColor.sd_hexString isEqualToString:@"#9a430d06"]).beTruthy();
+    UIColor *bottomCenterColor = [blurredImage sd_colorAtPoint:CGPointMake(150, 280)];
+    expect([topCenterColor.sd_hexString isEqualToString:bottomCenterColor.sd_hexString]).beFalsy();
 }
 
 - (void)test08UIImageTransformFilterCG {

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -74,7 +74,8 @@
     // Fit size, may change size
     rotatedImage = [self.testImage sd_rotatedImageWithAngle:angle fitSize:YES];
     CGSize rotatedSize = CGSizeMake(ceil(300 * 1.414), ceil(300 * 1.414)); // 45º, square length * sqrt(2)
-    expect(CGSizeEqualToSize(rotatedImage.size, rotatedSize)).beTruthy();
+    expect(rotatedImage.size.width - rotatedSize.width <= 1).beTruthy();
+    expect(rotatedImage.size.height - rotatedSize.height <= 1).beTruthy();
     // Check image not inversion
     UIColor *leftCenterColor = [rotatedImage sd_colorAtPoint:CGPointMake(60, 175)];
     expect([leftCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -13,7 +13,8 @@
 
 @interface SDImageTransformerTests : SDTestCase
 
-@property (nonatomic, strong) UIImage *testImage;
+@property (nonatomic, strong) UIImage *testImageCG;
+@property (nonatomic, strong) UIImage *testImageCI;
 
 @end
 
@@ -22,21 +23,37 @@
 #pragma mark - UIImage+Transform
 
 // UIImage+Transform test is hard to write because it's more about visual effect. Current it's tied to the `TestImage.png`, please keep that image or write new test with new image
-- (void)test01UIImageTransformResize {
+- (void)test01UIImageTransformResizeCG {
+    [self test01UIImageTransformResizeWithImage:self.testImageCG];
+}
+
+- (void)test01UIImageTransformResizeCI {
+    [self test01UIImageTransformResizeWithImage:self.testImageCI];
+}
+
+- (void)test01UIImageTransformResizeWithImage:(UIImage *)testImage {
     CGSize scaleDownSize = CGSizeMake(200, 100);
-    UIImage *scaledDownImage = [self.testImage sd_resizedImageWithSize:scaleDownSize scaleMode:SDImageScaleModeFill];
+    UIImage *scaledDownImage = [testImage sd_resizedImageWithSize:scaleDownSize scaleMode:SDImageScaleModeFill];
     expect(CGSizeEqualToSize(scaledDownImage.size, scaleDownSize)).beTruthy();
     CGSize scaleUpSize = CGSizeMake(2000, 1000);
-    UIImage *scaledUpImage = [self.testImage sd_resizedImageWithSize:scaleUpSize scaleMode:SDImageScaleModeAspectFit];
+    UIImage *scaledUpImage = [testImage sd_resizedImageWithSize:scaleUpSize scaleMode:SDImageScaleModeAspectFit];
     expect(CGSizeEqualToSize(scaledUpImage.size, scaleUpSize)).beTruthy();
     // Check image not inversion
     UIColor *topCenterColor = [scaledUpImage sd_colorAtPoint:CGPointMake(1000, 50)];
     expect([topCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test02UIImageTransformCrop {
+- (void)test02UIImageTransformCropCG {
+    [self test02UIImageTransformCropWithImage:self.testImageCG];
+}
+
+- (void)test02UIImageTransformCropCI {
+    [self test02UIImageTransformCropWithImage:self.testImageCI];
+}
+
+- (void)test02UIImageTransformCropWithImage:(UIImage *)testImage {
     CGRect rect = CGRectMake(50, 10, 200, 200);
-    UIImage *croppedImage = [self.testImage sd_croppedImageWithRect:rect];
+    UIImage *croppedImage = [testImage sd_croppedImageWithRect:rect];
     expect(CGSizeEqualToSize(croppedImage.size, CGSizeMake(200, 200))).beTruthy();
     UIColor *startColor = [croppedImage sd_colorAtPoint:CGPointZero];
     expect([startColor.sd_hexString isEqualToString:[UIColor clearColor].sd_hexString]).beTruthy();
@@ -45,7 +62,15 @@
     expect([topCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test03UIImageTransformRoundedCorner {
+- (void)test03UIImageTransformRoundedCornerCG {
+    [self test03UIImageTransformRoundedCornerWithImage:self.testImageCG];
+}
+
+- (void)test03UIImageTransformRoundedCornerCI {
+    [self test03UIImageTransformRoundedCornerWithImage:self.testImageCI];
+}
+
+- (void)test03UIImageTransformRoundedCornerWithImage:(UIImage *)testImage {
     CGFloat radius = 50;
 #if SD_UIKIT
     SDRectCorner corners = UIRectCornerAllCorners;
@@ -54,7 +79,7 @@
 #endif
     CGFloat borderWidth = 1;
     UIColor *borderColor = [UIColor blackColor];
-    UIImage *roundedCornerImage = [self.testImage sd_roundedCornerImageWithRadius:radius corners:corners borderWidth:borderWidth borderColor:borderColor];
+    UIImage *roundedCornerImage = [testImage sd_roundedCornerImageWithRadius:radius corners:corners borderWidth:borderWidth borderColor:borderColor];
     expect(CGSizeEqualToSize(roundedCornerImage.size, CGSizeMake(300, 300))).beTruthy();
     UIColor *startColor = [roundedCornerImage sd_colorAtPoint:CGPointZero];
     expect([startColor.sd_hexString isEqualToString:[UIColor clearColor].sd_hexString]).beTruthy();
@@ -66,13 +91,21 @@
     expect([topCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test04UIImageTransformRotate {
+- (void)test04UIImageTransformRotateCG {
+    [self test04UIImageTransformRotateWithImage:self.testImageCG];
+}
+
+- (void)test04UIImageTransformRotateCI {
+    [self test04UIImageTransformRotateWithImage:self.testImageCI];
+}
+
+- (void)test04UIImageTransformRotateWithImage:(UIImage *)testImage {
     CGFloat angle = M_PI_4;
-    UIImage *rotatedImage = [self.testImage sd_rotatedImageWithAngle:angle fitSize:NO];
+    UIImage *rotatedImage = [testImage sd_rotatedImageWithAngle:angle fitSize:NO];
     // Not fit size and no change
-    expect(CGSizeEqualToSize(rotatedImage.size, self.testImage.size)).beTruthy();
+    expect(CGSizeEqualToSize(rotatedImage.size, testImage.size)).beTruthy();
     // Fit size, may change size
-    rotatedImage = [self.testImage sd_rotatedImageWithAngle:angle fitSize:YES];
+    rotatedImage = [testImage sd_rotatedImageWithAngle:angle fitSize:YES];
     CGSize rotatedSize = CGSizeMake(ceil(300 * 1.414), ceil(300 * 1.414)); // 45º, square length * sqrt(2)
     expect(rotatedImage.size.width - rotatedSize.width <= 1).beTruthy();
     expect(rotatedImage.size.height - rotatedSize.height <= 1).beTruthy();
@@ -81,11 +114,19 @@
     expect([leftCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test05UIImageTransformFlip {
+- (void)test05UIImageTransformFlipCG {
+    [self test05UIImageTransformFlipWithImage:self.testImageCG];
+}
+
+- (void)test05UIImageTransformFlipCI {
+    [self test05UIImageTransformFlipWithImage:self.testImageCI];
+}
+
+- (void)test05UIImageTransformFlipWithImage:(UIImage *)testImage {
     BOOL horizontal = YES;
     BOOL vertical = YES;
-    UIImage *flippedImage = [self.testImage sd_flippedImageWithHorizontal:horizontal vertical:vertical];
-    expect(CGSizeEqualToSize(flippedImage.size, self.testImage.size)).beTruthy();
+    UIImage *flippedImage = [testImage sd_flippedImageWithHorizontal:horizontal vertical:vertical];
+    expect(CGSizeEqualToSize(flippedImage.size, testImage.size)).beTruthy();
     // Test pixel colors method here
     UIColor *checkColor = [flippedImage sd_colorAtPoint:CGPointMake(75, 75)];
     expect(checkColor);
@@ -99,10 +140,18 @@
     expect([bottomCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test06UIImageTransformTint {
+- (void)test06UIImageTransformTintCG {
+    [self test06UIImageTransformTintWithImage:self.testImageCG];
+}
+
+- (void)test06UIImageTransformTintCI {
+    [self test06UIImageTransformTintWithImage:self.testImageCI];
+}
+
+- (void)test06UIImageTransformTintWithImage:(UIImage *)testImage {
     UIColor *tintColor = [UIColor blackColor];
-    UIImage *tintedImage = [self.testImage sd_tintedImageWithColor:tintColor];
-    expect(CGSizeEqualToSize(tintedImage.size, self.testImage.size)).beTruthy();
+    UIImage *tintedImage = [testImage sd_tintedImageWithColor:tintColor];
+    expect(CGSizeEqualToSize(tintedImage.size, testImage.size)).beTruthy();
     // Check center color, should keep clear
     UIColor *centerColor = [tintedImage sd_colorAtPoint:CGPointMake(150, 150)];
     expect([centerColor.sd_hexString isEqualToString:[UIColor clearColor].sd_hexString]);
@@ -114,10 +163,18 @@
     expect([topCenterColor.sd_hexString isEqualToString:[UIColor blackColor].sd_hexString]).beTruthy();
 }
 
-- (void)test07UIImageTransformBlur {
+- (void)test07UIImageTransformBlurCG {
+    [self test07UIImageTransformBlurWithImage:self.testImageCG];
+}
+
+- (void)test07UIImageTransformBlurCI {
+    [self test07UIImageTransformBlurWithImage:self.testImageCI];
+}
+
+- (void)test07UIImageTransformBlurWithImage:(UIImage *)testImage {
     CGFloat radius = 50;
-    UIImage *blurredImage = [self.testImage sd_blurredImageWithRadius:radius];
-    expect(CGSizeEqualToSize(blurredImage.size, self.testImage.size)).beTruthy();
+    UIImage *blurredImage = [testImage sd_blurredImageWithRadius:radius];
+    expect(CGSizeEqualToSize(blurredImage.size, testImage.size)).beTruthy();
     // Check left color, should be blurred
     UIColor *leftColor = [blurredImage sd_colorAtPoint:CGPointMake(80, 150)];
     // Hard-code from the output
@@ -128,11 +185,19 @@
     expect([topCenterColor.sd_hexString isEqualToString:@"#9a430d06"]).beTruthy();
 }
 
-- (void)test08UIImageTransformFilter {
+- (void)test08UIImageTransformFilterCG {
+    [self test08UIImageTransformFilterWithImage:self.testImageCG];
+}
+
+- (void)test08UIImageTransformFilterCI {
+    [self test08UIImageTransformFilterWithImage:self.testImageCI];
+}
+
+- (void)test08UIImageTransformFilterWithImage:(UIImage *)testImage {
     // Invert color filter
     CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];
-    UIImage *filteredImage = [self.testImage sd_filteredImageWithFilter:filter];
-    expect(CGSizeEqualToSize(filteredImage.size, self.testImage.size)).beTruthy();
+    UIImage *filteredImage = [testImage sd_filteredImageWithFilter:filter];
+    expect(CGSizeEqualToSize(filteredImage.size, testImage.size)).beTruthy();
     // Check left color, should be inverted
     UIColor *leftColor = [filteredImage sd_colorAtPoint:CGPointMake(80, 150)];
     // Hard-code from the output
@@ -199,7 +264,7 @@
     NSString *transformerKey = [transformerKeys componentsJoinedByString:@"-"]; // SDImageTransformerKeySeparator
     expect([pipelineTransformer.transformerKey isEqualToString:transformerKey]).beTruthy();
     
-    UIImage *transformedImage = [pipelineTransformer transformedImageWithImage:self.testImage forKey:@"Test"];
+    UIImage *transformedImage = [pipelineTransformer transformedImageWithImage:self.testImageCG forKey:@"Test"];
     expect(transformedImage).notTo.beNil();
     expect(CGSizeEqualToSize(transformedImage.size, cropRect.size)).beTruthy();
 }
@@ -239,6 +304,8 @@
     key = @"ftp://root:password@foo.com/image.png";
     expect(SDTransformedKeyForKey(key, transformerKey)).equal(@"ftp://root:password@foo.com/image-SDImageFlippingTransformer(1,0).png");
 }
+
+#pragma mark - Coder Helper
 
 - (void)test20CGImageCreateDecodedWithOrientation {
     // Test EXIF orientation tag, you can open this image with `Preview.app`, open inspector (Command+I) and rotate (Command+L/R) to check
@@ -332,11 +399,23 @@
 
 #pragma mark - Helper
 
-- (UIImage *)testImage {
-    if (!_testImage) {
-        _testImage = [[UIImage alloc] initWithContentsOfFile:[self testPNGPathForName:@"TestImage"]];
+- (UIImage *)testImageCG {
+    if (!_testImageCG) {
+        _testImageCG = [[UIImage alloc] initWithContentsOfFile:[self testPNGPathForName:@"TestImage"]];
     }
-    return _testImage;
+    return _testImageCG;
+}
+
+- (UIImage *)testImageCI {
+    if (!_testImageCI) {
+        CIImage *ciImage = [[CIImage alloc] initWithContentsOfURL:[NSURL fileURLWithPath:[self testPNGPathForName:@"TestImage"]]];
+#if SD_UIKIT
+        _testImageCI = [[UIImage alloc] initWithCIImage:ciImage scale:1 orientation:UIImageOrientationUp];
+#else
+        _testImageCI = [[UIImage alloc] initWithCIImage:ciImage scale:1 orientation:kCGImagePropertyOrientationUp];
+#endif
+    }
+    return _testImageCI;
 }
 
 - (NSString *)testPNGPathForName:(NSString *)name {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Current all methods in `UIImage+Transform`, does not works on the CIImage based UIImage/NSImage (which `.CIImage` returns nonnil, but `.CGImage` returns nil)

This PR support all CIImage, with the correspond Core Image method (not just convert it into CGImage, because it's slower).

