### PR TITLE
Add the convenient request/response modifier, which provide HTTP header directly

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
@@ -30,7 +30,12 @@ A downloader response modifier class with block.
 */
 @interface SDWebImageDownloaderDecryptor : NSObject <SDWebImageDownloaderDecryptor>
 
+/// Create the data decryptor with block
+/// @param block A block to control decrypt logic
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageDownloaderDecryptorBlock)block;
+
+/// Create the data decryptor with block
+/// @param block A block to control decrypt logic
 + (nonnull instancetype)decryptorWithBlock:(nonnull SDWebImageDownloaderDecryptorBlock)block;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -39,18 +39,16 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
  */
 @interface SDWebImageDownloaderHTTPRequestModifier : NSObject <SDWebImageDownloaderRequestModifier>
 
+/// Create the request modifier with HTTP Headers
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
+- (nonnull instancetype)initWithHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
+
 /// Create the request modifier with HTTP Method, Headers and Body
 /// @param method HTTP Method, nil means to GET.
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
 /// @param body HTTP Body
 /// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
-- (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
-
-/// Create the request modifier with HTTP Method, Headers and Body
-/// @param method HTTP Method, nil means to GET.
-/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from SDWebImageDownloader global configuration.
-/// @param body HTTP Body
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
-+ (nonnull instancetype)requestModifierWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
+- (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -33,3 +33,24 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
 + (nonnull instancetype)requestModifierWithBlock:(nonnull SDWebImageDownloaderRequestModifierBlock)block;
 
 @end
+
+/**
+ A convenient request modifier to provide the HTTP request including HTTP method, headers and body.
+ */
+@interface SDWebImageDownloaderHTTPRequestModifier : NSObject <SDWebImageDownloaderRequestModifier>
+
+/// Create the request modifier with HTTP Method, Headers and Body
+/// @param method HTTP Method, nil means to GET.
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
+/// @param body HTTP Body
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
+- (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
+
+/// Create the request modifier with HTTP Method, Headers and Body
+/// @param method HTTP Method, nil means to GET.
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from SDWebImageDownloader global configuration.
+/// @param body HTTP Body
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
++ (nonnull instancetype)requestModifierWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -42,7 +42,7 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
 /**
 A convenient request modifier to provide the HTTP request including HTTP Method, Headers and Body.
 */
-@interface SDWebImageDownloaderRequestModifier (HTTPConveniences)
+@interface SDWebImageDownloaderRequestModifier (Conveniences)
 
 /// Create the request modifier with HTTP Method.
 /// @param method HTTP Method, nil means to GET.

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -29,7 +29,12 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
  */
 @interface SDWebImageDownloaderRequestModifier : NSObject <SDWebImageDownloaderRequestModifier>
 
+/// Create the request modifier with block
+/// @param block A block to control modifier logic
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageDownloaderRequestModifierBlock)block;
+
+/// Create the request modifier with block
+/// @param block A block to control modifier logic
 + (nonnull instancetype)requestModifierWithBlock:(nonnull SDWebImageDownloaderRequestModifierBlock)block;
 
 @end
@@ -49,6 +54,6 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
 /// @param body HTTP Body
 /// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
-- (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -40,20 +40,30 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
 @end
 
 /**
- A convenient request modifier to provide the HTTP request including HTTP method, headers and body.
- */
-@interface SDWebImageDownloaderHTTPRequestModifier : NSObject <SDWebImageDownloaderRequestModifier>
+A convenient request modifier to provide the HTTP request including HTTP Method, Headers and Body.
+*/
+@interface SDWebImageDownloaderRequestModifier (HTTPConveniences)
 
-/// Create the request modifier with HTTP Headers
+/// Create the request modifier with HTTP Method.
+/// @param method HTTP Method, nil means to GET.
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
+- (nonnull instancetype)initWithMethod:(nullable NSString *)method;
+
+/// Create the request modifier with HTTP Headers.
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
 - (nonnull instancetype)initWithHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
-/// Create the request modifier with HTTP Method, Headers and Body
+/// Create the request modifier with HTTP Body.
+/// @param body HTTP Body.
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
+- (nonnull instancetype)initWithBody:(nullable NSData *)body;
+
+/// Create the request modifier with HTTP Method, Headers and Body.
 /// @param method HTTP Method, nil means to GET.
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original request.
-/// @param body HTTP Body
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderRequestModifier` instead
+/// @param body HTTP Body.
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
 - (nonnull instancetype)initWithMethod:(nullable NSString *)method headers:(nullable NSDictionary<NSString *, NSString *> *)headers body:(nullable NSData *)body;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
@@ -48,6 +48,10 @@
 
 @implementation SDWebImageDownloaderHTTPRequestModifier
 
+- (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers {
+    return [self initWithMethod:nil headers:headers body:nil];
+}
+
 - (instancetype)initWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
     self = [super init];
     if (self) {
@@ -56,11 +60,6 @@
         _body = [body copy];
     }
     return self;
-}
-
-+ (instancetype)requestModifierWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
-    SDWebImageDownloaderHTTPRequestModifier *requestModifier = [[SDWebImageDownloaderHTTPRequestModifier alloc] initWithMethod:method headers:headers body:body];
-    return requestModifier;
 }
 
 - (NSURLRequest *)modifiedRequestWithRequest:(NSURLRequest *)request {

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
@@ -38,39 +38,34 @@
 
 @end
 
-@interface SDWebImageDownloaderHTTPRequestModifier ()
+@implementation SDWebImageDownloaderRequestModifier (HTTPConveniences)
 
-@property (nonatomic, copy, nullable) NSString *method;
-@property (nonatomic, copy, nullable) NSDictionary<NSString *,NSString *> *headers;
-@property (nonatomic, copy, nullable) NSData *body;
-
-@end
-
-@implementation SDWebImageDownloaderHTTPRequestModifier
+- (instancetype)initWithMethod:(NSString *)method {
+    return [self initWithMethod:method headers:nil body:nil];
+}
 
 - (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers {
     return [self initWithMethod:nil headers:headers body:nil];
 }
 
-- (instancetype)initWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
-    self = [super init];
-    if (self) {
-        _method = [method copy];
-        _headers = [headers copy];
-        _body = [body copy];
-    }
-    return self;
+- (instancetype)initWithBody:(NSData *)body {
+    return [self initWithMethod:nil headers:nil body:body];
 }
 
-- (NSURLRequest *)modifiedRequestWithRequest:(NSURLRequest *)request {
-    NSMutableURLRequest *mutableRequest = [request mutableCopy];
-    mutableRequest.HTTPMethod = self.method;
-    mutableRequest.HTTPBody = self.body;
-    for (NSString *header in self.headers) {
-        NSString *value = self.headers[header];
-        [mutableRequest setValue:value forHTTPHeaderField:header];
-    }
-    return [mutableRequest copy];
+- (instancetype)initWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
+    method = [method copy];
+    headers = [headers copy];
+    body = [body copy];
+    return [self initWithBlock:^NSURLRequest * _Nullable(NSURLRequest * _Nonnull request) {
+        NSMutableURLRequest *mutableRequest = [request mutableCopy];
+        mutableRequest.HTTPMethod = method;
+        mutableRequest.HTTPBody = body;
+        for (NSString *header in headers) {
+            NSString *value = headers[header];
+            [mutableRequest setValue:value forHTTPHeaderField:header];
+        }
+        return [mutableRequest copy];
+    }];
 }
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
@@ -38,7 +38,7 @@
 
 @end
 
-@implementation SDWebImageDownloaderRequestModifier (HTTPConveniences)
+@implementation SDWebImageDownloaderRequestModifier (Conveniences)
 
 - (instancetype)initWithMethod:(NSString *)method {
     return [self initWithMethod:method headers:nil body:nil];

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
@@ -37,3 +37,41 @@
 }
 
 @end
+
+@interface SDWebImageDownloaderHTTPRequestModifier ()
+
+@property (nonatomic, copy, nullable) NSString *method;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *,NSString *> *headers;
+@property (nonatomic, copy, nullable) NSData *body;
+
+@end
+
+@implementation SDWebImageDownloaderHTTPRequestModifier
+
+- (instancetype)initWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
+    self = [super init];
+    if (self) {
+        _method = [method copy];
+        _headers = [headers copy];
+        _body = [body copy];
+    }
+    return self;
+}
+
++ (instancetype)requestModifierWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
+    SDWebImageDownloaderHTTPRequestModifier *requestModifier = [[SDWebImageDownloaderHTTPRequestModifier alloc] initWithMethod:method headers:headers body:body];
+    return requestModifier;
+}
+
+- (NSURLRequest *)modifiedRequestWithRequest:(NSURLRequest *)request {
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+    mutableRequest.HTTPMethod = self.method;
+    mutableRequest.HTTPBody = self.body;
+    for (NSString *header in self.headers) {
+        NSString *value = self.headers[header];
+        [mutableRequest setValue:value forHTTPHeaderField:header];
+    }
+    return [mutableRequest copy];
+}
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -40,20 +40,30 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
 @end
 
 /**
- A convenient response modifier to provide the HTTP response including HTTP method, headers and body.
- */
-@interface SDWebImageDownloaderHTTPResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
+A convenient response modifier to provide the HTTP response including HTTP Status Code, Version and Headers.
+*/
+@interface SDWebImageDownloaderResponseModifier (HTTPConveniences)
+
+/// Create the response modifier with HTTP Status code.
+/// @param statusCode HTTP Status Code.
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
+- (nonnull instancetype)initWithStatusCode:(NSInteger)statusCode;
+
+/// Create the response modifier with HTTP Version. Status code defaults to 200.
+/// @param version HTTP Version, nil means "HTTP/1.1".
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
+- (nonnull instancetype)initWithVersion:(nullable NSString *)version;
 
 /// Create the response modifier with HTTP Headers. Status code defaults to 200.
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
 - (nonnull instancetype)initWithHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
-/// Create the response modifier with HTTP Version, Status Code and Headers
-/// @param version HTTP Version, nil means "HTTP/1.1"
-/// @param statusCode HTTP Status Code
+/// Create the response modifier with HTTP Status Code, Version and Headers.
+/// @param statusCode HTTP Status Code.
+/// @param version HTTP Version, nil means "HTTP/1.1".
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
-- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
+/// @note This is for convenience, if you need code to control the logic, use block API instead.
+- (nonnull instancetype)initWithStatusCode:(NSInteger)statusCode version:(nullable NSString *)version headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -33,3 +33,24 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
 + (nonnull instancetype)responseModifierWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
 
 @end
+
+/**
+ A convenient response modifier to provide the HTTP response including HTTP method, headers and body.
+ */
+@interface SDWebImageDownloaderHTTPResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
+
+/// Create the response modifier with HTTP Version, Status Code and Headers
+/// @param version HTTP Version, nil means "HTTP/1.1"
+/// @param statusCode HTTP Status Code
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
+- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
+
+/// Create the response modifier with HTTP Version, Status Code and Headers
+/// @param version HTTP Version, nil means "HTTP/1.1". See available value in CFNetwork like `kCFHTTPVersion1_1`.
+/// @param statusCode HTTP Status Code
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
++ (nonnull instancetype)responseModifierWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -42,7 +42,7 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
 /**
 A convenient response modifier to provide the HTTP response including HTTP Status Code, Version and Headers.
 */
-@interface SDWebImageDownloaderResponseModifier (HTTPConveniences)
+@interface SDWebImageDownloaderResponseModifier (Conveniences)
 
 /// Create the response modifier with HTTP Status code.
 /// @param statusCode HTTP Status Code.

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -39,18 +39,16 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
  */
 @interface SDWebImageDownloaderHTTPResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
 
+/// Create the response modifier with HTTP Headers. Status code defaults to 200.
+/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
+/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
+- (nonnull instancetype)initWithHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
+
 /// Create the response modifier with HTTP Version, Status Code and Headers
 /// @param version HTTP Version, nil means "HTTP/1.1"
 /// @param statusCode HTTP Status Code
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
 /// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
-- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
-
-/// Create the response modifier with HTTP Version, Status Code and Headers
-/// @param version HTTP Version, nil means "HTTP/1.1". See available value in CFNetwork like `kCFHTTPVersion1_1`.
-/// @param statusCode HTTP Status Code
-/// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
-/// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
-+ (nonnull instancetype)responseModifierWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
+- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -29,7 +29,12 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
  */
 @interface SDWebImageDownloaderResponseModifier : NSObject <SDWebImageDownloaderResponseModifier>
 
+/// Create the response modifier with block
+/// @param block A block to control modifier logic
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
+
+/// Create the response modifier with block
+/// @param block A block to control modifier logic
 + (nonnull instancetype)responseModifierWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
 
 @end
@@ -49,6 +54,6 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
 /// @param statusCode HTTP Status Code
 /// @param headers HTTP Headers. Case insensitive according to HTTP/1.1(HTTP/2) standard. The headers will overide the same fileds from original response.
 /// @note This is for convenience, if you need code to control the logic, use `SDWebImageDownloaderResponseModifier` instead
-- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithVersion:(nullable NSString *)version statusCode:(NSInteger)statusCode headers:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -72,7 +72,7 @@
         NSString *value = self.headers[header];
         mutableHeaders[header] = value;
     }
-    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:response.URL statusCode:self.statusCode HTTPVersion:self.version ?: (__bridge NSString *)kCFHTTPVersion1_1 headerFields:[mutableHeaders copy]];
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:response.URL statusCode:self.statusCode HTTPVersion:self.version ?: @"HTTP/1.1" headerFields:[mutableHeaders copy]];
     return httpResponse;
 }
 

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -38,3 +38,43 @@
 }
 
 @end
+
+@interface SDWebImageDownloaderHTTPResponseModifier ()
+
+@property (nonatomic, copy, nullable) NSString *version;
+@property (nonatomic) NSInteger statusCode;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *,NSString *> *headers;
+
+@end
+
+@implementation SDWebImageDownloaderHTTPResponseModifier
+
+- (instancetype)initWithVersion:(NSString *)version statusCode:(NSInteger)statusCode headers:(NSDictionary<NSString *,NSString *> *)headers {
+    self = [super init];
+    if (self) {
+        _version = [version copy];
+        _statusCode = statusCode;
+        _headers = [headers copy];
+    }
+    return self;
+}
+
++ (instancetype)responseModifierWithVersion:(NSString *)version statusCode:(NSInteger)statusCode headers:(NSDictionary<NSString *,NSString *> *)headers {
+    SDWebImageDownloaderHTTPResponseModifier *responseModifier = [[SDWebImageDownloaderHTTPResponseModifier alloc] initWithVersion:version statusCode:statusCode headers:headers];
+    return responseModifier;
+}
+
+- (NSURLResponse *)modifiedResponseWithResponse:(NSURLResponse *)response {
+    if (![response isKindOfClass:NSHTTPURLResponse.class]) {
+        return response;
+    }
+    NSMutableDictionary *mutableHeaders = [((NSHTTPURLResponse *)response).allHeaderFields mutableCopy];
+    for (NSString *header in self.headers) {
+        NSString *value = self.headers[header];
+        mutableHeaders[header] = value;
+    }
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:response.URL statusCode:self.statusCode HTTPVersion:self.version ?: (__bridge NSString *)kCFHTTPVersion1_1 headerFields:[mutableHeaders copy]];
+    return httpResponse;
+}
+
+@end

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -39,7 +39,7 @@
 
 @end
 
-@implementation SDWebImageDownloaderResponseModifier (HTTPConveniences)
+@implementation SDWebImageDownloaderResponseModifier (Conveniences)
 
 - (instancetype)initWithStatusCode:(NSInteger)statusCode {
     return [self initWithStatusCode:statusCode version:nil headers:nil];

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.m
@@ -49,6 +49,10 @@
 
 @implementation SDWebImageDownloaderHTTPResponseModifier
 
+- (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers {
+    return [self initWithVersion:nil statusCode:200 headers:headers];
+}
+
 - (instancetype)initWithVersion:(NSString *)version statusCode:(NSInteger)statusCode headers:(NSDictionary<NSString *,NSString *> *)headers {
     self = [super init];
     if (self) {
@@ -57,11 +61,6 @@
         _headers = [headers copy];
     }
     return self;
-}
-
-+ (instancetype)responseModifierWithVersion:(NSString *)version statusCode:(NSInteger)statusCode headers:(NSDictionary<NSString *,NSString *> *)headers {
-    SDWebImageDownloaderHTTPResponseModifier *responseModifier = [[SDWebImageDownloaderHTTPResponseModifier alloc] initWithVersion:version statusCode:statusCode headers:headers];
-    return responseModifier;
 }
 
 - (NSURLResponse *)modifiedResponseWithResponse:(NSURLResponse *)response {

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -502,7 +502,14 @@
 - (void)test23ThatDownloadRequestModifierWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Download request modifier not works"];
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
-    SDWebImageDownloaderRequestModifier *requestModifier = [SDWebImageDownloaderRequestModifier requestModifierWithBlock:^NSURLRequest * _Nullable(NSURLRequest * _Nonnull request) {
+    
+    // Test conveniences modifier
+    SDWebImageDownloaderRequestModifier *requestModifier = [[SDWebImageDownloaderRequestModifier alloc] initWithHeaders:@{@"Biz" : @"Bazz"}];
+    NSURLRequest *testRequest = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:kTestJPEGURL]];
+    testRequest = [requestModifier modifiedRequestWithRequest:testRequest];
+    expect(testRequest.allHTTPHeaderFields).equal(@{@"Biz" : @"Bazz"});
+    
+    requestModifier = [SDWebImageDownloaderRequestModifier requestModifierWithBlock:^NSURLRequest * _Nullable(NSURLRequest * _Nonnull request) {
         if ([request.URL.absoluteString isEqualToString:kTestPNGURL]) {
             // Test that return a modified request
             NSMutableURLRequest *mutableRequest = [request mutableCopy];
@@ -550,8 +557,15 @@
     
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
     
+    // Test conveniences modifier
+    SDWebImageDownloaderResponseModifier *responseModifier = [[SDWebImageDownloaderResponseModifier alloc] initWithHeaders:@{@"Biz" : @"Bazz"}];
+    NSURLResponse *testResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:kTestPNGURL] statusCode:404 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    testResponse = [responseModifier modifiedResponseWithResponse:testResponse];
+    expect(((NSHTTPURLResponse *)testResponse).allHeaderFields).equal(@{@"Biz" : @"Bazz"});
+    expect(((NSHTTPURLResponse *)testResponse).statusCode).equal(200);
+    
     // 1. Test webURL to response custom status code and header
-    SDWebImageDownloaderResponseModifier *responseModifier = [SDWebImageDownloaderResponseModifier responseModifierWithBlock:^NSURLResponse * _Nullable(NSURLResponse * _Nonnull response) {
+    responseModifier = [SDWebImageDownloaderResponseModifier responseModifierWithBlock:^NSURLResponse * _Nullable(NSURLResponse * _Nonnull response) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         NSMutableDictionary *mutableHeaderFields = [httpResponse.allHeaderFields mutableCopy];
         mutableHeaderFields[@"Foo"] = @"Bar";


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Don't need to repeat the code...

See user request from https://github.com/SDWebImage/SDWebImageSwiftUI/issues/99

Currently user have to write verbose code to provide HTTP header/method/body:

```swift
[.downloadRequestModifier: SDWebImageDownloaderRequestModifier {
    var request = $0
    request.setValue("MyValue", forHTTPHeaderField: "MyHeader")
    return request
}]
```

Now we can use 

```swift
[.downloadRequestModifier: SDWebImageDownloaderHTTPRequestModifier(headers: ["Foo": "Bar"])
```

Though it's still ugly, but more simple than previus version :)

This API on Swift in SDWebImage 6.0, will have a more Swify one, like

```swift
[.download(.requestModifier(.headers(["Foo": "Bar"])))]
```

Note:
The naming maybe need to contains the `HTTP`, because URLSession or us, supports any following URL schema:

+ `data://`
+ `file://`
+ `ftp://`

They have no such a concept of `HTTP Header`.

But anyway, if this is OK, we can remove that HTTP suffix and put this convenient method directly in`SDWebImageDownloaderRequestModifer` class.

Any idea ? @kinarobin