### PR TITLE
[SDWebImageTransition] Fix: `duration` is not used in convenience initializers.

### DIFF
--- a/SDWebImage/Core/SDWebImageTransition.m
+++ b/SDWebImage/Core/SDWebImageTransition.m
@@ -89,6 +89,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)fadeTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionCrossDissolve | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -103,6 +104,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)flipFromLeftTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionFlipFromLeft | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -117,6 +119,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)flipFromRightTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionFlipFromRight | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -131,6 +134,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)flipFromTopTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionFlipFromTop | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -145,6 +149,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)flipFromBottomTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionFlipFromBottom | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -159,6 +164,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)curlUpTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionCurlUp | UIViewAnimationOptionAllowUserInteraction;
 #else
@@ -173,6 +179,7 @@ CATransition * SDTransitionFromAnimationOptions(SDWebImageAnimationOptions optio
 
 + (SDWebImageTransition *)curlDownTransitionWithDuration:(NSTimeInterval)duration {
     SDWebImageTransition *transition = [SDWebImageTransition new];
+    transition.duration = duration;
 #if SD_UIKIT
     transition.animationOptions = UIViewAnimationOptionTransitionCurlDown | UIViewAnimationOptionAllowUserInteraction;
 #else


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

[SDWebImageTransition] Fix: `duration` is not used in the convenience initializers. 

