### PR TITLE
Fix the image format detection for smaller SVG which less than 100 Bytes

### DIFF
--- a/SDWebImage/Core/NSData+ImageContentType.m
+++ b/SDWebImage/Core/NSData+ImageContentType.m
@@ -74,12 +74,9 @@
             }
         }
         case 0x3C: {
-            if (data.length > 100) {
-                // Check end with SVG tag
-                NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(data.length - 100, 100)] encoding:NSASCIIStringEncoding];
-                if ([testString containsString:kSVGTagEnd]) {
-                    return SDImageFormatSVG;
-                }
+            // Check end with SVG tag
+            if ([data rangeOfData:[kSVGTagEnd dataUsingEncoding:NSUTF8StringEncoding] options:NSDataSearchBackwards range: NSMakeRange(data.length - MIN(100, data.length), MIN(100, data.length))].location != NSNotFound) {
+                return SDImageFormatSVG;
             }
         }
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR is from the SVGCoder repo: https://github.com/SDWebImage/SDWebImageSVGCoder/pull/26