### PR TITLE
Try to fix the issue caused by Swift PM 5.2, the `sources` DSL only matches the individual source files, but not folder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,24 +30,14 @@ let package = Package(
         .target(
             name: "SDWebImage",
             dependencies: [],
-            path: ".",
-            sources: ["SDWebImage/Core", "SDWebImage/Private"],
-            publicHeadersPath: "SDWebImage/Core",
-            cSettings: [
-                .headerSearchPath("SDWebImage/Core"),
-                .headerSearchPath("SDWebImage/Private")
-            ]
+            path: "SDWebImage",
+            exclude: ["MapKit"],
+            publicHeadersPath: "Core"
         ),
         .target(
             name: "SDWebImageMapKit",
             dependencies: ["SDWebImage"],
-            path: ".",
-            sources: ["SDWebImage/MapKit"],
-            publicHeadersPath: "SDWebImage/MapKit",
-            cSettings: [
-                .headerSearchPath("SDWebImage/Core"),
-                .headerSearchPath("SDWebImage/Private")
-            ]
+            path: "SDWebImage/MapKit"
         )
     ]
 )

--- a/SDWebImage/MapKit/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MapKit/MKAnnotationView+WebCache.m
@@ -10,10 +10,7 @@
 
 #if SD_UIKIT || SD_MAC
 
-#import "objc/runtime.h"
-#import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
-#import "SDInternalMacros.h"
 
 @implementation MKAnnotationView (WebCache)
 
@@ -55,14 +52,13 @@
                    context:(nullable SDWebImageContext *)context
                   progress:(nullable SDImageLoaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
-    @weakify(self);
+    __weak typeof(self) wself = self;
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
                              options:options
                              context:context
                        setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-                           @strongify(self);
-                           self.image = image;
+                           wself.image = image;
                        }
                             progress:progressBlock
                            completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2941 

### Pull Request Description

I didn't upgrade to macOS Catalina 10.15.2 yet so I can not use Xcode 11.4 to test, can anyone help me to have a try ? @kylebrowning  @RyuX51 @maundytime @kiliankoe

You can change to use the dependency with the folk repo in Xcode 11.4 Package dependency

This based on the reply from Swift Forum: https://forums.swift.org/t/any-changes-to-spm-5-2-with-xcode-11-4-beta2-pure-objective-c-project-which-contains-multiple-targets-now-fail-to-integrate/34101/6