### PR TITLE
SDAnimatedImage now only keep the animated coder when frame count >=1 , else we wil behave like UIImage to save RAM usage

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.h
+++ b/SDWebImage/Core/SDAnimatedImage.h
@@ -72,6 +72,7 @@
 
 // This class override these methods from UIImage(NSImage), and it supports NSSecureCoding.
 // You should use these methods to create a new animated image. Use other methods just call super instead.
+// Pay attention, when the animated image frame count <= 1, all the `SDAnimatedImage` protocol methods will return nil or 0 value, you'd better check the frame count before usage and keep fallback.
 + (nullable instancetype)imageNamed:(nonnull NSString *)name; // Cache in memory, no Asset Catalog support
 #if __has_include(<UIKit/UITraitCollection.h>)
 + (nullable instancetype)imageNamed:(nonnull NSString *)name inBundle:(nullable NSBundle *)bundle compatibleWithTraitCollection:(nullable UITraitCollection *)traitCollection; // Cache in memory, no Asset Catalog support


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2923

### Pull Request Description

See #2923 and https://github.com/SDWebImage/SDWebImageWebPCoder/issues/29 to know the reason. 

One solution, is to return nil when the frame count <= 1. However, I found this may break some users' usage. See our own code `SDWebImageMatchAnimatedImageClass` which assume the init success, or the [SDWebImageSwiftUI](https://github.com/SDWebImage/SDWebImageSwiftUI)'s `AnimatedImage` struct, which use only `SDAnimatedImage`.

So, I this instead of return a nil value, return a valid `SDAnimatedImage` instance, but without the keep of `SDAnimatedImageCoder` is a better idea. Which can both reduce RAM usage and keep the compatible for users.
