### PR TITLE
Don't unnecessarily copy image data in the Download Operation

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -452,7 +452,7 @@ didReceiveResponse:(NSURLResponse *)response
         [self done];
     } else {
         if ([self callbacksForKey:kCompletedCallbackKey].count > 0) {
-            NSData *imageData = [self.imageData copy];
+            NSData *imageData = self.imageData;
             self.imageData = nil;
             // data decryptor
             if (imageData && self.decryptor) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
    - Did not add tests because it's super hard to test a memory pressure bug.
* [ ] I have updated the documentation (if necessary)
    - Not necessary, IMO.
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This is an attempt at addressing [Out of memory crashes immediately prior to decoding the image](https://github.com/SDWebImage/SDWebImage/issues/2353). I don't expect this to solve all of the cases of OoM crashes that would get reported to that thread, but it should address what looks to me to be the most common one (and is the one affecting my work).

There was previously a related work done to reduce memory usage of the SDWebImageDownloadOperation decoding work, [here](https://github.com/SDWebImage/SDWebImage/pull/2624). This is fine for reducing the amount of memory used during decoding, but the crashes I and others in that thread are seeing are happening during the `[self.imageData copy]` operation.

Looking through the code, because we're immediately re-assigning `self.imageData` to nil after the copy, there's no real reason - thread-safety wise - to even create the copy in the first place, other than to "know" that this NSData instance isn't actually an NSMutableData. So, instead, let's just not make the copy in the first place. This also reduces memory pressure during the copy, as you don't have two copies of the same data lying around.

I kept the re-assignment of self.imageData to nil in this PR, but it could just as easily be thrown out. I have no attachment to that code.