### PR TITLE
Refactory the current thumbnail && transformer about cache key. Developer should have the API to calcualte the cache key from thumbnail or transformer, not hard-coded.

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -247,7 +247,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Operation that queries the cache asynchronously and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image
+ * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a NSOperation instance containing the cache op
@@ -257,7 +257,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image
+ * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param options   A mask to specify options to use for this cache query
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
@@ -268,7 +268,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image
+ * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param options   A mask to specify options to use for this cache query
  * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
  * @param doneBlock The completion block. Will not get called if the operation is cancelled

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -227,8 +227,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 #pragma mark - Query and Retrieve Ops
 
 /**
- * Asynchronously queries the cache with operation and call the completion when done.
- *  Query the image data for the given key synchronously.
+ * Synchronously query the image data for the given key in disk cache. You can decode the image data to image after loaded.
  *
  *  @param key The unique key used to store the wanted image
  *  @return The image data for the given key, or nil if not found.
@@ -236,16 +235,16 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 - (nullable NSData *)diskImageDataForKey:(nullable NSString *)key;
 
 /**
- * Asynchronously load the image data in disk cache. You can decode the image data to image after loaded.
+ * Asynchronously query the image data for the given key in disk cache. You can decode the image data to image after loaded.
  *
  *  @param key The unique key used to store the wanted image
- *  @param completionBlock the block to be executed when the check is done.
+ *  @param completionBlock the block to be executed when the query is done.
  *  @note the completion block will be always executed on the main queue
  */
 - (void)diskImageDataQueryForKey:(nullable NSString *)key completion:(nullable SDImageCacheQueryDataCompletionBlock)completionBlock;
 
 /**
- * Operation that queries the cache asynchronously and call the completion when done.
+ * Asynchronously queries the cache with operation and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image. If you want transformed or thumbnail image, calculate the key with `SDTransformedKeyForKey`, `SDThumbnailedKeyForKey`, or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
@@ -307,12 +306,32 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key;
 
 /**
+ * Synchronously query the disk cache. With the options and context which may effect the image generation. (Such as transformer, animated image, thumbnail, etc)
+ *
+ * @param key The unique key used to store the image
+ * @param options   A mask to specify options to use for this cache query
+ * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ * @return The image for the given key, or nil if not found.
+ */
+- (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context;
+
+/**
  * Synchronously query the cache (memory and or disk) after checking the memory cache.
  *
  * @param key The unique key used to store the image
  * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key;
+
+/**
+ * Synchronously query the cache (memory and or disk) after checking the memory cache. With the options and context which may effect the image generation. (Such as transformer, animated image, thumbnail, etc)
+ *
+ * @param key The unique key used to store the image
+ * @param options   A mask to specify options to use for this cache query
+ * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ * @return The image for the given key, or nil if not found.
+ */
+- (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context;;
 
 #pragma mark - Remove Ops
 

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -247,7 +247,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Operation that queries the cache asynchronously and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
+ * @param key       The unique key used to store the wanted image. If you want transformed or thumbnail image, calculate the key with `SDTransformedKeyForKey`, `SDThumbnailedKeyForKey`, or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a NSOperation instance containing the cache op
@@ -257,7 +257,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
+ * @param key       The unique key used to store the wanted image. If you want transformed or thumbnail image, calculate the key with `SDTransformedKeyForKey`, `SDThumbnailedKeyForKey`, or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param options   A mask to specify options to use for this cache query
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
@@ -268,7 +268,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
  *
- * @param key       The unique key used to store the wanted image. If you need transformer's image, calculate the key with `SDTransformedKeyForKey` or generate the cache key from url with `cacheKeyForURL:context:`.
+ * @param key       The unique key used to store the wanted image. If you want transformed or thumbnail image, calculate the key with `SDTransformedKeyForKey`, `SDThumbnailedKeyForKey`, or generate the cache key from url with `cacheKeyForURL:context:`.
  * @param options   A mask to specify options to use for this cache query
  * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
  * @param doneBlock The completion block. Will not get called if the operation is cancelled

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -9,7 +9,6 @@
 #import "SDImageCache.h"
 #import "NSImage+Compatibility.h"
 #import "SDImageCodersManager.h"
-#import "SDImageTransformer.h"
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 #import "UIImage+MemoryCacheCost.h"
@@ -453,13 +452,6 @@
             doneBlock(nil, nil, SDImageCacheTypeNone);
         }
         return nil;
-    }
-    
-    id<SDImageTransformer> transformer = context[SDWebImageContextImageTransformer];
-    if (transformer) {
-        // grab the transformed disk image if transformer provided
-        NSString *transformerKey = [transformer transformerKey];
-        key = SDTransformedKeyForKey(key, transformerKey);
     }
     
     // First check the in-memory cache...

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -341,7 +341,12 @@
 }
 
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key {
-    UIImage *diskImage = [self diskImageForKey:key];
+    return [self imageFromDiskCacheForKey:key options:0 context:nil];
+}
+
+- (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context {
+    NSData *data = [self diskImageDataForKey:key];
+    UIImage *diskImage = [self diskImageForKey:key data:data options:options context:context];
     if (diskImage && self.config.shouldCacheImagesInMemory) {
         NSUInteger cost = diskImage.sd_memoryCost;
         [self.memoryCache setObject:diskImage forKey:key cost:cost];
@@ -351,6 +356,10 @@
 }
 
 - (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key {
+    return [self imageFromCacheForKey:key options:0 context:nil];
+}
+
+- (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context {
     // First check the in-memory cache...
     UIImage *image = [self imageFromMemoryCacheForKey:key];
     if (image) {
@@ -358,7 +367,7 @@
     }
     
     // Second check the disk cache...
-    image = [self imageFromDiskCacheForKey:key];
+    image = [self imageFromDiskCacheForKey:key options:options context:context];
     return image;
 }
 

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -61,7 +61,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeCompressio
  But this may be useful for some custom coders, because some business logic may dependent on things other than image or image data inforamtion only.
  See `SDWebImageContext` for more detailed information.
  */
-FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext;
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext API_DEPRECATED("The coder component will be seperated from Core subspec in the future. Update your code to not rely on this context option.", macos(10.10, API_TO_BE_DEPRECATED), ios(8.0, API_TO_BE_DEPRECATED), tvos(9.0, API_TO_BE_DEPRECATED), watchos(2.0, API_TO_BE_DEPRECATED));;
 
 #pragma mark - Coder
 /**

--- a/SDWebImage/Core/SDImageTransformer.h
+++ b/SDWebImage/Core/SDImageTransformer.h
@@ -24,6 +24,7 @@ FOUNDATION_EXPORT NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullab
  @param thumbnailPixelSize The thumbnail pixel size
  @param preserveAspectRatio The preserve aspect ratio option
  @return The thumbnailed cache key
+ @note If you have both transformer and thumbnail applied for image, call `SDThumbnailedKeyForKey` firstly and then with `SDTransformedKeyForKey`.`
  */
 FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, BOOL preserveAspectRatio);
 

--- a/SDWebImage/Core/SDImageTransformer.h
+++ b/SDWebImage/Core/SDImageTransformer.h
@@ -19,6 +19,15 @@
 FOUNDATION_EXPORT NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullable key, NSString * _Nonnull transformerKey);
 
 /**
+ Return the thumbnailed cache key which applied with specify thumbnailSize and preserveAspectRatio control.
+ @param key The original cache key
+ @param thumbnailPixelSize The thumbnail pixel size
+ @param preserveAspectRatio The preserve aspect ratio option
+ @return The thumbnailed cache key
+ */
+FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, BOOL preserveAspectRatio);
+
+/**
  A transformer protocol to transform the image load from cache or from download.
  You can provide transformer to cache and manager (Through the `transformer` property or context option `SDWebImageContextImageTransformer`).
  
@@ -38,10 +47,10 @@ FOUNDATION_EXPORT NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullab
  Transform the image to another image.
 
  @param image The image to be transformed
- @param key The cache key associated to the image
+ @param key The cache key associated to the image. This arg is a hint for image source, not always useful and should be nullable. In the future we will remove this arg.
  @return The transformed image, or nil if transform failed
  */
-- (nullable UIImage *)transformedImageWithImage:(nonnull UIImage *)image forKey:(nonnull NSString *)key;
+- (nullable UIImage *)transformedImageWithImage:(nonnull UIImage *)image forKey:(nonnull NSString *)key API_DEPRECATED("The key arg will be removed in the future. Update your code and don't rely on that.", macos(10.10, API_TO_BE_DEPRECATED), ios(8.0, API_TO_BE_DEPRECATED), tvos(9.0, API_TO_BE_DEPRECATED), watchos(2.0, API_TO_BE_DEPRECATED));
 
 @end
 

--- a/SDWebImage/Core/SDImageTransformer.m
+++ b/SDWebImage/Core/SDImageTransformer.m
@@ -38,6 +38,11 @@ NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullable key, NSString *
     }
 }
 
+NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, BOOL preserveAspectRatio) {
+    NSString *thumbnailKey = [NSString stringWithFormat:@"Thumbnail({%f,%f},%d)", thumbnailPixelSize.width, thumbnailPixelSize.height, preserveAspectRatio];
+    return SDTransformedKeyForKey(key, thumbnailKey);
+}
+
 @interface SDImagePipelineTransformer ()
 
 @property (nonatomic, copy, readwrite, nonnull) NSArray<id<SDImageTransformer>> *transformers;

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -237,7 +237,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageL
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageCoder;
 
 /**
- A id<SDImageTransformer> instance which conforms `SDImageTransformer` protocol. It's used for image transform after the image load finished and store the transformed image to cache. If you provide one, it will ignore the `transformer` in manager and use provided one instead. (id<SDImageTransformer>)
+ A id<SDImageTransformer> instance which conforms `SDImageTransformer` protocol. It's used for image transform after the image load finished and store the transformed image to cache. If you provide one, it will ignore the `transformer` in manager and use provided one instead. If you pass NSNull, the transformer feature will be disabled. (id<SDImageTransformer>)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageTransformer;
 

--- a/SDWebImage/Core/SDWebImageManager.h
+++ b/SDWebImage/Core/SDWebImageManager.h
@@ -266,4 +266,10 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  */
 - (nullable NSString *)cacheKeyForURL:(nullable NSURL *)url;
 
+/**
+ * Return the cache key for a given URL and context option.
+ * Some option like `.thumbnailPixelSize` and `imageTransformer` will effect the generated cache key, using this if you have those context associated.
+*/
+- (nullable NSString *)cacheKeyForURL:(nullable NSURL *)url context:(nullable SDWebImageContext *)context;
+
 @end

--- a/SDWebImage/Core/SDWebImageManager.h
+++ b/SDWebImage/Core/SDWebImageManager.h
@@ -262,13 +262,14 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 - (void)cancelAll;
 
 /**
- * Return the cache key for a given URL
+ * Return the cache key for a given URL, does not considerate transformer or thumbnail.
+ * @note This method does not have context option, only use the url and manager level cacheKeyFilter to generate the cache key.
  */
 - (nullable NSString *)cacheKeyForURL:(nullable NSURL *)url;
 
 /**
  * Return the cache key for a given URL and context option.
- * Some option like `.thumbnailPixelSize` and `imageTransformer` will effect the generated cache key, using this if you have those context associated.
+ * @note The context option like `.thumbnailPixelSize` and `.imageTransformer` will effect the generated cache key, using this if you have those context associated.
 */
 - (nullable NSString *)cacheKeyForURL:(nullable NSURL *)url context:(nullable SDWebImageContext *)context;
 

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -229,7 +229,7 @@
     SDWebImageContext *context = @{SDWebImageContextOriginalStoreCacheType : @(SDImageCacheTypeDisk), SDWebImageContextStoreCacheType : @(SDImageCacheTypeMemory)};
     NSURL *url = [NSURL URLWithString:kTestJPEGURL];
     NSString *originalKey = [manager cacheKeyForURL:url];
-    NSString *transformedKey = SDTransformedKeyForKey(originalKey, transformer.transformerKey);
+    NSString *transformedKey = [manager cacheKeyForURL:url context:context];
     
     [manager loadImageWithURL:url options:SDWebImageTransformAnimatedImage context:context progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         expect(image).equal(transformer.testImage);

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -220,6 +220,7 @@
     
     // Use a fresh manager && cache to avoid get effected by other test cases
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"SDWebImageStoreCacheType"];
+    [cache clearDiskOnCompletion:nil];
     SDWebImageManager *manager = [[SDWebImageManager alloc] initWithCache:cache loader:SDWebImageDownloader.sharedDownloader];
     SDWebImageTestTransformer *transformer = [[SDWebImageTestTransformer alloc] init];
     transformer.testImage = [[UIImage alloc] initWithContentsOfFile:[self testJPEGPath]];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

### Motivation


Current Thumbnail (introduced in 5.6.0) and Transformer with cache key is not works correct. For example:

1. The thumbnail's cache key does not applied when you have a transformer at the same time...Only the transformer key get applied. Bug...
2. The transformer's cache key and thumbnail cache key is hard to generate, which means most of cache API (`imageFromMemoryForKey:`) need to care about and generate cache key manually
3. The thumbnail's cache key (That harded `"Thumbnail({%f,%f},%d)`) does not have any public way to access this unless you harcode. Which means, you can not directly get the thumbnail image from cache by yourself without SDWebImageManager.

### Changes

New API:

+ `SDThumbnailedKeyForKey()`

Used for public API to generate thumbnail cache key, if you access the cache directly without SDWebImageManager.

+`cacheKeyForURL:context:`

Used for user who don't want to care about what context in it (it may have thumbnail pixel size, it may have cache filter, it may have transformer...etc). Just pass in the context, we give you the final cache key which can directly passed to `SDImageCache`