### PR TITLE
Bumped the min deployment target version to iOS 9, macOS 10.11. Bumped the min Xcode version to Xcode 11

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -176,7 +176,7 @@ GCC_WARN_UNUSED_VARIABLE = YES
 HEADER_SEARCH_PATHS = $(inherited)
 
 // Code will load on this and later versions of iOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
-IPHONEOS_DEPLOYMENT_TARGET = 8.0
+IPHONEOS_DEPLOYMENT_TARGET = 9.0
 
 // This is a list of paths to be added to the `runpath` search path list for the image being created. At runtime, `dyld` uses the `runpath` when searching for dylibs whose load path begins with `@rpath/`. 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
@@ -185,7 +185,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/
 LIBRARY_SEARCH_PATHS = $(inherited)
 
 // Code will load on this and later versions of macOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
-MACOSX_DEPLOYMENT_TARGET = 10.10
+MACOSX_DEPLOYMENT_TARGET = 10.11
 
 // Options defined in this setting are passed to invocations of the linker.
 OTHER_LDFLAGS = -ObjC

--- a/Examples/SDWebImage Demo/SDWebImage Demo-Prefix.pch
+++ b/Examples/SDWebImage Demo/SDWebImage Demo-Prefix.pch
@@ -4,10 +4,6 @@
 
 #import <Availability.h>
 
-#ifndef __IPHONE_4_0
-#warning "This project uses features only available in iOS SDK 4.0 and later."
-#endif
-
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SDWebImage",
     platforms: [
-        .macOS(.v10_10),
-        .iOS(.v8),
+        .macOS(.v10_11),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],

--- a/Podfile
+++ b/Podfile
@@ -23,19 +23,19 @@ workspace 'SDWebImage.xcworkspace'
 # Example Project
 target 'SDWebImage iOS Demo' do
   project example_project_path
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   all_example_pods
 end
 
 target 'SDWebImage OSX Demo' do
   project example_project_path
-  platform :osx, '10.10'
+  platform :osx, '10.11'
   all_example_pods
 end
 
 target 'SDWebImage TV Demo' do
   project example_project_path
-  platform :tvos, '9.2'
+  platform :tvos, '9.0'
   all_example_pods
 end
 
@@ -48,18 +48,18 @@ end
 # Test Project
 target 'Tests iOS' do
   project test_project_path
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   all_test_pods
 end
 
 target 'Tests Mac' do
   project test_project_path
-  platform :osx, '10.10'
+  platform :osx, '10.11'
   all_test_pods
 end
 
 target 'Tests TV' do
   project test_project_path
-  platform :tvos, '9.2'
+  platform :tvos, '9.0'
   all_test_pods
 end

--- a/README.md
+++ b/README.md
@@ -93,14 +93,15 @@ You can use those directly, or create similar components of your own, by using t
 
 ## Requirements
 
-- iOS 8.0 or later
+- iOS 9.0 or later
 - tvOS 9.0 or later
 - watchOS 2.0 or later
-- macOS 10.10 or later (10.15 for Catalyst)
-- Xcode 10.0 or later
+- macOS 10.11 or later (10.15 for Catalyst)
+- Xcode 11.0 or later
 
 #### Backwards compatibility
 
+- For iOS 8, macOS 10.10 or Xcode < 11, use [any 5.x version up to 5.9.5](https://github.com/SDWebImage/SDWebImage/releases/tag/5.9.5)
 - For iOS 7, macOS 10.9 or Xcode < 8, use [any 4.x version up to 4.4.6](https://github.com/SDWebImage/SDWebImage/releases/tag/4.4.6)
 - For macOS 10.8, use [any 4.x version up to 4.3.0](https://github.com/SDWebImage/SDWebImage/releases/tag/4.3.0)
 - For iOS 5 and 6, use [any 3.x version up to 3.7.6](https://github.com/SDWebImage/SDWebImage/tag/3.7.6)

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -2,8 +2,8 @@ Pod::Spec.new do |s|
   s.name = 'SDWebImage'
   s.version = '5.9.5'
 
-  s.osx.deployment_target = '10.10'
-  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
@@ -37,9 +37,9 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'MapKit' do |mk|
-    mk.osx.deployment_target = '10.10'
-    mk.ios.deployment_target = '8.0'
-    mk.tvos.deployment_target = '9.2'
+    mk.osx.deployment_target = '10.11'
+    mk.ios.deployment_target = '9.0'
+    mk.tvos.deployment_target = '9.0'
     mk.source_files = 'SDWebImageMapKit/MapKit/*.{h,m}'
     mk.framework = 'MapKit'
     mk.dependency 'SDWebImage/Core'

--- a/SDWebImage/Core/SDImageAPNGCoder.m
+++ b/SDWebImage/Core/SDImageAPNGCoder.m
@@ -13,14 +13,6 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
-// iOS 8 Image/IO framework binary does not contains these APNG constants, so we define them. Thanks Apple :)
-// We can not use runtime @available check for this issue, because it's a global symbol and should be loaded during launch time by dyld. So hack if the min deployment target version < iOS 9.0, whatever it running on iOS 9+ or not.
-#if (__IPHONE_OS_VERSION_MIN_REQUIRED && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
-const CFStringRef kCGImagePropertyAPNGLoopCount = (__bridge CFStringRef)@"LoopCount";
-const CFStringRef kCGImagePropertyAPNGDelayTime = (__bridge CFStringRef)@"DelayTime";
-const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef)@"UnclampedDelayTime";
-#endif
-
 @implementation SDImageAPNGCoder
 
 + (instancetype)sharedCoder {

--- a/SDWebImage/Core/SDImageHEICCoder.m
+++ b/SDWebImage/Core/SDImageHEICCoder.m
@@ -18,8 +18,6 @@ static NSString * kSDCGImagePropertyHEICSUnclampedDelayTime = @"UnclampedDelayTi
 @implementation SDImageHEICCoder
 
 + (void)initialize {
-#if __IPHONE_13_0 || __TVOS_13_0 || __MAC_10_15 || __WATCHOS_6_0
-    // Xcode 11
     if (@available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)) {
         // Use SDK instead of raw value
         kSDCGImagePropertyHEICSDictionary = (__bridge NSString *)kCGImagePropertyHEICSDictionary;
@@ -27,7 +25,6 @@ static NSString * kSDCGImagePropertyHEICSUnclampedDelayTime = @"UnclampedDelayTi
         kSDCGImagePropertyHEICSDelayTime = (__bridge NSString *)kCGImagePropertyHEICSDelayTime;
         kSDCGImagePropertyHEICSUnclampedDelayTime = (__bridge NSString *)kCGImagePropertyHEICSUnclampedDelayTime;
     }
-#endif
 }
 
 + (instancetype)sharedCoder {

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -12,13 +12,6 @@
 #import "SDWebImageDownloaderResponseModifier.h"
 #import "SDWebImageDownloaderDecryptor.h"
 
-// iOS 8 Foundation.framework extern these symbol but the define is in CFNetwork.framework. We just fix this without import CFNetwork.framework
-#if ((__IPHONE_OS_VERSION_MIN_REQUIRED && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0) || (__MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_11))
-const float NSURLSessionTaskPriorityHigh = 0.75;
-const float NSURLSessionTaskPriorityDefault = 0.5;
-const float NSURLSessionTaskPriorityLow = 0.25;
-#endif
-
 static NSString *const kProgressCallbackKey = @"progress";
 static NSString *const kCompletedCallbackKey = @"completed";
 

--- a/SDWebImage/Core/SDWebImageIndicator.m
+++ b/SDWebImage/Core/SDWebImageIndicator.m
@@ -14,16 +14,6 @@
 #import <QuartzCore/QuartzCore.h>
 #endif
 
-#if SD_UIKIT
-#if __IPHONE_13_0 || __TVOS_13_0 || __MAC_10_15
-// Xcode 11
-#else
-// Supports Xcode 10 users, for those users, define these enum
-static NSInteger UIActivityIndicatorViewStyleMedium = 100;
-static NSInteger UIActivityIndicatorViewStyleLarge = 101;
-#endif
-#endif
-
 #pragma mark - Activity Indicator
 
 @interface SDWebImageActivityIndicator ()

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -622,13 +622,10 @@
     SDWebImageDownloaderDecryptor *decryptor = [SDWebImageDownloaderDecryptor decryptorWithBlock:^NSData * _Nullable(NSData * _Nonnull data, NSURLResponse * _Nullable response) {
         if (@available(iOS 13, macOS 10.15, tvOS 13, *)) {
             return [data decompressedDataUsingAlgorithm:NSDataCompressionAlgorithmZlib error:nil];
-        } else if (@available (iOS 9, macOS 10.11, tvOS 9, *)) {
+        } else {
             NSMutableData *decodedData = [NSMutableData dataWithLength:10 * data.length];
             compression_decode_buffer((uint8_t *)decodedData.bytes, decodedData.length, data.bytes, data.length, nil, COMPRESSION_ZLIB);
             return [decodedData copy];
-        } else {
-            // iOS 8 does not have built-in Zlib support, just mock the data
-            return base64PNGData;
         }
     }];
     // Note this is not a Zip Archive, just PNG raw buffer data using zlib compression

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -63,7 +63,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     [self waitForExpectationsWithCommonTimeout];
@@ -130,7 +130,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     [self waitForExpectationsWithCommonTimeoutUsingHandler:^(NSError * _Nullable error) {
@@ -145,7 +145,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else if (finished) {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         } else {
             // progressive updates
         }
@@ -161,7 +161,7 @@
         if (!image && !data && error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     [self waitForExpectationsWithCommonTimeout];
@@ -227,7 +227,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     
@@ -243,7 +243,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     [self waitForExpectationsWithCommonTimeout];
@@ -256,7 +256,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         }
     }];
     [self waitForExpectationsWithCommonTimeout];
@@ -353,6 +353,8 @@
     } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         if (allProgressCount > 0) {
             [expectation fulfill];
+            allProgressCount = 0;
+            return;
         } else {
             XCTFail(@"Progress callback more than once");
         }
@@ -370,7 +372,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else if (finished) {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         } else {
             // progressive updates
         }
@@ -385,7 +387,7 @@
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else if (finished) {
-            XCTFail(@"Something went wrong");
+            XCTFail(@"Something went wrong: %@", error.description);
         } else {
             // progressive updates
         }
@@ -422,7 +424,7 @@
                                            if (image && data && !error && finished) {
                                                [expectation fulfill];
                                            } else {
-                                               XCTFail(@"Something went wrong");
+                                               XCTFail(@"Something went wrong: %@", error.description);
                                            }
                                        }];
     expect(token2).toNot.beNil();
@@ -464,7 +466,7 @@
                                                [expectation fulfill];
                                            } else {
                                                NSLog(@"image = %@, data = %@, error = %@", image, data, error);
-                                               XCTFail(@"Something went wrong");
+                                               XCTFail(@"Something went wrong: %@", error.description);
                                            }
                                        }];
     expect(token2).toNot.beNil();


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This follows Apple's App Store submit rule, and user request from the dependency. Similar to last year's #2372 

# App Store submit rule

> Starting April 2020, all new apps and app updates will need to be built with the iOS 13 SDK and support the all-screen design of iPhone XS Max or later.

See: https://developer.apple.com/news/?id=09102019a

# User requests

Many issues and users complain about the current iOS 8+ deployment target version:
This close #3097
This close #3085
This close #3054 

Even some from other components (because WebPCoder or SwiftUI depends on this Core)

This close https://github.com/SDWebImage/SDWebImageSwiftUI/issues/140
This close https://github.com/SDWebImage/SDWebImageWebPCoder/pull/43

# Why now
Previouslly I decide to release this on SDWebImage 6.0, but 6.0 milestone has some challenge, which can not release until 2021 first season.

So, a better idea, we can release another version which fix this simple Xcode version and iOS deployement version firstly, then 6.0 focus on Swifty and API polishment.