### PR TITLE
Refactory the current behavior to use transition. Now it automatically do transition when manager callback asynchronously (if user see waiting, then do transition)

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -47,7 +47,7 @@
     self.imageView4.sd_imageTransition = SDWebImageTransition.fadeTransition;
     self.imageView4.imageScaling = NSImageScaleProportionallyUpOrDown;
     self.imageView4.imageAlignment = NSImageAlignLeft; // supports NSImageView's layout properties
-    [self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"] placeholderImage:nil options:SDWebImageForceTransition];
+    [self.imageView4 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"]];
     NSMenu *menu2 = [[NSMenu alloc] initWithTitle:@"Toggle Animation"];
     NSMenuItem *item2 = [menu2 addItemWithTitle:@"Toggle Animation" action:@selector(toggleAnimation:) keyEquivalent:@""];
     item2.tag = 2;

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -539,14 +539,13 @@ static NSString * _defaultDiskCacheDirectory;
                     [self.memoryCache setObject:diskImage forKey:key cost:cost];
                 }
             }
-            SDImageCacheType cacheType = diskImage ? SDImageCacheTypeDisk : SDImageCacheTypeNone;
             
             if (doneBlock) {
                 if (shouldQueryDiskSync) {
-                    doneBlock(diskImage, diskData, cacheType);
+                    doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
                 } else {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        doneBlock(diskImage, diskData, cacheType);
+                        doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
                     });
                 }
             }

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -528,13 +528,10 @@ static NSString * _defaultDiskCacheDirectory;
         @autoreleasepool {
             NSData *diskData = [self diskImageDataBySearchingAllPathsForKey:key];
             UIImage *diskImage;
-            SDImageCacheType cacheType = SDImageCacheTypeNone;
             if (image) {
                 // the image is from in-memory cache, but need image data
                 diskImage = image;
-                cacheType = SDImageCacheTypeMemory;
             } else if (diskData) {
-                cacheType = SDImageCacheTypeDisk;
                 // decode image data only if in-memory cache missed
                 diskImage = [self diskImageForKey:key data:diskData options:options context:context];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
@@ -542,6 +539,7 @@ static NSString * _defaultDiskCacheDirectory;
                     [self.memoryCache setObject:diskImage forKey:key cost:cost];
                 }
             }
+            SDImageCacheType cacheType = diskImage ? SDImageCacheTypeDisk : SDImageCacheTypeNone;
             
             if (doneBlock) {
                 if (shouldQueryDiskSync) {

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -161,6 +161,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     
     /**
      * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for memory and disk cache as well.
+     * @note This options naming may be `SDWebImageForceTransitionAlways` in the furture. Which does not check any condition, just do transition even we query the cache immediately from memory. See related `SDWebImageForceTransitionAsync`.
      */
     SDWebImageForceTransition = 1 << 17,
     
@@ -201,6 +202,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * Use this flag to transform them anyway.
      */
     SDWebImageTransformVectorImage = 1 << 23,
+    
+    /**
+     * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for condition when the callback from manager is asynchronous.
+     * For example, when memory cache hit, or disk cache who using `queryDiskDataSync`, this will trigger  transition. The default behavior (without any options) only do transition when network query successed.
+     * @note This is used for UI rendering which relay  the same runloop to avoid flashing, suitable for common use case cases. Which means, if user can see any waiting, do transition. else not.
+     */
+    SDWebImageForceTransitionAsync = 1 << 24
 };
 
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -160,8 +160,8 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     SDWebImageFromLoaderOnly = 1 << 16,
     
     /**
-     * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for memory and disk cache as well.
-     * @note This options naming may be `SDWebImageForceTransitionAlways` in the furture. Which does not check any condition, just do transition even we query the cache immediately from memory. See related `SDWebImageForceTransitionAsync`.
+     * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image when the callback from manager is asynchronous (from network, or disk cache query)
+     * This mask can force to apply view transition for any cases, like memory cache query, or sync disk cache query.
      */
     SDWebImageForceTransition = 1 << 17,
     
@@ -201,14 +201,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * We usually don't apply transform on vector images, because vector images supports dynamically changing to any size, rasterize to a fixed size will loss details. To modify vector images, you can process the vector data at runtime (such as modifying PDF tag / SVG element).
      * Use this flag to transform them anyway.
      */
-    SDWebImageTransformVectorImage = 1 << 23,
-    
-    /**
-     * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for condition when the callback from manager is asynchronous.
-     * For example, when disk cache hit (and you don't use `queryDiskDataSync`), this will trigger transition because disk query is asynchronous. The default behavior (without any options) only do transition when network query successed.
-     * @note This is best used for UI rendering common cases, because even the cache is from disk, we may see a quick flashing of placeholder. In summary, if user can see any waiting (whether it takes 10 milliseconds or 10 minutes), do transition. else not.
-     */
-    SDWebImageForceTransitionAsync = 1 << 24
+    SDWebImageTransformVectorImage = 1 << 23
 };
 
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -205,8 +205,8 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     
     /**
      * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for condition when the callback from manager is asynchronous.
-     * For example, when memory cache hit, or disk cache who using `queryDiskDataSync`, this will trigger  transition. The default behavior (without any options) only do transition when network query successed.
-     * @note This is used for UI rendering which relay  the same runloop to avoid flashing, suitable for common use case cases. Which means, if user can see any waiting, do transition. else not.
+     * For example, when disk cache hit (and you don't use `queryDiskDataSync`), this will trigger transition because disk query is asynchronous. The default behavior (without any options) only do transition when network query successed.
+     * @note This is best used for UI rendering common cases, because even the cache is from disk, we may see a quick flashing of placeholder. In summary, if user can see any waiting (whether it takes 10 milliseconds or 10 minutes), do transition. else not.
      */
     SDWebImageForceTransitionAsync = 1 << 24
 };

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -179,23 +179,20 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                 // Always
                 shouldUseTransition = YES;
             } else if (cacheType == SDImageCacheTypeNone) {
-                // Default, from network
+                // From network
                 shouldUseTransition = YES;
             } else {
-                // Async, from disk (and, user don't use sync query)
-                if (options & SDWebImageForceTransitionAsync) {
-                    if (cacheType == SDImageCacheTypeMemory) {
+                // From disk (and, user don't use sync query)
+                if (cacheType == SDImageCacheTypeMemory) {
+                    shouldUseTransition = NO;
+                } else if (cacheType == SDImageCacheTypeDisk) {
+                    if (options & SDWebImageQueryMemoryDataSync || options & SDWebImageQueryDiskDataSync) {
                         shouldUseTransition = NO;
-                    } else if (cacheType == SDImageCacheTypeDisk) {
-                        if (options & SDWebImageQueryMemoryDataSync || options & SDWebImageQueryDiskDataSync) {
-                            shouldUseTransition = NO;
-                        } else {
-                            shouldUseTransition = YES;
-                        }
                     } else {
-                        shouldUseTransition = NO;
+                        shouldUseTransition = YES;
                     }
                 } else {
+                    // Not valid cache type, fallback
                     shouldUseTransition = NO;
                 }
             }

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -174,7 +174,32 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 #if SD_UIKIT || SD_MAC
             // check whether we should use the image transition
             SDWebImageTransition *transition = nil;
-            if (finished && (options & SDWebImageForceTransition || cacheType == SDImageCacheTypeNone)) {
+            BOOL shouldUseTransition = NO;
+            if (options & SDWebImageForceTransition) {
+                // Always
+                shouldUseTransition = YES;
+            } else if (cacheType == SDImageCacheTypeNone) {
+                // Default, from network
+                shouldUseTransition = YES;
+            } else {
+                // Async, from disk (and, user don't use sync query)
+                if (options & SDWebImageForceTransitionAsync) {
+                    if (cacheType == SDImageCacheTypeMemory) {
+                        shouldUseTransition = NO;
+                    } else if (cacheType == SDImageCacheTypeDisk) {
+                        if (options & SDWebImageQueryMemoryDataSync || options & SDWebImageQueryDiskDataSync) {
+                            shouldUseTransition = NO;
+                        } else {
+                            shouldUseTransition = YES;
+                        }
+                    } else {
+                        shouldUseTransition = NO;
+                    }
+                } else {
+                    shouldUseTransition = NO;
+                }
+            }
+            if (finished && shouldUseTransition) {
                 transition = self.sd_imageTransition;
             }
 #endif

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -253,8 +253,8 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)testUIViewTransitionWork {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"UIView transition does not work"];
+- (void)testUIViewTransitionFromNetworkWork {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"UIView transition from network does not work"];
     
     // Attach a window, or CALayer will not submit drawing
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
@@ -296,8 +296,8 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)testUIViewTransitionAsyncWork {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"UIView transition async does not work"];
+- (void)testUIViewTransitionFromDiskWork {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"UIView transition from disk does not work"];
     
     // Attach a window, or CALayer will not submit drawing
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
@@ -323,7 +323,7 @@
     __weak typeof(imageView) wimageView = imageView;
     [imageView sd_setImageWithURL:originalImageURL
                  placeholderImage:placeholder
-                          options:SDWebImageForceTransitionAsync | SDWebImageFromCacheOnly // Ensure we queired from disk cache
+                          options:SDWebImageFromCacheOnly // Ensure we queired from disk cache
                         completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                             [SDImageCache.sharedImageCache removeImageFromMemoryForKey:kTestJPEGURL];
                             [SDImageCache.sharedImageCache removeImageFromDiskForKey:kTestJPEGURL];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3065 #3063

### Pull Request Description

This MR close #3065 and replace it.

From the user reply and feature request, I found user just want:

> When I see any waiting time (async operation), I do transition.

This is the feature current we lack of. So, this MR introduce the new option `SDWebImageForceTransitionAsync`. We do transiton when async callback, which means:

+ Network Callback
+ Disk Cache Callback and User do not use any `SDWebImageQueryMemoryDataSync` or `SDWebImageQueryDiskDataSync`


Compared to the exist option `SDWebImageForceTransition`, which will become `SDWebImageForceTransitionAlways` in sematic.

In the future, I think this transition control can using a block arguments, let user itself to detect **Whether or not I should do transition based on current context**. So that we as a framework, do not maintain such complicated logic.