### PR TITLE
Fix deprecation warnings for OSSpinLock

### DIFF
--- a/SDWebImage/Core/SDWebImagePrefetcher.m
+++ b/SDWebImage/Core/SDWebImagePrefetcher.m
@@ -22,7 +22,7 @@
     unsigned long _totalCount;
     
     // Used to ensure NSPointerArray thread safe
-    SD_LOCK_DECLARE(_prefetchOperationsLock)
+    SD_LOCK_DECLARE(_prefetchOperationsLock);
     SD_LOCK_DECLARE(_loadOperationsLock);
 }
 

--- a/SDWebImage/Private/SDInternalMacros.h
+++ b/SDWebImage/Private/SDInternalMacros.h
@@ -11,9 +11,15 @@
 #import <libkern/OSAtomic.h>
 #import "SDmetamacros.h"
 
+#define SD_USE_OS_UNFAIR_LOCK TARGET_OS_MACCATALYST ||\
+    (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0) ||\
+    (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12) ||\
+    (__TV_OS_VERSION_MIN_REQUIRED >= __TVOS_10_0) ||\
+    (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)
+
 #ifndef SD_LOCK_DECLARE
-#if TARGET_OS_MACCATALYST
-#define SD_LOCK_DECLARE(lock) os_unfair_lock lock;
+#if SD_USE_OS_UNFAIR_LOCK
+#define SD_LOCK_DECLARE(lock) os_unfair_lock lock
 #else
 #define SD_LOCK_DECLARE(lock) os_unfair_lock lock API_AVAILABLE(ios(10.0), tvos(10), watchos(3), macos(10.12)); \
 OSSpinLock lock##_deprecated;
@@ -21,8 +27,8 @@ OSSpinLock lock##_deprecated;
 #endif
 
 #ifndef SD_LOCK_INIT
-#if TARGET_OS_MACCATALYST
-#define SD_LOCK_INIT(lock) lock = OS_UNFAIR_LOCK_INIT;
+#if SD_USE_OS_UNFAIR_LOCK
+#define SD_LOCK_INIT(lock) lock = OS_UNFAIR_LOCK_INIT
 #else
 #define SD_LOCK_INIT(lock) if (@available(iOS 10, tvOS 10, watchOS 3, macOS 10.12, *)) lock = OS_UNFAIR_LOCK_INIT; \
 else lock##_deprecated = OS_SPINLOCK_INIT;
@@ -30,8 +36,8 @@ else lock##_deprecated = OS_SPINLOCK_INIT;
 #endif
 
 #ifndef SD_LOCK
-#if TARGET_OS_MACCATALYST
-#define SD_LOCK(lock) os_unfair_lock_lock(&lock);
+#if SD_USE_OS_UNFAIR_LOCK
+#define SD_LOCK(lock) os_unfair_lock_lock(&lock)
 #else
 #define SD_LOCK(lock) if (@available(iOS 10, tvOS 10, watchOS 3, macOS 10.12, *)) os_unfair_lock_lock(&lock); \
 else OSSpinLockLock(&lock##_deprecated);
@@ -39,8 +45,8 @@ else OSSpinLockLock(&lock##_deprecated);
 #endif
 
 #ifndef SD_UNLOCK
-#if TARGET_OS_MACCATALYST
-#define SD_UNLOCK(lock) os_unfair_lock_unlock(&lock);
+#if SD_USE_OS_UNFAIR_LOCK
+#define SD_UNLOCK(lock) os_unfair_lock_unlock(&lock)
 #else
 #define SD_UNLOCK(lock) if (@available(iOS 10, tvOS 10, watchOS 3, macOS 10.12, *)) os_unfair_lock_unlock(&lock); \
 else OSSpinLockUnlock(&lock##_deprecated);


### PR DESCRIPTION
If the deployment target was newer than the target that os_unfair_lock() became available deprecation warnings were generated for use of OSSpinLock. Now OSSpinLock isn't used if the deployment target is >= the OS version where os_unfair_lock() became available.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have tested to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3136

### Pull Request Description

Fix deprecation warnings for OSSpinLock
    
If the deployment target was newer than the target that os_unfair_lock() became available deprecation warnings were generated for use of OSSpinLock. Now OSSpinLock isn't used if the deployment target is >= the OS version where os_unfair_lock() became available.

If you want to test this manually you can temporarily set the iOS Deployment target in the SDWebImage project to 11 or newer (and the same for the other OS targets) and build for iOS. In master you will get the deprecation warnings and in this PR branch the warning will not be present.
