### PR TITLE
Fix the issue for Carthage/SwiftPM framework version symbols, this should match the framework name SDWebImage, or will get a link error when used

### DIFF
--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -9,15 +9,11 @@
 
 #import <SDWebImage/SDWebImageCompat.h>
 
-#if SD_UIKIT
-#import <UIKit/UIKit.h>
-#endif
+//! Project version number for SDWebImage.
+FOUNDATION_EXPORT double SDWebImageVersionNumber;
 
-//! Project version number for WebImage.
-FOUNDATION_EXPORT double WebImageVersionNumber;
-
-//! Project version string for WebImage.
-FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
+//! Project version string for SDWebImage.
+FOUNDATION_EXPORT const unsigned char SDWebImageVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <WebImage/PublicHeader.h>
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #2969 

### Pull Request Description

The compiler will synthesize the `${FrameworkName}VersionNumber` and `${FrameworkName}VersionString` symbol, so this naming should match SDWebImage.

@iamlion
