### PR TITLE
Fix the issue that the NSURLRequest method should not be nil, which may cause Crash

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.m
@@ -53,7 +53,7 @@
 }
 
 - (instancetype)initWithMethod:(NSString *)method headers:(NSDictionary<NSString *,NSString *> *)headers body:(NSData *)body {
-    method = [method copy];
+    method = method ? [method copy] : @"GET";
     headers = [headers copy];
     body = [body copy];
     return [self initWithBlock:^NSURLRequest * _Nullable(NSURLRequest * _Nonnull request) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
NSURLRequest.HTTPMethod should not be nil, the default value should be `GET`. Or, when request some specify HTTP URL contains 302 redirect, a runtime crash will occurs.

See screenshot here: https://github.com/DylanVann/react-native-fast-image/pull/691#issuecomment-639413527

The react-native-fast-image PR already test this behavior.

@kinarobin 