### PR TITLE
Fix the issue that SDAnimatedImageView will trigger an empty callback when animation stopped. This will cause some bad effect such as rendering a empty image or placeholder image (especially on iOS 14)

### DIFF
--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -160,14 +160,14 @@
     }
 }
 
-- (void)resetCurrentFrameIndex {
-    self.currentFrame = nil;
-    self.currentFrameIndex = 0;
-    self.currentLoopCount = 0;
-    self.currentTime = 0;
-    self.bufferMiss = NO;
-    self.needsDisplayWhenImageBecomesAvailable = NO;
-    [self handleFrameChange];
+- (void)resetCurrentFrameStatus {
+    // These should not trigger KVO, user don't need to receive an `index == 0, image == nil` callback.
+    _currentFrame = nil;
+    _currentFrameIndex = 0;
+    _currentLoopCount = 0;
+    _currentTime = 0;
+    _bufferMiss = NO;
+    _needsDisplayWhenImageBecomesAvailable = NO;
 }
 
 - (void)clearFrameBuffer {
@@ -191,7 +191,8 @@
     [_fetchQueue cancelAllOperations];
     // Using `_displayLink` here because when UIImageView dealloc, it may trigger `[self stopAnimating]`, we already release the display link in SDAnimatedImageView's dealloc method.
     [_displayLink stop];
-    [self resetCurrentFrameIndex];
+    // We need to reset the frame status, but not trigger any handle. This can ensure next time's playing status correct.
+    [self resetCurrentFrameStatus];
 }
 
 - (void)pausePlaying {

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -395,7 +395,6 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
         imageView.animates = NO;
 #endif
         expect(imageView.player.frameBuffer.count).equal(0);
-        expect(imageView.currentFrameIndex).equal(0);
         
         [imageView removeFromSuperview];
         [expectation fulfill];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3091 

### Pull Request Description

This fix issue #3091.

The issue #3019 caused by two different PRs, one is this bug behavior (when stopping, the `self.currentFrame == nil`), another is the iOS 14 compatible issue #3046 .
Because when trigger this extra callback.

![image](https://user-images.githubusercontent.com/6919743/94358438-97371100-00d3-11eb-85d9-fe3af6a2f277.png)

+ on iOS 13, UIImageView does not implements `updateLayer:` method and just do nothing.
+ on iOS 14, UIImageView do implements `updateLayer:` method, and render the static poster image instead.