### PR TITLE
Added new query cache type support, including the SDImageCache API and context option

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -269,6 +269,19 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 - (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
 /**
+ * Asynchronously queries the cache with operation and call the completion when done.
+ *
+ * @param key       The unique key used to store the wanted image. If you want transformed or thumbnail image, calculate the key with `SDTransformedKeyForKey`, `SDThumbnailedKeyForKey`, or generate the cache key from url with `cacheKeyForURL:context:`.
+ * @param options   A mask to specify options to use for this cache query
+ * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ * @param queryCacheType Specify where to query the cache from. By default we use `.all`, which means both memory cache and disk cache. You can choose to query memory only or disk only as well. Pass `.none` is invalid and callback with nil immediatelly.
+ * @param doneBlock The completion block. Will not get called if the operation is cancelled
+ *
+ * @return a NSOperation instance containing the cache op
+ */
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context cacheType:(SDImageCacheType)queryCacheType done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
+
+/**
  * Synchronously query the memory cache.
  *
  * @param key The unique key used to store the image

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -236,6 +236,15 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 - (nullable NSData *)diskImageDataForKey:(nullable NSString *)key;
 
 /**
+ * Asynchronously load the image data in disk cache. You can decode the image data to image after loaded.
+ *
+ *  @param key The unique key used to store the wanted image
+ *  @param completionBlock the block to be executed when the check is done.
+ *  @note the completion block will be always executed on the main queue
+ */
+- (void)diskImageDataQueryForKey:(nullable NSString *)key completion:(nullable SDImageCacheQueryDataCompletionBlock)completionBlock;
+
+/**
  * Operation that queries the cache asynchronously and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -314,6 +314,17 @@
     return [self.diskCache containsDataForKey:key];
 }
 
+- (void)diskImageDataQueryForKey:(NSString *)key completion:(SDImageCacheQueryDataCompletionBlock)completionBlock {
+    dispatch_async(self.ioQueue, ^{
+        NSData *imageData = [self diskImageDataBySearchingAllPathsForKey:key];
+        if (completionBlock) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionBlock(imageData);
+            });
+        }
+    });
+}
+
 - (nullable NSData *)diskImageDataForKey:(nullable NSString *)key {
     if (!key) {
         return nil;

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -723,6 +723,10 @@
 
 #pragma mark - SDImageCache
 
+- (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock {
+    return [self queryImageForKey:key options:options context:context cacheType:SDImageCacheTypeAll completion:completionBlock];
+}
+
 - (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context cacheType:(SDImageCacheType)cacheType completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock {
     SDImageCacheOptions cacheOptions = 0;
     if (options & SDWebImageQueryMemoryData) cacheOptions |= SDImageCacheQueryMemoryData;

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -69,6 +69,21 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonn
  @param key The image cache key
  @param options A mask to specify options to use for this query
  @param context A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ @param completionBlock The completion block. Will not get called if the operation is cancelled
+ @return The operation for this query
+ */
+- (nullable id<SDWebImageOperation>)queryImageForKey:(nullable NSString *)key
+                                             options:(SDWebImageOptions)options
+                                             context:(nullable SDWebImageContext *)context
+                                          completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock;
+
+/**
+ Query the cached image from image cache for given key. The operation can be used to cancel the query.
+ If image is cached in memory, completion is called synchronously, else aynchronously and depends on the options arg (See `SDWebImageQueryDiskSync`)
+
+ @param key The image cache key
+ @param options A mask to specify options to use for this query
+ @param context A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
  @param cacheType Specify where to query the cache from. By default we use `.all`, which means both memory cache and disk cache. You can choose to query memory only or disk only as well. Pass `.none` is invalid and callback with nil immediatelly.
  @param completionBlock The completion block. Will not get called if the operation is cancelled
  @return The operation for this query

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
 };
 
 typedef void(^SDImageCacheCheckCompletionBlock)(BOOL isInCache);
+typedef void(^SDImageCacheQueryDataCompletionBlock)(NSData * _Nullable data);
 typedef void(^SDImageCacheCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
 typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
 typedef void(^SDImageCacheQueryCompletionBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -68,12 +68,14 @@ FOUNDATION_EXPORT UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonn
  @param key The image cache key
  @param options A mask to specify options to use for this query
  @param context A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ @param cacheType Specify where to query the cache from. By default we use `.all`, which means both memory cache and disk cache. You can choose to query memory only or disk only as well. Pass `.none` is invalid and callback with nil immediatelly.
  @param completionBlock The completion block. Will not get called if the operation is cancelled
  @return The operation for this query
  */
 - (nullable id<SDWebImageOperation>)queryImageForKey:(nullable NSString *)key
                                              options:(SDWebImageOptions)options
                                              context:(nullable SDWebImageContext *)context
+                                           cacheType:(SDImageCacheType)cacheType
                                           completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock;
 
 /**

--- a/SDWebImage/Core/SDImageCachesManager.m
+++ b/SDWebImage/Core/SDImageCachesManager.m
@@ -84,6 +84,10 @@
 
 #pragma mark - SDImageCache
 
+- (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock {
+    return [self queryImageForKey:key options:options context:context cacheType:SDImageCacheTypeAll completion:completionBlock];
+}
+
 - (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheQueryCompletionBlock)completionBlock {
     if (!key) {
         return nil;

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -260,6 +260,12 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageP
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageThumbnailPixelSize;
 
 /**
+ A SDImageCacheType raw value which specify the source of cache to query. For example, you can query memory only, query disk only, or query from both memory and disk cache.
+ If not provide or the value is invalid, we will use `SDImageCacheTypeAll`. (NSNumber)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextQueryCacheType;
+
+/**
  A SDImageCacheType raw value which specify the store cache type when the image has just been downloaded and will be stored to the cache. Specify `SDImageCacheTypeNone` to disable cache storage; `SDImageCacheTypeDisk` to store in disk cache only; `SDImageCacheTypeMemory` to store in memory only. And `SDImageCacheTypeAll` to store in both memory cache and disk cache.
  If you use image transformer feature, this actually apply for the transformed image, but not the original image itself. Use `SDWebImageContextOriginalStoreCacheType` if you want to control the original image's store cache type at the same time.
  If not provide or the value is invalid, we will use `SDImageCacheTypeAll`. (NSNumber)

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -260,7 +260,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageP
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageThumbnailPixelSize;
 
 /**
- A SDImageCacheType raw value which specify the source of cache to query. For example, you can query memory only, query disk only, or query from both memory and disk cache.
+ A SDImageCacheType raw value which specify the source of cache to query. Specify `SDImageCacheTypeDisk` to query from disk cache only; `SDImageCacheTypeMemory` to query from memory only. And `SDImageCacheTypeAll` to query from both memory cache and disk cache. Specify `SDImageCacheTypeNone` is invalid and totally ignore the cache query.
  If not provide or the value is invalid, we will use `SDImageCacheTypeAll`. (NSNumber)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextQueryCacheType;

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -127,6 +127,7 @@ SDWebImageContextOption const SDWebImageContextImageTransformer = @"imageTransfo
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextImagePreserveAspectRatio = @"imagePreserveAspectRatio";
 SDWebImageContextOption const SDWebImageContextImageThumbnailPixelSize = @"imageThumbnailPixelSize";
+SDWebImageContextOption const SDWebImageContextQueryCacheType = @"queryCacheType";
 SDWebImageContextOption const SDWebImageContextStoreCacheType = @"storeCacheType";
 SDWebImageContextOption const SDWebImageContextOriginalStoreCacheType = @"originalStoreCacheType";
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -220,10 +220,15 @@ static id<SDImageLoader> _defaultImageLoader;
     }
     // Check whether we should query cache
     BOOL shouldQueryCache = !SD_OPTIONS_CONTAINS(options, SDWebImageFromLoaderOnly);
+    // Get the query cache type
+    SDImageCacheType queryCacheType = SDImageCacheTypeAll;
+    if (context[SDWebImageContextQueryCacheType]) {
+        queryCacheType = [context[SDWebImageContextQueryCacheType] integerValue];
+    }
     if (shouldQueryCache) {
         NSString *key = [self cacheKeyForURL:url context:context];
         @weakify(operation);
-        operation.cacheOperation = [imageCache queryImageForKey:key options:options context:context completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
+        operation.cacheOperation = [imageCache queryImageForKey:key options:options context:context cacheType:queryCacheType completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
             @strongify(operation);
             if (!operation || operation.isCancelled) {
                 // Image combined operation cancelled by user

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -610,7 +610,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
 - (void)test50SDImageCacheQueryOp {
     XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache query op works"];
     [[SDImageCache sharedImageCache] storeImage:[self testJPEGImage] forKey:kTestImageKeyJPEG toDisk:NO completion:nil];
-    [[SDImageCachesManager sharedManager] queryImageForKey:kTestImageKeyJPEG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    [[SDImageCachesManager sharedManager] queryImageForKey:kTestImageKeyJPEG options:0 context:nil cacheType:SDImageCacheTypeAll completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).notTo.beNil();
         [expectation fulfill];
     }];
@@ -680,7 +680,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
     cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
     cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
-    [cachesManager queryImageForKey:kTestImageKeyJPEG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    [cachesManager queryImageForKey:kTestImageKeyJPEG options:0 context:nil cacheType:SDImageCacheTypeAll completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).to.beNil();
     }];
     [cachesManager storeImage:[self testJPEGImage] imageData:nil forKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeMemory completion:nil];
@@ -699,7 +699,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
     cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
     cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
-    [cachesManager queryImageForKey:kTestImageKeyPNG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    [cachesManager queryImageForKey:kTestImageKeyPNG options:0 context:nil cacheType:SDImageCacheTypeAll completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).to.beNil();
     }];
     [cachesManager storeImage:[self testPNGImage] imageData:nil forKey:kTestImageKeyPNG cacheType:SDImageCacheTypeMemory completion:nil];
@@ -732,7 +732,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
     cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
     cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
-    [cachesManager queryImageForKey:kConcurrentTestImageKey options:0 context:nil completion:nil];
+    [cachesManager queryImageForKey:kConcurrentTestImageKey options:0 context:nil cacheType:SDImageCacheTypeAll completion:nil];
     [cachesManager storeImage:[self testJPEGImage] imageData:nil forKey:kConcurrentTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager removeImageForKey:kConcurrentTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager clearWithCacheType:SDImageCacheTypeMemory completion:nil];
@@ -772,7 +772,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicySerial;
     cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicySerial;
     cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicySerial;
-    [cachesManager queryImageForKey:kSerialTestImageKey options:0 context:nil completion:nil];
+    [cachesManager queryImageForKey:kSerialTestImageKey options:0 context:nil cacheType:SDImageCacheTypeAll completion:nil];
     [cachesManager storeImage:[self testJPEGImage] imageData:nil forKey:kSerialTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager removeImageForKey:kSerialTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager clearWithCacheType:SDImageCacheTypeMemory completion:nil];

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -800,6 +800,8 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     expect(cache.memoryCache).notTo.beNil();
     expect(cache.diskCache).notTo.beNil();
     
+    // Clear
+    [cache clearWithCacheType:SDImageCacheTypeAll completion:nil];
     // Store
     UIImage *image1 = self.testJPEGImage;
     NSString *key1 = @"testJPEGImage";
@@ -816,6 +818,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     }];
     // Remove
     [cache removeImageForKey:key1 cacheType:SDImageCacheTypeAll completion:nil];
+    // Contain
     [cache containsImageForKey:key1 cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType containsCacheType) {
         expect(containsCacheType).equal(SDImageCacheTypeNone);
     }];

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -474,7 +474,6 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
-#if SD_UIKIT
 - (void)test22ThatCustomDecoderWorksForImageDownload {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Custom decoder for SDWebImageDownloader not works"];
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
@@ -487,8 +486,8 @@
     UIImage *testJPEGImage = [[UIImage alloc] initWithContentsOfFile:testJPEGImagePath];
     
     [downloader downloadImageWithURL:testImageURL options:0 progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
-        NSData *data1 = UIImagePNGRepresentation(testJPEGImage);
-        NSData *data2 = UIImagePNGRepresentation(image);
+        NSData *data1 = [testJPEGImage sd_imageDataAsFormat:SDImageFormatPNG];
+        NSData *data2 = [image sd_imageDataAsFormat:SDImageFormatPNG];
         if (![data1 isEqualToData:data2]) {
             XCTFail(@"The image data is not equal to cutom decoder, check -[SDWebImageTestDecoder decodedImageWithData:]");
         }
@@ -499,7 +498,6 @@
     [self waitForExpectationsWithCommonTimeout];
     [downloader invalidateSessionAndCancel:YES];
 }
-#endif
 
 - (void)test23ThatDownloadRequestModifierWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Download request modifier not works"];

--- a/Tests/Tests/SDWebImageTestCache.h
+++ b/Tests/Tests/SDWebImageTestCache.h
@@ -9,9 +9,9 @@
 
 #import <SDWebImage/SDMemoryCache.h>
 #import <SDWebImage/SDDiskCache.h>
+#import <SDWebImage/SDImageCacheDefine.h>
 
 // A really naive implementation of custom memory cache and disk cache
-
 @interface SDWebImageTestMemoryCache : NSObject <SDMemoryCache>
 
 @property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
@@ -24,5 +24,16 @@
 @property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
 @property (nonatomic, copy, nonnull) NSString *cachePath;
 @property (nonatomic, strong, nonnull) NSFileManager *fileManager;
+
+@end
+
+// A really naive implementation of custom image cache using memory cache and disk cache
+@interface SDWebImageTestCache : NSObject <SDImageCache>
+
+@property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
+@property (nonatomic, strong, nonnull) SDWebImageTestMemoryCache *memoryCache;
+@property (nonatomic, strong, nonnull) SDWebImageTestDiskCache *diskCache;
+
+- (nullable instancetype)initWithCachePath:(nonnull NSString *)cachePath config:(nonnull SDImageCacheConfig *)config;
 
 @end

--- a/Tests/Tests/SDWebImageTestCache.h
+++ b/Tests/Tests/SDWebImageTestCache.h
@@ -36,4 +36,6 @@
 
 - (nullable instancetype)initWithCachePath:(nonnull NSString *)cachePath config:(nonnull SDImageCacheConfig *)config;
 
+@property (nonatomic, class, readonly, nonnull) SDWebImageTestCache *sharedCache;
+
 @end

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -188,6 +188,7 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
             } else if ([self.diskCache containsDataForKey:key]) {
                 containsCacheType = SDImageCacheTypeDisk;
             }
+            break;
         default:
             break;
     }

--- a/Tests/Tests/SDWebImageTestLoader.h
+++ b/Tests/Tests/SDWebImageTestLoader.h
@@ -13,4 +13,6 @@
 // A really naive implementation of custom image loader using `NSURLSession`
 @interface SDWebImageTestLoader : NSObject <SDImageLoader>
 
+@property (nonatomic, class, readonly, nonnull) SDWebImageTestLoader *sharedLoader;
+
 @end

--- a/Tests/Tests/SDWebImageTestLoader.m
+++ b/Tests/Tests/SDWebImageTestLoader.m
@@ -16,6 +16,15 @@
 
 @implementation SDWebImageTestLoader
 
++ (SDWebImageTestLoader *)sharedLoader {
+    static dispatch_once_t onceToken;
+    static SDWebImageTestLoader *loader;
+    dispatch_once(&onceToken, ^{
+        loader = [[SDWebImageTestLoader alloc] init];
+    });
+    return loader;
+}
+
 - (BOOL)canRequestImageForURL:(NSURL *)url {
     return YES;
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR supports the user, to specify where to query cache from:

+ Memory Cache Only
+ Disk Cache Only
+ Both (Default)

This is useful for cases when we want to do some prefetch only for memory cache (because it's fast and sync), but not want to access to disk cache.

