### PR TITLE
Fix the NotificationCenter does not remove the observer and little private header garden

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -514,6 +514,7 @@ didReceiveResponse:(NSURLResponse *)response
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadStopNotification object:nil];
 }
 
 - (instancetype)initWithDownloadOperation:(NSOperation<SDWebImageDownloaderOperation> *)downloadOperation {

--- a/SDWebImage/Private/SDAsyncBlockOperation.h
+++ b/SDWebImage/Private/SDAsyncBlockOperation.h
@@ -11,6 +11,7 @@
 @class SDAsyncBlockOperation;
 typedef void (^SDAsyncBlock)(SDAsyncBlockOperation * __nonnull asyncOperation);
 
+/// A async block operation, success after you call `completer` (not like `NSBlockOperation` which is for sync block, success on return)
 @interface SDAsyncBlockOperation : NSOperation
 
 - (nonnull instancetype)initWithBlock:(nonnull SDAsyncBlock)block;

--- a/SDWebImage/Private/SDDeviceHelper.h
+++ b/SDWebImage/Private/SDDeviceHelper.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
+/// Device information helper methods
 @interface SDDeviceHelper : NSObject
 
 + (NSUInteger)totalMemory;

--- a/SDWebImage/Private/SDDisplayLink.h
+++ b/SDWebImage/Private/SDDisplayLink.h
@@ -9,9 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-// Cross-platform display link wrapper. Do not retain the target
-// Use `CADisplayLink` on iOS/tvOS, `CVDisplayLink` on macOS, `NSTimer` on watchOS
-
+/// Cross-platform display link wrapper. Do not retain the target
+/// Use `CADisplayLink` on iOS/tvOS, `CVDisplayLink` on macOS, `NSTimer` on watchOS
 @interface SDDisplayLink : NSObject
 
 @property (readonly, nonatomic, weak, nullable) id target;

--- a/SDWebImage/Private/SDFileAttributeHelper.h
+++ b/SDWebImage/Private/SDFileAttributeHelper.h
@@ -7,12 +7,13 @@
 
 #import <Foundation/Foundation.h>
 
+/// File Extended Attribute (xattr) helper methods
 @interface SDFileAttributeHelper : NSObject
 
-+ (NSArray*)extendedAttributeNamesAtPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err;
-+ (BOOL)hasExtendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err;
-+ (NSData*)extendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err;
-+ (BOOL)setExtendedAttribute:(NSString*)name value:(NSData*)value atPath:(NSString*)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError**)err;
-+ (BOOL)removeExtendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err;
++ (nullable NSArray<NSString *> *)extendedAttributeNamesAtPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)hasExtendedAttribute:(nonnull NSString *)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (nullable NSData *)extendedAttribute:(nonnull NSString*)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)setExtendedAttribute:(nonnull NSString*)name value:(nonnull NSData *)value atPath:(nonnull NSString*)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)removeExtendedAttribute:(nonnull NSString*)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
 
 @end

--- a/SDWebImage/Private/SDFileAttributeHelper.h
+++ b/SDWebImage/Private/SDFileAttributeHelper.h
@@ -10,10 +10,10 @@
 /// File Extended Attribute (xattr) helper methods
 @interface SDFileAttributeHelper : NSObject
 
-+ (nullable NSArray<NSString *> *)extendedAttributeNamesAtPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
-+ (BOOL)hasExtendedAttribute:(nonnull NSString *)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
-+ (nullable NSData *)extendedAttribute:(nonnull NSString*)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
-+ (BOOL)setExtendedAttribute:(nonnull NSString*)name value:(nonnull NSData *)value atPath:(nonnull NSString*)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError * _Nullable * _Nullable)err;
-+ (BOOL)removeExtendedAttribute:(nonnull NSString*)name atPath:(nonnull NSString*)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (nullable NSArray<NSString *> *)extendedAttributeNamesAtPath:(nonnull NSString *)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)hasExtendedAttribute:(nonnull NSString *)name atPath:(nonnull NSString *)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (nullable NSData *)extendedAttribute:(nonnull NSString *)name atPath:(nonnull NSString *)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)setExtendedAttribute:(nonnull NSString *)name value:(nonnull NSData *)value atPath:(nonnull NSString *)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError * _Nullable * _Nullable)err;
++ (BOOL)removeExtendedAttribute:(nonnull NSString *)name atPath:(nonnull NSString *)path traverseLink:(BOOL)follow error:(NSError * _Nullable * _Nullable)err;
 
 @end

--- a/SDWebImage/Private/SDFileAttributeHelper.m
+++ b/SDWebImage/Private/SDFileAttributeHelper.m
@@ -10,7 +10,7 @@
 
 @implementation SDFileAttributeHelper
 
-+ (NSArray*)extendedAttributeNamesAtPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err {
++ (NSArray*)extendedAttributeNamesAtPath:(NSString *)path traverseLink:(BOOL)follow error:(NSError **)err {
     int flags = follow? 0 : XATTR_NOFOLLOW;
     
     // get size of name list
@@ -39,7 +39,7 @@
     return [NSArray arrayWithArray:names];
 }
 
-+ (BOOL)hasExtendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err {
++ (BOOL)hasExtendedAttribute:(NSString *)name atPath:(NSString *)path traverseLink:(BOOL)follow error:(NSError **)err {
     int flags = follow? 0 : XATTR_NOFOLLOW;
     
     // get size of name list
@@ -67,7 +67,7 @@
     return NO;
 }
 
-+ (NSData*)extendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err {
++ (NSData *)extendedAttribute:(NSString *)name atPath:(NSString *)path traverseLink:(BOOL)follow error:(NSError **)err {
     int flags = follow? 0 : XATTR_NOFOLLOW;
     // get length
     ssize_t attrLen = getxattr([path fileSystemRepresentation], [name UTF8String], NULL, 0, 0, flags);
@@ -85,12 +85,12 @@
     }
     
     // get attribute data
-    NSMutableData * attrData = [NSMutableData dataWithLength:attrLen];
+    NSMutableData *attrData = [NSMutableData dataWithLength:attrLen];
     getxattr([path fileSystemRepresentation], [name UTF8String], [attrData mutableBytes], attrLen, 0, flags);
     return attrData;
 }
 
-+ (BOOL)setExtendedAttribute:(NSString*)name value:(NSData*)value atPath:(NSString*)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError**)err {
++ (BOOL)setExtendedAttribute:(NSString *)name value:(NSData *)value atPath:(NSString *)path traverseLink:(BOOL)follow overwrite:(BOOL)overwrite error:(NSError **)err {
     int flags = (follow? 0 : XATTR_NOFOLLOW) | (overwrite? 0 : XATTR_CREATE);
     if (0 == setxattr([path fileSystemRepresentation], [name UTF8String], [value bytes], [value length], 0, flags)) return YES;
     // error
@@ -108,7 +108,7 @@
     return NO;
 }
 
-+ (BOOL)removeExtendedAttribute:(NSString*)name atPath:(NSString*)path traverseLink:(BOOL)follow error:(NSError**)err {
++ (BOOL)removeExtendedAttribute:(NSString *)name atPath:(NSString *)path traverseLink:(BOOL)follow error:(NSError **)err {
     int flags = (follow? 0 : XATTR_NOFOLLOW);
     if (0 == removexattr([path fileSystemRepresentation], [name UTF8String], flags)) return YES;
     // error

--- a/SDWebImage/Private/SDImageAssetManager.h
+++ b/SDWebImage/Private/SDImageAssetManager.h
@@ -9,8 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-// Apple parse the Asset Catalog compiled file(`Assets.car`) by CoreUI.framework, however it's a private framework and there are no other ways to directly get the data. So we just process the normal bundle files :)
-
+/// A Image-Asset manager to work like UIKit/AppKit's image cache behavior
+/// Apple parse the Asset Catalog compiled file(`Assets.car`) by CoreUI.framework, however it's a private framework and there are no other ways to directly get the data. So we just process the normal bundle files :)
 @interface SDImageAssetManager : NSObject
 
 @property (nonatomic, strong, nonnull) NSMapTable<NSString *, UIImage *> *imageTable;

--- a/SDWebImage/Private/SDImageCachesManagerOperation.h
+++ b/SDWebImage/Private/SDImageCachesManagerOperation.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-// This is used for operation management, but not for operation queue execute
+/// This is used for operation management, but not for operation queue execute
 @interface SDImageCachesManagerOperation : NSOperation
 
 @property (nonatomic, assign, readonly) NSUInteger pendingCount;

--- a/SDWebImage/Private/SDWeakProxy.h
+++ b/SDWebImage/Private/SDWeakProxy.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
+/// A weak proxy which forward all the message to the target
 @interface SDWeakProxy : NSProxy
 
 @property (nonatomic, weak, readonly, nullable) id target;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

@kinarobin This PR seems be Missed during the 5.6.0.

The NSNotification remove observer should be added for iOS 8.0~9.0, or it will receive notification even object is dealloced and crassh.

