### PR TITLE
Change the behavior to return the abstract type for unknown image format, this  can solve the accident issue for custom coder who provide a new format

### DIFF
--- a/SDWebImage/Core/NSData+ImageContentType.h
+++ b/SDWebImage/Core/NSData+ImageContentType.h
@@ -45,6 +45,7 @@ static const SDImageFormat SDImageFormatSVG       = 8;
  *
  *  @param format Format as SDImageFormat
  *  @return The UTType as CFStringRef
+ *  @note For unknown format, `kUTTypeImage` abstract type will return
  */
 + (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED NS_SWIFT_NAME(sd_UTType(from:));
 
@@ -53,6 +54,7 @@ static const SDImageFormat SDImageFormatSVG       = 8;
  *
  *  @param uttype The UTType as CFStringRef
  *  @return The Format as SDImageFormat
+ *  @note For unknown type, `SDImageFormatUndefined` will return
  */
 + (SDImageFormat)sd_imageFormatFromUTType:(nonnull CFStringRef)uttype;
 

--- a/SDWebImage/Core/NSData+ImageContentType.m
+++ b/SDWebImage/Core/NSData+ImageContentType.m
@@ -119,8 +119,8 @@
             UTType = kUTTypeScalableVectorGraphics;
             break;
         default:
-            // default is kUTTypePNG
-            UTType = kUTTypePNG;
+            // default is kUTTypeImage abstract type
+            UTType = kUTTypeImage;
             break;
     }
     return UTType;

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -25,7 +25,7 @@
     
     // Test invalid format
     CFStringRef type = [NSData sd_UTTypeFromImageFormat:SDImageFormatUndefined];
-    expect(CFStringCompare(kUTTypePNG, type, 0)).equal(kCFCompareEqualTo);
+    expect(CFStringCompare(kUTTypeImage, type, 0)).equal(kCFCompareEqualTo);
     expect([NSData sd_imageFormatFromUTType:kUTTypeImage]).equal(SDImageFormatUndefined);
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The original code comes from me 😅 , see https://github.com/SDWebImage/SDWebImage/blame/c1df782869955cc505a9304637599c606ba04477/SDWebImage/NSData+ImageContentType.m

However, at that time, maybe I think all the UTI type we can handle is limited, and no externel Image Decoder support as current SDWebImage 5.0's design. So I hardcode that PNG for backup.

This design cause issue now, because we have custom decoder, example, the AVIF decoder: [SDWebImageAVIFCoder](https://github.com/SDWebImage/SDWebImageAVIFCoder). When user accidently pass the `SDImageFormatAVIF` into this `sd_UTTypeFromImageFormat:` method, a `PNG` will returned. And when he encode again, it will cause failsure.

So, instead, a better way to solve this problem, it's that we return a nil value. Sadly this is a **API Break** and can not been done until 6.0.0. In 6.0.0, I have some more changes and mixed Swift-Objc stuff to do, which need times.

Another solution for now, we return an abstract type, like that `kUTTypeImage`. Then all the custom encoder like AVIF, can assume this `kUTTypeImage` as a default value, which use the encoder's own choice (For AVIFEncoder, it's AVIF, obviously)

So this PR change the fallback value to this abstract type. Solve the accident issue causd by this.

CC @kinarobin
