### PR TITLE
Add animationImages support when using SDAnimatedImageView

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -14,7 +14,7 @@
 
 /**
  A drop-in replacement for UIImageView/NSImageView, you can use this for animated image rendering.
- Call `setImage:` with `UIImage(NSImage)` which conform to `SDAnimatedImage` protocol will start animated image rendering. Call with normal UIImage(NSImage) will back to normal UIImageView(NSImageView) rendering
+ Call `setImage:` with `UIImage(NSImage)` which conforms to `SDAnimatedImage` protocol will start animated image rendering. Call with normal UIImage(NSImage) will back to normal UIImageView(NSImageView) rendering
  For UIKit: use `-startAnimating`, `-stopAnimating` to control animating. `isAnimating` to check animation state.
  For AppKit: use `-setAnimates:` to control animating, `animates` to check animation state. This view is layer-backed.
  */
@@ -82,7 +82,7 @@
 @property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
 
 /**
- If the image has more than one frame, set this value to `YES` will automatically
+ If the image which conforms to `SDAnimatedImage` protocol has more than one frame, set this value to `YES` will automatically
  play/stop the animation when the view become visible/invisible.
  Default is YES.
  */

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -402,7 +402,8 @@
 /// Check if it should be played
 - (void)checkPlay
 {
-    if (self.autoPlayAnimatedImage) {
+    // Only handle for SDAnimatedImage, leave UIAnimatedImage or animationImages for super implementation control
+    if (self.player && self.autoPlayAnimatedImage) {
         [self updateShouldAnimate];
         if (self.shouldAnimate) {
             [self startAnimating];

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -602,6 +602,26 @@ static BOOL _isCalled;
     expect(SDImageAPNGTestCoder.isCalled).equal(YES);
 }
 
+#if SD_UIKIT
+- (void)test31AnimatedImageViewSetAnimationImages {
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    UIImage *image = [[UIImage alloc] initWithData:[self testJPEGData]];
+    imageView.animationImages = @[image];
+    expect(imageView.animationImages).notTo.beNil();
+}
+
+- (void)test32AnimatedImageViewNotStopPlayingAnimationImagesWhenHidden {
+    SDAnimatedImageView *imageView = [SDAnimatedImageView new];
+    [self.window addSubview:imageView];
+    UIImage *image = [[UIImage alloc] initWithData:[self testJPEGData]];
+    imageView.animationImages = @[image];
+    [imageView startAnimating];
+    expect(imageView.animating).beTruthy();
+    imageView.hidden = YES;
+    expect(imageView.animating).beTruthy();
+}
+#endif
+
 #pragma mark - Helper
 - (UIWindow *)window {
     if (!_window) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Add `animationImages` support when using `SDAnimatedImageView`.
...

