### PR TITLE
Fix the issue of iOS 14 vector image rendering on SDAnimatedImageView

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -474,7 +474,7 @@
         layer.contents = (__bridge id)currentFrame.CGImage;
     } else {
         // If we have no animation frames, call super implementation. iOS 14+ UIImageView use this delegate method for rendering.
-        if ([super respondsToSelector:@selector(displayLayer:)]) {
+        if ([UIImageView instancesRespondToSelector:@selector(displayLayer:)]) {
             [super displayLayer:layer];
         }
     }

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -16,7 +16,10 @@
 #import "SDInternalMacros.h"
 #import "objc/runtime.h"
 
-@interface SDAnimatedImageView () <CALayerDelegate> {
+@interface UIImageView () <CALayerDelegate>
+@end
+
+@interface SDAnimatedImageView () {
     BOOL _initFinished; // Extra flag to mark the `commonInit` is called
     NSRunLoopMode _runLoopMode;
     NSUInteger _maxBufferSize;
@@ -466,12 +469,14 @@
 - (void)displayLayer:(CALayer *)layer
 {
     UIImage *currentFrame = self.currentFrame;
-    if (!currentFrame) {
-        currentFrame = self.image;
-    }
     if (currentFrame) {
         layer.contentsScale = currentFrame.scale;
         layer.contents = (__bridge id)currentFrame.CGImage;
+    } else {
+        // If we have no animation frames, call super implementation. iOS 14+ UIImageView use this delegate method for rendering.
+        if ([super respondsToSelector:@selector(displayLayer:)]) {
+            [super displayLayer:layer];
+        }
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3043 

### Pull Request Description

In the #3043, we apply a hot-patch to use CALayer.contents for rendering static images. However, that breaks the vector images which UIImageView supports.

For example, previouslly, we can render SVG/PDF images in dynamic sizes via [SVGCoder](https://github.com/SDWebImage/SDWebImageSVGCoder) and [PDFCoder](https://github.com/SDWebImage/SDWebImagePDFCoder). That #3043 breaks this after v5.8.2 version.

Should call super method if need for best compatibility. This is the best solution to keep function.



