### PR TITLE
Fix the wrong value assignment for SDAnimatedImageView code on macOS, warning

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -470,7 +470,7 @@
 // NSImageView use a subview. We need this subview's layer for actual rendering.
 // Why using this design may because of properties like `imageAlignment` and `imageScaling`, which it's not available for UIImageView.contentMode (it's impossible to align left and keep aspect ratio at the same time)
 - (NSView *)imageView {
-    NSImageView *imageView = imageView = objc_getAssociatedObject(self, SD_SEL_SPI(imageView));
+    NSImageView *imageView = objc_getAssociatedObject(self, SD_SEL_SPI(imageView));
     if (!imageView) {
         // macOS 10.14
         imageView = objc_getAssociatedObject(self, SD_SEL_SPI(imageSubview));


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This code maybe wrong coding style, the `A = B = C` will actually is not correct. Mabye this is caused by some code refactory typo.

This does not effect the runtime behavior, just source code warning. 

