### PR TITLE
Added autoplay control property to AnimatedImageView (autoPlayAnimatedImage)

### DIFF
--- a/SDWebImage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDWebImage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SDWebImage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDWebImage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -21,13 +21,6 @@
 @interface SDAnimatedImageView : UIImageView
 
 /**
- If the image has more than one frame, set this value to `YES` will automatically
- play/stop the animation when the view become visible/invisible.
- 
- The default value is `YES`.
- */
-@property (nonatomic) BOOL autoPlayAnimatedImage;
-/**
  Current display frame image. This value is KVO Compliance.
  */
 @property (nonatomic, strong, readonly, nullable) UIImage *currentFrame;
@@ -87,6 +80,14 @@
  Default is NO.
  */
 @property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
+
+/**
+ If the image has more than one frame, set this value to `YES` will automatically
+ play/stop the animation when the view become visible/invisible.
+ 
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL autoPlayAnimatedImage;
 
 /**
  You can specify a runloop mode to let it rendering.

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -21,6 +21,13 @@
 @interface SDAnimatedImageView : UIImageView
 
 /**
+ If the image has more than one frame, set this value to `YES` will automatically
+ play/stop the animation when the view become visible/invisible.
+ 
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL autoPlayAnimatedImage;
+/**
  Current display frame image. This value is KVO Compliance.
  */
 @property (nonatomic, strong, readonly, nullable) UIImage *currentFrame;

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -184,12 +184,8 @@
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
         super.highlighted = NO;
         
-        if (self.autoPlayAnimatedImage) {
-            // Start animating
-            [self startAnimating];
-        } else {
-            [self stopAnimating];
-        }
+        [self stopAnimating];
+        [self checkPlay];
 
         [self.imageViewLayer setNeedsDisplay];
     }
@@ -263,14 +259,7 @@
     [super didMoveToSuperview];
 #endif
     
-    if (self.autoPlayAnimatedImage) {
-        [self updateShouldAnimate];
-        if (self.shouldAnimate) {
-            [self startAnimating];
-        } else {
-            [self stopAnimating];
-        }
-    }
+    [self checkPlay];
 }
 
 #if SD_MAC
@@ -285,14 +274,7 @@
     [super didMoveToWindow];
 #endif
     
-    if (self.autoPlayAnimatedImage) {
-        [self updateShouldAnimate];
-        if (self.shouldAnimate) {
-            [self startAnimating];
-        } else {
-            [self stopAnimating];
-        }
-    }
+    [self checkPlay];
 }
 
 #if SD_MAC
@@ -307,28 +289,14 @@
     [super setAlpha:alpha];
 #endif
     
-    if (self.autoPlayAnimatedImage) {
-        [self updateShouldAnimate];
-        if (self.shouldAnimate) {
-            [self startAnimating];
-        } else {
-            [self stopAnimating];
-        }
-    }
+    [self checkPlay];
 }
 
 - (void)setHidden:(BOOL)hidden
 {
     [super setHidden:hidden];
     
-    if (self.autoPlayAnimatedImage) {
-        [self updateShouldAnimate];
-        if (self.shouldAnimate) {
-            [self startAnimating];
-        } else {
-            [self stopAnimating];
-        }
-    }
+    [self checkPlay];
 }
 
 #pragma mark - UIImageView Method Overrides
@@ -415,6 +383,19 @@
 
 #pragma mark - Private Methods
 #pragma mark Animation
+
+/// Check if it should be played
+- (void)checkPlay
+{
+    if (self.autoPlayAnimatedImage) {
+        [self updateShouldAnimate];
+        if (self.shouldAnimate) {
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
+    }
+}
 
 // Don't repeatedly check our window & superview in `-displayDidRefresh:` for performance reasons.
 // Just update our cached value whenever the animated image or visibility (window, superview, hidden, alpha) is changed.

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -93,6 +93,7 @@
 {
     // Pay attention that UIKit's `initWithImage:` will trigger a `setImage:` during initialization before this `commonInit`.
     // So the properties which rely on this order, should using lazy-evaluation or do extra check in `setImage:`.
+    self.autoPlayAnimatedImage = YES;
     self.shouldCustomLoopCount = NO;
     self.shouldIncrementalLoad = YES;
     self.playbackRate = 1.0;
@@ -183,8 +184,12 @@
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
         super.highlighted = NO;
         
-        // Start animating
-        [self startAnimating];
+        if (self.autoPlayAnimatedImage) {
+            // Start animating
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
 
         [self.imageViewLayer setNeedsDisplay];
     }
@@ -258,11 +263,13 @@
     [super didMoveToSuperview];
 #endif
     
-    [self updateShouldAnimate];
-    if (self.shouldAnimate) {
-        [self startAnimating];
-    } else {
-        [self stopAnimating];
+    if (self.autoPlayAnimatedImage) {
+        [self updateShouldAnimate];
+        if (self.shouldAnimate) {
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
     }
 }
 
@@ -278,11 +285,13 @@
     [super didMoveToWindow];
 #endif
     
-    [self updateShouldAnimate];
-    if (self.shouldAnimate) {
-        [self startAnimating];
-    } else {
-        [self stopAnimating];
+    if (self.autoPlayAnimatedImage) {
+        [self updateShouldAnimate];
+        if (self.shouldAnimate) {
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
     }
 }
 
@@ -298,11 +307,13 @@
     [super setAlpha:alpha];
 #endif
     
-    [self updateShouldAnimate];
-    if (self.shouldAnimate) {
-        [self startAnimating];
-    } else {
-        [self stopAnimating];
+    if (self.autoPlayAnimatedImage) {
+        [self updateShouldAnimate];
+        if (self.shouldAnimate) {
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
     }
 }
 
@@ -310,11 +321,13 @@
 {
     [super setHidden:hidden];
     
-    [self updateShouldAnimate];
-    if (self.shouldAnimate) {
-        [self startAnimating];
-    } else {
-        [self stopAnimating];
+    if (self.autoPlayAnimatedImage) {
+        [self updateShouldAnimate];
+        if (self.shouldAnimate) {
+            [self startAnimating];
+        } else {
+            [self stopAnimating];
+        }
     }
 }
 

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -183,8 +183,11 @@
         
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
         super.highlighted = NO;
-        
+    #if SD_UIKIT
         [self stopAnimating];
+    #else
+        [self setAnimates:NO];
+    #endif
         [self checkPlay];
 
         [self.imageViewLayer setNeedsDisplay];
@@ -389,11 +392,19 @@
 {
     if (self.autoPlayAnimatedImage) {
         [self updateShouldAnimate];
+    #if SD_UIKIT
         if (self.shouldAnimate) {
             [self startAnimating];
         } else {
             [self stopAnimating];
         }
+    #else
+        if (self.shouldAnimate) {
+            [self setAnimates:YES];
+        } else {
+            [self setAnimates:NO];
+        }
+    #endif
     }
 }
 

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -183,11 +183,8 @@
         
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).
         super.highlighted = NO;
-    #if SD_UIKIT
+        
         [self stopAnimating];
-    #else
-        [self setAnimates:NO];
-    #endif
         [self checkPlay];
 
         [self.imageViewLayer setNeedsDisplay];
@@ -328,6 +325,8 @@
     } else {
 #if SD_UIKIT
         [super startAnimating];
+#else
+        [super setAnimates:YES];
 #endif
     }
 }
@@ -346,6 +345,8 @@
     } else {
 #if SD_UIKIT
         [super stopAnimating];
+#else
+        [super setAnimates:NO];
 #endif
     }
 }
@@ -362,9 +363,17 @@
 #endif
 
 #if SD_MAC
+- (BOOL)animates
+{
+    if (self.player) {
+        return self.player.isPlaying;
+    } else {
+        return [super animates];
+    }
+}
+
 - (void)setAnimates:(BOOL)animates
 {
-    [super setAnimates:animates];
     if (animates) {
         [self startAnimating];
     } else {
@@ -392,19 +401,11 @@
 {
     if (self.autoPlayAnimatedImage) {
         [self updateShouldAnimate];
-    #if SD_UIKIT
         if (self.shouldAnimate) {
             [self startAnimating];
         } else {
             [self stopAnimating];
         }
-    #else
-        if (self.shouldAnimate) {
-            [self setAnimates:YES];
-        } else {
-            [self setAnimates:NO];
-        }
-    #endif
     }
 }
 

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -468,6 +468,50 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test28AnimatedImageAutoPlayAnimatedImage {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView AutoPlayAnimatedImage behavior"];
+    
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    imageView.autoPlayAnimatedImage = NO;
+    
+#if SD_UIKIT
+    [self.window addSubview:imageView];
+#else
+    [self.window.contentView addSubview:imageView];
+#endif
+    // This APNG duration is 2s
+    SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
+    imageView.image = image;
+
+    expect(imageView.animating).equal(0);
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        expect(imageView.animating).equal(0);
+        
+        #if SD_UIKIT
+            [imageView startAnimating];
+        #else
+            imageView.animates = YES;
+        #endif
+        
+        expect(imageView.animating).equal(1);
+    });
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        expect(imageView.animating).equal(1);
+
+        #if SD_UIKIT
+            [imageView stopAnimating];
+        #else
+            imageView.animates = NO;
+        #endif
+        [imageView removeFromSuperview];
+        [expectation fulfill];
+    });
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 #pragma mark - Helper
 - (UIWindow *)window {
     if (!_window) {

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -483,28 +483,39 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     SDAnimatedImage *image = [SDAnimatedImage imageWithData:[self testAPNGPData]];
     imageView.image = image;
 
-    expect(imageView.animating).equal(0);
+    #if SD_UIKIT
+        expect(imageView.animating).equal(0);
+    #else
+        expect(imageView.animates).equal(0);
+    #endif
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        expect(imageView.animating).equal(0);
+        #if SD_UIKIT
+            expect(imageView.animating).equal(0);
+        #else
+            expect(imageView.animates).equal(0);
+        #endif
         
         #if SD_UIKIT
             [imageView startAnimating];
         #else
             imageView.animates = YES;
         #endif
-        
-        expect(imageView.animating).equal(1);
     });
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        expect(imageView.animating).equal(1);
-
+        #if SD_UIKIT
+            expect(imageView.animating).equal(1);
+        #else
+            expect(imageView.animates).equal(1);
+        #endif
+        
         #if SD_UIKIT
             [imageView stopAnimating];
         #else
             imageView.animates = NO;
         #endif
+        
         [imageView removeFromSuperview];
         [expectation fulfill];
     });

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -484,16 +484,16 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     imageView.image = image;
 
     #if SD_UIKIT
-        expect(imageView.animating).equal(0);
+        expect(imageView.animating).equal(NO);
     #else
-        expect(imageView.animates).equal(0);
+        expect(imageView.animates).equal(NO);
     #endif
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         #if SD_UIKIT
-            expect(imageView.animating).equal(0);
+            expect(imageView.animating).equal(NO);
         #else
-            expect(imageView.animates).equal(0);
+            expect(imageView.animates).equal(NO);
         #endif
         
         #if SD_UIKIT
@@ -505,9 +505,9 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         #if SD_UIKIT
-            expect(imageView.animating).equal(1);
+            expect(imageView.animating).equal(YES);
         #else
-            expect(imageView.animates).equal(1);
+            expect(imageView.animates).equal(YES);
         #endif
         
         #if SD_UIKIT


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Sometimes we set up a GIF and don't want it to play right away, so we need to add a control
Added autoplay control property to AnimatedImageView (autoPlayAnimatedImage)
(reference YYAnimatedImageView)
