### PR TITLE
Fix the issue that `maxBufferSize` property does not correctlly works for `SDAnimatedImageView`

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -19,6 +19,7 @@
 @interface SDAnimatedImageView () <CALayerDelegate> {
     BOOL _initFinished; // Extra flag to mark the `commonInit` is called
     NSRunLoopMode _runLoopMode;
+    NSUInteger _maxBufferSize;
     double _playbackRate;
 }
 
@@ -153,6 +154,9 @@
         // RunLoop Mode
         self.player.runLoopMode = self.runLoopMode;
         
+        // Max Buffer Size
+        self.player.maxBufferSize = self.maxBufferSize;
+        
         // Play Rate
         self.player.playbackRate = self.playbackRate;
         
@@ -205,6 +209,16 @@
 + (NSString *)defaultRunLoopMode {
     // Key off `activeProcessorCount` (as opposed to `processorCount`) since the system could shut down cores in certain situations.
     return [NSProcessInfo processInfo].activeProcessorCount > 1 ? NSRunLoopCommonModes : NSDefaultRunLoopMode;
+}
+
+- (void)setMaxBufferSize:(NSUInteger)maxBufferSize
+{
+    _maxBufferSize = maxBufferSize;
+    self.player.maxBufferSize = maxBufferSize;
+}
+
+- (NSUInteger)maxBufferSize {
+    return _maxBufferSize; // Defaults to 0
 }
 
 - (void)setPlaybackRate:(double)playbackRate


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Should setup the player's property

