### PR TITLE
Mark the black list formal error code, support remove the failed URL from black list

### DIFF
--- a/SDWebImage/Core/SDWebImageError.h
+++ b/SDWebImage/Core/SDWebImageError.h
@@ -19,6 +19,7 @@ typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
     SDWebImageErrorInvalidURL = 1000, // The URL is invalid, such as nil URL or corrupted URL
     SDWebImageErrorBadImageData = 1001, // The image data can not be decoded to image, or the image data is empty
     SDWebImageErrorCacheNotModified = 1002, // The remote location specify that the cached image is not modified, such as the HTTP response 304 code. It's useful for `SDWebImageRefreshCached`
+    SDWebImageErrorBlackListed = 1003, // The URL is blacklisted because of unrecoverable failsure marked by downloader (such as 404), you can use `.retryFailed` option to avoid this
     SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error occur when operation initialized
     SDWebImageErrorInvalidDownloadStatusCode = 2001, // The image download response a invalid status code. You can check the status code in error's userInfo under `SDWebImageErrorDownloadStatusCodeKey`
     SDWebImageErrorCancelled = 2002, // The image loading operation is cancelled before finished, during either async disk cache query, or waiting before actual network request. For actual network request error, check `NSURLErrorDomain` error domain and code.

--- a/SDWebImage/Core/SDWebImageManager.h
+++ b/SDWebImage/Core/SDWebImageManager.h
@@ -262,6 +262,17 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 - (void)cancelAll;
 
 /**
+ * Remove the specify URL from failed black list.
+ * @param url The failed URL.
+ */
+- (void)removeFailedURL:(nonnull NSURL *)url;
+
+/**
+ * Remove all the URL from failed black list.
+ */
+- (void)removeAllFailedURLs;
+
+/**
  * Return the cache key for a given URL, does not considerate transformer or thumbnail.
  * @note This method does not have context option, only use the url and manager level cacheKeyFilter to generate the cache key.
  */

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -194,7 +194,9 @@ static id<SDImageLoader> _defaultImageLoader;
     }
 
     if (url.absoluteString.length == 0 || (!(options & SDWebImageRetryFailed) && isFailedUrl)) {
-        [self callCompletionBlockForOperation:operation completion:completedBlock error:[NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}] url:url];
+        NSString *description = isFailedUrl ? @"Image url is blacklisted" : @"Image url is nil";
+        NSInteger code = isFailedUrl ? SDWebImageErrorBlackListed : SDWebImageErrorInvalidURL;
+        [self callCompletionBlockForOperation:operation completion:completedBlock error:[NSError errorWithDomain:SDWebImageErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : description}] url:url];
         return operation;
     }
 

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -228,6 +228,21 @@ static id<SDImageLoader> _defaultImageLoader;
     return isRunning;
 }
 
+- (void)removeFailedURL:(NSURL *)url {
+    if (!url) {
+        return;
+    }
+    SD_LOCK(self.failedURLsLock);
+    [self.failedURLs removeObject:url];
+    SD_UNLOCK(self.failedURLsLock);
+}
+
+- (void)removeAllFailedURLs {
+    SD_LOCK(self.failedURLsLock);
+    [self.failedURLs removeAllObjects];
+    SD_UNLOCK(self.failedURLsLock);
+}
+
 #pragma mark - Private
 
 // Query normal cache process


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The feature to support removal of black list can solve the use case that some URL may have some extra condition to un-block, like the server recovery back after some retry. (Not always have to use `.retryFailed`)

The error code can makes it easy to investigate the issue, and produce a localized error report.

