### PR TITLE
add animation loop completion hander on SDAnimatedImageView

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -94,6 +94,12 @@
  @note This is useful for some cases, for example, always specify NSDefaultRunLoopMode, if you want to pause the animation when user scroll (for Mac user, drag the mouse or touchpad)
  */
 @property (nonatomic, copy, nonnull) NSRunLoopMode runLoopMode;
+
+/**
+ You can handle every animation loop completion.
+ @note totalLoopCount 0 means infinite loop.
+ */
+@property (nonatomic, copy, nullable) void (^animationLoopCompletion)(NSUInteger currentLoopCount, NSUInteger totalLoopCount);
 @end
 
 #endif

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -182,6 +182,10 @@
             } else {
                 self.currentLoopCount = loopCount;
             }
+            
+            if (self.animationLoopCompletion) {
+                self.animationLoopCompletion(loopCount, self.player.totalLoopCount);
+            }
         };
         
         // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

SDAnimatedImageView doesn't give any handler to notify animation completion.
Add block property to handle animation completion.( I DO need this feature to implement my project. ;) )

