### PR TITLE
Add the support to pass small bytes to `decodedAndScaledDownLargeImage`, which always scale down (at least 1x1 pixel) but not return the original size

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -92,7 +92,7 @@
 
 /**
  Return the decoded and probably scaled down image by the provided image. If the image pixels bytes size large than the limit bytes, will try to scale down. Or just works as `decodedImageWithImage:`, never scale up.
- @warning You should not pass a too smaller bytes limit, the suggestion value should be larger than 1MB. We use Tile Decoding to avoid OOM, however, this will consume much more CPU time because we need to iterate and draw each tile (which may be hundreds).
+ @warning You should not pass a too small bytes limit, the suggestion value should be larger than 1MB. We use Tile Decoding to avoid OOM, however, this will consume much more CPU time because we need to iterate and draw each tile line by line.
 
  @param image The image to be decoded and scaled down
  @param bytes The limit bytes size. Provide 0 to use the build-in limit.

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -91,7 +91,8 @@
 + (UIImage * _Nullable)decodedImageWithImage:(UIImage * _Nullable)image;
 
 /**
- Return the decoded and probably scaled down image by the provided image. If the image is large than the limit size, will try to scale down. Or just works as `decodedImageWithImage:`
+ Return the decoded and probably scaled down image by the provided image. If the image pixels bytes size large than the limit bytes, will try to scale down. Or just works as `decodedImageWithImage:`, never scale up.
+ @warning You should not pass a too smaller bytes limit, the suggestion value should be larger than 1MB. We use Tile Decoding to avoid OOM, however, this will consume much more CPU time because we need to iterate and draw each tile (which may be hundreds).
 
  @param image The image to be decoded and scaled down
  @param bytes The limit bytes size. Provide 0 to use the build-in limit.
@@ -101,7 +102,7 @@
 
 /**
  Control the default limit bytes to scale down largest images.
- This value must be larger than or equal to 1MB. Defaults to 60MB on iOS/tvOS, 90MB on macOS, 30MB on watchOS.
+ This value must be larger than 4 Bytes (at least 1x1 pixel). Defaults to 60MB on iOS/tvOS, 90MB on macOS, 30MB on watchOS.
  */
 @property (class, readwrite) NSUInteger defaultScaleDownLimitBytes;
 

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -92,7 +92,7 @@
 
 /**
  Return the decoded and probably scaled down image by the provided image. If the image pixels bytes size large than the limit bytes, will try to scale down. Or just works as `decodedImageWithImage:`, never scale up.
- @warning You should not pass a too small bytes limit, the suggestion value should be larger than 1MB. We use Tile Decoding to avoid OOM, however, this will consume much more CPU time because we need to iterate and draw each tile line by line.
+ @warning You should not pass too small bytes, the suggestion value should be larger than 1MB. Even we use Tile Decoding to avoid OOM, however, small bytes will consume much more CPU time because we need to iterate more times to draw each tile.
 
  @param image The image to be decoded and scaled down
  @param bytes The limit bytes size. Provide 0 to use the build-in limit.

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -25,7 +25,6 @@ static const size_t kBytesPerPixel = 4;
 static const size_t kBitsPerComponent = 8;
 
 static const CGFloat kBytesPerMB = 1024.0f * 1024.0f;
-static const CGFloat kPixelsPerMB = kBytesPerMB / kBytesPerPixel;
 /*
  * Defines the maximum size in MB of the decoded image when the flag `SDWebImageScaleDownLargeImages` is set
  * Suggested value for iPad1 and iPhone 3GS: 60.
@@ -379,8 +378,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // see kDestImageSizeMB, and how it relates to destTotalPixels.
         CGFloat imageScale = sqrt(destTotalPixels / sourceTotalPixels);
         CGSize destResolution = CGSizeZero;
-        destResolution.width = (int)(sourceResolution.width * imageScale);
-        destResolution.height = (int)(sourceResolution.height * imageScale);
+        destResolution.width = MAX(1, (int)(sourceResolution.width * imageScale));
+        destResolution.height = MAX(1, (int)(sourceResolution.height * imageScale));
         
         // device color space
         CGColorSpaceRef colorspaceRef = [self colorSpaceGetDeviceRGB];
@@ -419,7 +418,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // The source tile height is dynamic. Since we specified the size
         // of the source tile in MB, see how many rows of pixels high it
         // can be given the input image width.
-        sourceTile.size.height = (int)(tileTotalPixels / sourceTile.size.width );
+        sourceTile.size.height = MAX(1, (int)(tileTotalPixels / sourceTile.size.width));
         sourceTile.origin.x = 0.0f;
         // The output tile is the same proportions as the input tile, but
         // scaled to image scale.
@@ -485,7 +484,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 }
 
 + (void)setDefaultScaleDownLimitBytes:(NSUInteger)defaultScaleDownLimitBytes {
-    if (defaultScaleDownLimitBytes < kBytesPerMB) {
+    if (defaultScaleDownLimitBytes < kBytesPerPixel) {
         return;
     }
     kDestImageLimitBytes = defaultScaleDownLimitBytes;
@@ -595,25 +594,14 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         return NO;
     }
     CGFloat destTotalPixels;
-    CGFloat tileTotalPixels;
     if (bytes == 0) {
-        bytes = kDestImageLimitBytes;
+        bytes = [self defaultScaleDownLimitBytes];
     }
     destTotalPixels = bytes / kBytesPerPixel;
-    if (destTotalPixels <= kPixelsPerMB) {
-        // Too small to scale down
-        return NO;
-    }
     float imageScale = destTotalPixels / sourceTotalPixels;
     if (imageScale < 1) {
         shouldScaleDown = YES;
     } else {
-        shouldScaleDown = NO;
-    }
-    // Add a protect when tile rectangle is too small to calculate
-    // The tile rectangle width equals to image's width, height should be at least 1 pixel
-    tileTotalPixels = destTotalPixels / 3;
-    if (tileTotalPixels < sourceResolution.width * 1) {
         shouldScaleDown = NO;
     }
     

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -597,6 +597,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (bytes == 0) {
         bytes = [self defaultScaleDownLimitBytes];
     }
+    bytes = MAX(bytes, kBytesPerPixel);
     destTotalPixels = bytes / kBytesPerPixel;
     float imageScale = destTotalPixels / sourceTotalPixels;
     if (imageScale < 1) {

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -595,6 +595,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         return NO;
     }
     CGFloat destTotalPixels;
+    CGFloat tileTotalPixels;
     if (bytes == 0) {
         bytes = kDestImageLimitBytes;
     }
@@ -607,6 +608,12 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (imageScale < 1) {
         shouldScaleDown = YES;
     } else {
+        shouldScaleDown = NO;
+    }
+    // Add a protect when tile rectangle is too small to calculate
+    // The tile rectangle width equals to image's width, height should be at least 1 pixel
+    tileTotalPixels = destTotalPixels / 3;
+    if (tileTotalPixels < sourceResolution.width * 1) {
         shouldScaleDown = NO;
     }
     

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -83,6 +83,29 @@
     expect(decodedImage.size.height).to.equal(image.size.height);
 }
 
+- (void)test07ThatDecodeAndScaleDownImageDoesNotScaleSmallerBytes {
+    // Check when user provide a limit bytes, which cause the tile rectangle too small to calculate
+    NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImageLarge" ofType:@"jpg"];
+    UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];
+    CGFloat sourceWidth = CGImageGetWidth(image.CGImage);
+    CGFloat tileMinPixels = sourceWidth * 1;
+    NSUInteger kBytesPerPixel = 4;
+    NSUInteger kBytesPerMB = 1024 * 1024;
+    NSUInteger limitBytes = MAX(tileMinPixels * 3 * kBytesPerPixel, kBytesPerMB);
+    // Image 1 should be scaled down size (shouldScaleDownImage returns YES)
+    UIImage *decodedImage1 = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:limitBytes + kBytesPerPixel];
+    expect(decodedImage1).toNot.beNil();
+    expect(decodedImage1).toNot.equal(image);
+    expect(decodedImage1.size.width).toNot.equal(image.size.width);
+    expect(decodedImage1.size.height).toNot.equal(image.size.height);
+    // Image 2 should not be scaled down, only force decode (shouldScaleDownImage returns NO)
+    UIImage *decodedImage2 = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:limitBytes - kBytesPerPixel];
+    expect(decodedImage2).toNot.beNil();
+    expect(decodedImage2).toNot.equal(image);
+    expect(decodedImage2.size.width).to.equal(image.size.width);
+    expect(decodedImage2.size.height).to.equal(image.size.height);
+}
+
 - (void)test08ThatEncodeAlphaImageToJPGWithBackgroundColor {
     NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"png"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -74,6 +74,7 @@
 }
 
 - (void)test07ThatDecodeAndScaleDownImageDoesNotScaleSmallerImage {
+    // check when user use the larget bytes than image pixels byets, we do not scale up the image (defaults 60MB means 3965x3965 pixels)
     NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"jpg"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];
     UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image];
@@ -83,27 +84,15 @@
     expect(decodedImage.size.height).to.equal(image.size.height);
 }
 
-- (void)test07ThatDecodeAndScaleDownImageDoesNotScaleSmallerBytes {
-    // Check when user provide a limit bytes, which cause the tile rectangle too small to calculate
-    NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImageLarge" ofType:@"jpg"];
+- (void)test07ThatDecodeAndScaleDownImageScaleSmallerBytes {
+    // Check when user provide too smaller bytes, we scale it down to 1x1, but not return the force decoded original size image
+    NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"jpg"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];
-    CGFloat sourceWidth = CGImageGetWidth(image.CGImage);
-    CGFloat tileMinPixels = sourceWidth * 1;
-    NSUInteger kBytesPerPixel = 4;
-    NSUInteger kBytesPerMB = 1024 * 1024;
-    NSUInteger limitBytes = MAX(tileMinPixels * 3 * kBytesPerPixel, kBytesPerMB);
-    // Image 1 should be scaled down size (shouldScaleDownImage returns YES)
-    UIImage *decodedImage1 = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:limitBytes + kBytesPerPixel];
-    expect(decodedImage1).toNot.beNil();
-    expect(decodedImage1).toNot.equal(image);
-    expect(decodedImage1.size.width).toNot.equal(image.size.width);
-    expect(decodedImage1.size.height).toNot.equal(image.size.height);
-    // Image 2 should not be scaled down, only force decode (shouldScaleDownImage returns NO)
-    UIImage *decodedImage2 = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:limitBytes - kBytesPerPixel];
-    expect(decodedImage2).toNot.beNil();
-    expect(decodedImage2).toNot.equal(image);
-    expect(decodedImage2.size.width).to.equal(image.size.width);
-    expect(decodedImage2.size.height).to.equal(image.size.height);
+    UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:1];
+    expect(decodedImage).toNot.beNil();
+    expect(decodedImage).toNot.equal(image);
+    expect(decodedImage.size.width).to.equal(1);
+    expect(decodedImage.size.height).to.equal(1);
 }
 
 - (void)test08ThatEncodeAlphaImageToJPGWithBackgroundColor {

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -85,7 +85,7 @@
 }
 
 - (void)test07ThatDecodeAndScaleDownImageScaleSmallerBytes {
-    // Check when user provide too smaller bytes, we scale it down to 1x1, but not return the force decoded original size image
+    // Check when user provide too small bytes, we scale it down to 1x1, but not return the force decoded original size image
     NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"jpg"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];
     UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:1];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: close #3056 

### Pull Request Description

This add the protect code when the tile rectangle is too small to create (The rectangle height less than 1).

However, because we have a hack protect code which does not allows you pass `limitBytes` arg to less than 1MB.

Which means, to hit this race condition, your original full image's pixel width should be larger than **87381**. Not possible in real world :)

Calculation:
Assume limitBytes passed 1MB (1024*1024 Bytes);
Assume tile height use 1 pixel
Assume bytes per pixel use 4 (RGBA)
`width = 1024 * 1024(bytes) / 4(bytes per pixel) / 3(tile count) / 1(tile height) = 87381.333333`
