### PR TITLE
Fixed the store cache type was specified to `SDImageCacheTypeDisk ` that pictures shouldn't cache to memory.

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -361,7 +361,13 @@ static NSString * _defaultDiskCacheDirectory;
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context {
     NSData *data = [self diskImageDataForKey:key];
     UIImage *diskImage = [self diskImageForKey:key data:data options:options context:context];
-    if (diskImage && self.config.shouldCacheImagesInMemory) {
+    
+    BOOL shouldCacheToMomery = YES;
+    if (context[SDWebImageContextStoreCacheType]) {
+        SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
+        shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
+    }
+    if (diskImage && self.config.shouldCacheImagesInMemory && shouldCacheToMomery) {
         NSUInteger cost = diskImage.sd_memoryCost;
         [self.memoryCache setObject:diskImage forKey:key cost:cost];
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

 Relate  #3110 

