### PR TITLE
Fix that when first play animated image and use maxBufferSize to 0, the calculation does not works (The CGImage is nil)

### DIFF
--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -179,12 +179,12 @@
 #pragma mark - Animation Control
 - (void)startPlaying {
     [self.displayLink start];
-    // Calculate max buffer size
-    [self calculateMaxBufferCount];
     // Setup frame
     if (self.currentFrameIndex == 0 && !self.currentFrame) {
         [self setupCurrentFrame];
     }
+    // Calculate max buffer size
+    [self calculateMaxBufferCount];
 }
 
 - (void)stopPlaying {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This does not work as expected:



![image](https://user-images.githubusercontent.com/6919743/79002914-10719480-7b84-11ea-9934-22edd1e51afd.png)
