### PR TITLE
Supports the user to customize the default disk cache directory, which can be used to share cache for App && App Extension

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -104,6 +104,15 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 @property (nonatomic, class, readonly, nonnull) SDImageCache *sharedImageCache;
 
 /**
+ * Control the default disk cache directory. This will effect all the SDImageCache instance created, even for shared image cache.
+ * This can be used to share the same disk cache with the App and App Extension (Today/Notification Widget) using `- [NSFileManager.containerURLForSecurityApplicationGroupIdentifier:]`.
+ * @note If you pass nil, the value will be reset to `~/Library/Caches/com.hackemist.SDImageCache`.
+ * @note We still preserve the `namespace` arg, which means, if you change this property into `/path/to/use`,  the `SDImageCache.sharedImageCache.diskCachePath` should be `/path/to/use/default` because shared image cache use `default` as namespace.
+ * Defaults to nil.
+ */
+@property (nonatomic, class, readwrite, null_resettable) NSString *defaultDiskCacheDirectory;
+
+/**
  * Init a new cache store with a specific namespace
  *
  * @param ns The namespace to use for this cache store

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -104,7 +104,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 @property (nonatomic, class, readonly, nonnull) SDImageCache *sharedImageCache;
 
 /**
- * Control the default disk cache directory. This will effect all the SDImageCache instance created, even for shared image cache.
+ * Control the default disk cache directory. This will effect all the SDImageCache instance created after modification, even for shared image cache.
  * This can be used to share the same disk cache with the App and App Extension (Today/Notification Widget) using `- [NSFileManager.containerURLForSecurityApplicationGroupIdentifier:]`.
  * @note If you pass nil, the value will be reset to `~/Library/Caches/com.hackemist.SDImageCache`.
  * @note We still preserve the `namespace` arg, which means, if you change this property into `/path/to/use`,  the `SDImageCache.sharedImageCache.diskCachePath` should be `/path/to/use/default` because shared image cache use `default` as namespace.
@@ -114,6 +114,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 
 /**
  * Init a new cache store with a specific namespace
+ * The final disk cache directory should looks like ($directory/$namespace). And the default config of shared cache, should result in (~/Library/Caches/com.hackemist.SDImageCache/default/)
  *
  * @param ns The namespace to use for this cache store
  */
@@ -121,7 +122,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 
 /**
  * Init a new cache store with a specific namespace and directory.
- * If you don't provide the disk cache directory, we will use the User Cache directory with prefix (~/Library/Caches/com.hackemist.SDImageCache/).
+ * The final disk cache directory should looks like ($directory/$namespace). And the default config of shared cache, should result in (~/Library/Caches/com.hackemist.SDImageCache/default/)
  *
  * @param ns        The namespace to use for this cache store
  * @param directory Directory to cache disk images in
@@ -130,7 +131,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
                        diskCacheDirectory:(nullable NSString *)directory;
 
 /**
- * Init a new cache store with a specific namespace, directory and file manager
+ * Init a new cache store with a specific namespace, directory and config.
  * The final disk cache directory should looks like ($directory/$namespace). And the default config of shared cache, should result in (~/Library/Caches/com.hackemist.SDImageCache/default/)
  *
  * @param ns          The namespace to use for this cache store

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -85,15 +85,11 @@ static NSString * _defaultDiskCacheDirectory;
         _memoryCache = [[config.memoryCacheClass alloc] initWithConfig:_config];
         
         // Init the disk cache
-        if (directory != nil) {
-            _diskCachePath = [directory stringByAppendingPathComponent:ns];
-        } else {
-            if (!directory) {
-                // Use default disk cache directory
-                directory = [self.class defaultDiskCacheDirectory];
-            }
-            _diskCachePath = [directory stringByAppendingPathComponent:ns];
+        if (!directory) {
+            // Use default disk cache directory
+            directory = [self.class defaultDiskCacheDirectory];
         }
+        _diskCachePath = [directory stringByAppendingPathComponent:ns];
         
         NSAssert([config.diskCacheClass conformsToProtocol:@protocol(SDDiskCache)], @"Custom disk cache class must conform to `SDDiskCache` protocol");
         _diskCache = [[config.diskCacheClass alloc] initWithCachePath:_diskCachePath config:_config];

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -484,6 +484,25 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test43CustomDefaultCacheDirectory {
+    NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *testDirectory = [paths.firstObject stringByAppendingPathComponent:@"CustomDefaultCacheDirectory"];
+    NSString *defaultDirectory = [paths.firstObject stringByAppendingPathComponent:@"com.hackemist.SDImageCache"];
+    NSString *namespace = @"Test";
+    
+    // Default cache path
+    expect(SDImageCache.defaultDiskCacheDirectory).equal(defaultDirectory);
+    SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:namespace];
+    expect(cache1.diskCachePath).equal([defaultDirectory stringByAppendingPathComponent:namespace]);
+    // Custom cache path
+    SDImageCache.defaultDiskCacheDirectory = testDirectory;
+    SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:namespace];
+    expect(cache2.diskCachePath).equal([testDirectory stringByAppendingPathComponent:namespace]);
+    // Check reset
+    SDImageCache.defaultDiskCacheDirectory = nil;
+    expect(SDImageCache.defaultDiskCacheDirectory).equal(defaultDirectory);
+}
+
 #pragma mark - SDMemoryCache & SDDiskCache
 - (void)test42CustomMemoryCache {
     SDImageCacheConfig *config = [[SDImageCacheConfig alloc] init];

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -203,7 +203,7 @@
 }
 
 - (void)test16ThatHEICAnimatedWorks {
-    if (@available(iOS 11, tvOS 11, macOS 10.13, *)) {
+    if (@available(iOS 13, tvOS 13, macOS 10.15, *)) {
         NSURL *heicURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestImageAnimated" withExtension:@"heic"];
 #if SD_UIKIT
         BOOL isAnimatedImage = YES;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: close #3050

### Pull Request Description

This PR solve the feature request from #3050.

If you want to change the shared image cache's path, use like this:

```objective-c

- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
    // Insert code here to initialize your application
    SDImageCache.defaultImageCacheDirectory = [NSFileManager.defaultManager containerURLForSecurityApplicationGroupIdentifier:@"my.app.group.id"];
}
```

