### PR TITLE
Fix gaussian blur radius bug

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -237,7 +237,7 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
     return YES;
 }
 
-#pragma mark - SDAnimatedImage
+#pragma mark - SDAnimatedImageProvider
 
 - (NSData *)animatedImageData {
     return [self.animatedCoder animatedImageData];

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -569,12 +569,13 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
         return self;
     }
     
+    CGFloat scale = self.scale;
+    CGFloat inputRadius = blurRadius * scale;
 #if SD_UIKIT || SD_MAC
     if (self.CIImage) {
         CIFilter *filter = [CIFilter filterWithName:@"CIGaussianBlur"];
         [filter setValue:self.CIImage forKey:kCIInputImageKey];
-        // Blur Radius use pixel count
-        [filter setValue:@(blurRadius / 2) forKey:kCIInputRadiusKey];
+        [filter setValue:@(inputRadius) forKey:kCIInputRadiusKey];
         CIImage *ciImage = filter.outputImage;
         ciImage = [ciImage imageByCroppingToRect:CGRectMake(0, 0, self.size.width, self.size.height)];
 #if SD_UIKIT
@@ -586,7 +587,6 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
     }
 #endif
     
-    CGFloat scale = self.scale;
     CGImageRef imageRef = self.CGImage;
     
     //convert to BGRA if it isn't
@@ -640,9 +640,8 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
         //
         // ... if d is odd, use three box-blurs of size 'd', centered on the output pixel.
         //
-        CGFloat inputRadius = blurRadius * scale;
         if (inputRadius - 2.0 < __FLT_EPSILON__) inputRadius = 2.0;
-        uint32_t radius = floor((inputRadius * 3.0 * sqrt(2 * M_PI) / 4 + 0.5) / 2);
+        uint32_t radius = floor(inputRadius * 3.0 * sqrt(2 * M_PI) / 4 + 0.5);
         radius |= 1; // force radius to be odd so that the three box-blur methodology works.
         int iterations;
         if (blurRadius * scale < 0.5) iterations = 1;

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -559,7 +559,7 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
 
 #pragma mark - Image Effect
 
-// We use vImage to do box convolve for performance and support for watchOS. However, you can just use `CIFilter.CIBoxBlur`. For other blur effect, use any filter in `CICategoryBlur`
+// We use vImage to do box convolve for performance and support for watchOS. However, you can just use `CIFilter.CIGaussianBlur`. For other blur effect, use any filter in `CICategoryBlur`
 - (nullable UIImage *)sd_blurredImageWithRadius:(CGFloat)blurRadius {
     if (self.size.width < 1 || self.size.height < 1) {
         return nil;

--- a/Tests/Tests/SDImageTransformerTests.m
+++ b/Tests/Tests/SDImageTransformerTests.m
@@ -172,7 +172,7 @@
 }
 
 - (void)test07UIImageTransformBlurWithImage:(UIImage *)testImage {
-    CGFloat radius = 50;
+    CGFloat radius = 25;
     UIImage *blurredImage = [testImage sd_blurredImageWithRadius:radius];
     expect(CGSizeEqualToSize(blurredImage.size, testImage.size)).beTruthy();
     // Check left color, should be blurred


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See W3C Standard: https://www.w3.org/TR/SVG11/filters.html#feGaussianBlurElement

The gaussian blur should use 3 times box convolve, which the box size should be equal to the following fomula:

```
let d = floor(s * 3*sqrt(2*pi)/4 + 0.5)
```

But however, currrent we calculate with this fomula instead, which is wrong:

```
let d = floor((s * 3*sqrt(2*pi)/4 + 0.5) / 2)
```

+ Wrong One: React Native iOS: https://github.com/facebook/react-native/blob/master/Libraries/Image/RCTImageBlurUtils.m#L48
+ Correct One: Google Chrome for iOS: https://chromium.googlesource.com/chromium/src.git/+/81.0.4028.1/ios/chrome/browser/ui/util/uikit_ui_util.mm#363