### PR TITLE
Change to use kCGImageSourceCreateThumbnailFromImageAlways to solve the issue when HEIC/JPEG contains an embed thumbnail but its size is much smaller than provided `maxPixelSize`

### DIFF
--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -215,7 +215,7 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
             maxPixelSize = MAX(thumbnailSize.width, thumbnailSize.height);
         }
         decodingOptions[(__bridge NSString *)kCGImageSourceThumbnailMaxPixelSize] = @(maxPixelSize);
-        decodingOptions[(__bridge NSString *)kCGImageSourceCreateThumbnailFromImageIfAbsent] = @(YES);
+        decodingOptions[(__bridge NSString *)kCGImageSourceCreateThumbnailFromImageAlways] = @(YES);
         imageRef = CGImageSourceCreateThumbnailAtIndex(source, index, (__bridge CFDictionaryRef)decodingOptions);
     }
     if (!imageRef) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3036

### Pull Request Description

This close #3036 

Demo URL(JPEG which contains an embed thumbnail 120x160): http://resource-fat.7kid.com/7kid/moment/img/20206/55e26e85-a962-4d98-a51f-107b55911b24_6.jpg

You can use imagemagic to check the metadata.

+ Use  `kCGImageSourceCreateThumbnailFromImageIfAbsent `: Return 120x160

![image](https://user-images.githubusercontent.com/6919743/84462599-06faca80-aca2-11ea-9684-e87891536d2a.png)


+ Use `kCGImageSourceCreateThumbnailFromImageAlways`: Return 2975x3966

![image](https://user-images.githubusercontent.com/6919743/84462533-e29eee00-aca1-11ea-9409-ec345bed73b0.png)
