### PR TITLE
Add the support for that UIImage+MultiFormat methods on SDAnimartedImage, which supports encoding the animation like GIF/APNG/WebP with lower compression quality.

### DIFF
--- a/SDWebImage/Core/UIImage+MultiFormat.h
+++ b/SDWebImage/Core/UIImage+MultiFormat.h
@@ -45,6 +45,7 @@
 /**
  Encode the current image to the data, the image format is unspecified
 
+ @note If the receiver is `SDAnimatedImage`, this will return the animated image data if available. No more extra encoding process.
  @return The encoded data. If can't encode, return nil
  */
 - (nullable NSData *)sd_imageData;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See some user's requests from #3032 

Currently, because that `UIAnimatedImage` and `SDAnimatedImage` design from different root case, and have some incompatible behaviors. When call `SDAnimatedImage` instance with `UIImage+MultiFormat` category methods, it will fallback to encode as static image.

So, this PR now provide the convient implementation talked in #3032, which encode the `SDAnimatedImage` into real animated image data, which previouslly only encode first frame :(

### What's next

These mass between that encoder, animated image solution, and UIKit fucking `UIAnimatedImage` may be solved during 6.0's refactory of `SDImageCoder` protocol. The new encoding API does not take any `UIImage` arg, instead it takes each frames and context to let you encode animated image easily.

More design here in my [temp branch](https://github.com/SDWebImage/SDWebImage/compare/master...dreampiggy:temp_animated_encoder_protocol), draft protoocl method like:

```objective-c
- (void)addImageFrame:(nonnull UIImage *)image duration:(NSTimeInterval)duration options:(nullable SDImageEncoderOptions *)options;
```
