### PR TITLE
Fixed the store cache type was specified to `SDImageCacheTypeDisk `  that no pictures were obtained when the disk had pictures

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -537,13 +537,11 @@ static NSString * _defaultDiskCacheDirectory;
                     SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
                     shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
                 }
-                if (shouldCacheToMomery) {
-                    // decode image data only if in-memory cache missed
-                    diskImage = [self diskImageForKey:key data:diskData options:options context:context];
-                    if (diskImage && self.config.shouldCacheImagesInMemory) {
-                        NSUInteger cost = diskImage.sd_memoryCost;
-                        [self.memoryCache setObject:diskImage forKey:key cost:cost];
-                    }
+                // decode image data only if in-memory cache missed
+                diskImage = [self diskImageForKey:key data:diskData options:options context:context];
+                if (shouldCacheToMomery && diskImage && self.config.shouldCacheImagesInMemory) {
+                    NSUInteger cost = diskImage.sd_memoryCost;
+                    [self.memoryCache setObject:diskImage forKey:key cost:cost];
                 }
             }
             

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -632,6 +632,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [[SDImageCache sharedImageCache] storeImageDataToDisk:data forKey:kTestImageKeyJPEG];
     
     [[SDImageCachesManager sharedManager] queryImageForKey:kTestImageKeyJPEG options:0 context:@{SDWebImageContextStoreCacheType : @(SDImageCacheTypeDisk)} cacheType:SDImageCacheTypeAll completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+        expect(image).notTo.beNil();
         expect([[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:kTestImageKeyJPEG]).beNil();
         [expectation fulfill];
     }];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ... 

#3104  should not affect the way which the disk image is obtained.
