### PR TITLE
Update the Travis-CI to use Catalina and enable macCatalyst test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ env:
 notifications:
   email: false
 
+addons:
+  homebrew:
+    packages:
+    - curl # Fix the codecov upload issue
+
 cache: cocoapods
 podfile: Podfile
 
@@ -59,17 +64,19 @@ script:
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Watch Demo' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS Demo' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
 
-    - echo Clean DerivedData
-    - rm -rf ~/Library/Developer/Xcode/DerivedData/
     - mkdir DerivedData
+    - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/common
 
     - echo Run the tests
     - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/iOS
+    - cp -R ./DerivedData/common ~/Library/Developer/Xcode/DerivedData
     - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests Mac' -destination 'platform=macOS,arch=x86_64' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/macOS
+    - cp -R ./DerivedData/common ~/Library/Developer/Xcode/DerivedData
     - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests TV' -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/tvOS
+    - cp -R ./DerivedData/common ~/Library/Developer/Xcode/DerivedData
 
 after_success:
     - export PATH="/usr/local/opt/curl/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 language: objective-c
-osx_image: xcode11
+osx_image: xcode11.4
 
 env:
   global:
@@ -9,11 +9,6 @@ env:
 
 notifications:
   email: false
-
-addons:
-  homebrew:
-    packages:
-    - curl # Fix the codecov upload issue
 
 cache: cocoapods
 podfile: Podfile
@@ -51,11 +46,11 @@ script:
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage' -sdk appletvsimulator -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage' -sdk watchsimulator -configuration Debug | xcpretty -c
-    # - xcodebuild archive -project SDWebImage.xcodeproj -scheme 'SDWebImage' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug | xcpretty -c
+    - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -sdk macosx -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -sdk appletvsimulator -configuration Debug | xcpretty -c
-    # - xcodebuild archive -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug | xcpretty -c
+    - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug | xcpretty -c
 
     - echo Clean DerivedData
     - rm -rf ~/Library/Developer/Xcode/DerivedData/
@@ -66,7 +61,7 @@ script:
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS Demo' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage TV Demo' -destination 'platform=tvOS Simulator,name=Apple TV 4K' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Watch Demo' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
-    # - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS Demo' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS Demo' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
 
     - echo Clean DerivedData
     - rm -rf ~/Library/Developer/Xcode/DerivedData/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
 
     - echo Build as static library
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage static' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
-    - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImage static' -sdk watchsimulator -configuration Debug | xcpretty -c
 
     - echo Clean DerivedData
     - rm -rf ~/Library/Developer/Xcode/DerivedData/
@@ -52,9 +51,6 @@ script:
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -sdk appletvsimulator -configuration Debug | xcpretty -c
     - xcodebuild build -project SDWebImage.xcodeproj -scheme 'SDWebImageMapKit' -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -configuration Debug | xcpretty -c
 
-    - echo Clean DerivedData
-    - rm -rf ~/Library/Developer/Xcode/DerivedData/
-
     - echo Build the Demo apps
     - pod install
     - xcodebuild build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage OSX Demo' -destination 'platform=macOS,arch=x86_64' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
@@ -68,11 +64,11 @@ script:
     - mkdir DerivedData
 
     - echo Run the tests
-    - xcodebuild clean test -workspace SDWebImage.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/iOS
-    - xcodebuild clean test -workspace SDWebImage.xcworkspace -scheme 'Tests Mac' -destination 'platform=macOS,arch=x86_64' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests Mac' -destination 'platform=macOS,arch=x86_64' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/macOS
-    - xcodebuild clean test -workspace SDWebImage.xcworkspace -scheme 'Tests TV' -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests TV' -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/tvOS
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,11 @@ script:
     - mkdir DerivedData
 
     - echo Run the tests
-    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/iOS
-    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests Mac' -destination 'platform=macOS,arch=x86_64' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests Mac' -destination 'platform=macOS,arch=x86_64' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/macOS
-    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests TV' -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug -UseModernBuildSystem=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+    - xcodebuild test -workspace SDWebImage.xcworkspace -scheme 'Tests TV' -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug CODE_SIGNING_ALLOWED=NO | xcpretty -c
     - mv ~/Library/Developer/Xcode/DerivedData/ ./DerivedData/tvOS
 
 after_success:


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Travis finally supports macOS Catalina. See: https://changelog.travis-ci.com/xcode-11-4-1-is-now-available-149423

