### PR TITLE
Fix compile warning: Double-quoted include “XXX.h” in framework header

### DIFF
--- a/SDWebImage/Core/NSButton+WebCache.h
+++ b/SDWebImage/Core/NSButton+WebCache.h
@@ -6,11 +6,11 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_MAC
 
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 /**
  * Integrates SDWebImage async downloading and caching of remote images with NSButton.

--- a/SDWebImage/Core/NSData+ImageContentType.h
+++ b/SDWebImage/Core/NSData+ImageContentType.h
@@ -8,7 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  You can use switch case like normal enum. It's also recommended to add a default case. You should not assume anything about the raw value.

--- a/SDWebImage/Core/NSImage+Compatibility.h
+++ b/SDWebImage/Core/NSImage+Compatibility.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_MAC
 

--- a/SDWebImage/Core/SDAnimatedImage.h
+++ b/SDWebImage/Core/SDAnimatedImage.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDImageCoder.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDImageCoder.h>
 
 
 /**

--- a/SDWebImage/Core/SDAnimatedImagePlayer.h
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.h
@@ -7,8 +7,8 @@
 */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "SDImageCoder.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDImageCoder.h>
 
 typedef NS_ENUM(NSUInteger, SDAnimatedImagePlaybackMode) {
     /**

--- a/SDWebImage/Core/SDAnimatedImageRep.h
+++ b/SDWebImage/Core/SDAnimatedImageRep.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_MAC
 

--- a/SDWebImage/Core/SDAnimatedImageView+WebCache.h
+++ b/SDWebImage/Core/SDAnimatedImageView+WebCache.h
@@ -6,11 +6,11 @@
  * file that was distributed with this source code.
  */
 
-#import "SDAnimatedImageView.h"
+#import <SDWebImage/SDAnimatedImageView.h>
 
 #if SD_UIKIT || SD_MAC
 
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 /**
  Integrates SDWebImage async downloading and caching of remote images with SDAnimatedImageView.

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -6,12 +6,12 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_UIKIT || SD_MAC
 
-#import "SDAnimatedImage.h"
-#import "SDAnimatedImagePlayer.h"
+#import <SDWebImage/SDAnimatedImage.h>
+#import <SDWebImage/SDAnimatedImagePlayer.h>
 
 /**
  A drop-in replacement for UIImageView/NSImageView, you can use this for animated image rendering.

--- a/SDWebImage/Core/SDDiskCache.h
+++ b/SDWebImage/Core/SDDiskCache.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 @class SDImageCacheConfig;
 /**

--- a/SDWebImage/Core/SDGraphicsImageRenderer.h
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.h
@@ -6,7 +6,7 @@
 * file that was distributed with this source code.
 */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  These following class are provided to use `UIGraphicsImageRenderer` with polyfill, which allows write cross-platform(AppKit/UIKit) code and avoid runtime version check.

--- a/SDWebImage/Core/SDImageAPNGCoder.h
+++ b/SDWebImage/Core/SDImageAPNGCoder.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageIOAnimatedCoder.h"
+#import <SDWebImage/SDImageIOAnimatedCoder.h>
 
 /**
  Built in coder using ImageIO that supports APNG encoding/decoding

--- a/SDWebImage/Core/SDImageAWebPCoder.h
+++ b/SDWebImage/Core/SDImageAWebPCoder.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageIOAnimatedCoder.h"
+#import <SDWebImage/SDImageIOAnimatedCoder.h>
 
 /**
  This coder is used for Google WebP and Animated WebP(AWebP) image format.

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -7,12 +7,12 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "SDWebImageDefine.h"
-#import "SDImageCacheConfig.h"
-#import "SDImageCacheDefine.h"
-#import "SDMemoryCache.h"
-#import "SDDiskCache.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDImageCacheConfig.h>
+#import <SDWebImage/SDImageCacheDefine.h>
+#import <SDWebImage/SDMemoryCache.h>
+#import <SDWebImage/SDDiskCache.h>
 
 /// Image Cache Options
 typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {

--- a/SDWebImage/Core/SDImageCacheConfig.h
+++ b/SDWebImage/Core/SDImageCacheConfig.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /// Image Cache Expire Type
 typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -7,9 +7,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "SDWebImageOperation.h"
-#import "SDWebImageDefine.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageOperation.h>
+#import <SDWebImage/SDWebImageDefine.h>
 
 /// Image Cache Type
 typedef NS_ENUM(NSInteger, SDImageCacheType) {

--- a/SDWebImage/Core/SDImageCachesManager.h
+++ b/SDWebImage/Core/SDImageCachesManager.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageCacheDefine.h"
+#import <SDWebImage/SDImageCacheDefine.h>
 
 /// Policy for cache operation
 typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -7,8 +7,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "NSData+ImageContentType.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/NSData+ImageContentType.h>
 
 typedef NSString * SDImageCoderOption NS_STRING_ENUM;
 typedef NSDictionary<SDImageCoderOption, id> SDImageCoderOptions;

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -7,8 +7,8 @@
  */
 
 #import <ImageIO/ImageIO.h>
-#import "SDWebImageCompat.h"
-#import "SDImageFrame.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDImageFrame.h>
 
 /**
  Provide some common helper methods for building the image decoder/encoder.

--- a/SDWebImage/Core/SDImageCodersManager.h
+++ b/SDWebImage/Core/SDImageCodersManager.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageCoder.h"
+#import <SDWebImage/SDImageCoder.h>
 
 /**
  Global object holding the array of coders, so that we avoid passing them from object to object.

--- a/SDWebImage/Core/SDImageFrame.h
+++ b/SDWebImage/Core/SDImageFrame.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  This class is used for creating animated images via `animatedImageWithFrames` in `SDImageCoderHelper`.

--- a/SDWebImage/Core/SDImageGIFCoder.h
+++ b/SDWebImage/Core/SDImageGIFCoder.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageIOAnimatedCoder.h"
+#import <SDWebImage/SDImageIOAnimatedCoder.h>
 
 /**
  Built in coder using ImageIO that supports animated GIF encoding/decoding

--- a/SDWebImage/Core/SDImageGraphics.h
+++ b/SDWebImage/Core/SDImageGraphics.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 #import <CoreGraphics/CoreGraphics.h>
 
 /**

--- a/SDWebImage/Core/SDImageHEICCoder.h
+++ b/SDWebImage/Core/SDImageHEICCoder.h
@@ -7,7 +7,7 @@
 */
 
 #import <Foundation/Foundation.h>
-#import "SDImageIOAnimatedCoder.h"
+#import <SDWebImage/SDImageIOAnimatedCoder.h>
 
 /**
  This coder is used for HEIC (HEIF with HEVC container codec) image format.

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.h
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <ImageIO/ImageIO.h>
-#import "SDImageCoder.h"
+#import <SDWebImage/SDImageCoder.h>
 
 /**
  This is the abstract class for all animated coder, which use the Image/IO API. You can not use this directly as real coders. A exception will be raised if you use this class.

--- a/SDWebImage/Core/SDImageIOCoder.h
+++ b/SDWebImage/Core/SDImageIOCoder.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDImageCoder.h"
+#import <SDWebImage/SDImageCoder.h>
 
 /**
  Built in coder that supports PNG, JPEG, TIFF, includes support for progressive decoding.

--- a/SDWebImage/Core/SDImageLoader.h
+++ b/SDWebImage/Core/SDImageLoader.h
@@ -6,9 +6,9 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDWebImageDefine.h"
-#import "SDWebImageOperation.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDWebImageOperation.h>
 
 typedef void(^SDImageLoaderProgressBlock)(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL);
 typedef void(^SDImageLoaderCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished);

--- a/SDWebImage/Core/SDImageLoadersManager.h
+++ b/SDWebImage/Core/SDImageLoadersManager.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDImageLoader.h"
+#import <SDWebImage/SDImageLoader.h>
 
 /**
  A loaders manager to manage multiple loaders

--- a/SDWebImage/Core/SDImageTransformer.h
+++ b/SDWebImage/Core/SDImageTransformer.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "UIImage+Transform.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/UIImage+Transform.h>
 
 /**
  Return the transformed cache key which applied with specify transformerKey.

--- a/SDWebImage/Core/SDMemoryCache.h
+++ b/SDWebImage/Core/SDMemoryCache.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 @class SDImageCacheConfig;
 /**

--- a/SDWebImage/Core/SDWebImageCacheKeyFilter.h
+++ b/SDWebImage/Core/SDWebImageCacheKeyFilter.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NSString * _Nullable(^SDWebImageCacheKeyFilterBlock)(NSURL * _Nonnull url);
 

--- a/SDWebImage/Core/SDWebImageCacheSerializer.h
+++ b/SDWebImage/Core/SDWebImageCacheSerializer.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NSData * _Nullable(^SDWebImageCacheSerializerBlock)(UIImage * _Nonnull image, NSData * _Nullable data, NSURL * _Nullable imageURL);
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef void(^SDWebImageNoParamsBlock)(void);
 typedef NSString * SDWebImageContextOption NS_EXTENSIBLE_STRING_ENUM;

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -7,14 +7,14 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "SDWebImageDefine.h"
-#import "SDWebImageOperation.h"
-#import "SDWebImageDownloaderConfig.h"
-#import "SDWebImageDownloaderRequestModifier.h"
-#import "SDWebImageDownloaderResponseModifier.h"
-#import "SDWebImageDownloaderDecryptor.h"
-#import "SDImageLoader.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDWebImageOperation.h>
+#import <SDWebImage/SDWebImageDownloaderConfig.h>
+#import <SDWebImage/SDWebImageDownloaderRequestModifier.h>
+#import <SDWebImage/SDWebImageDownloaderResponseModifier.h>
+#import <SDWebImage/SDWebImageDownloaderDecryptor.h>
+#import <SDWebImage/SDImageLoader.h>
 
 /// Downloader options
 typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {

--- a/SDWebImage/Core/SDWebImageDownloaderConfig.h
+++ b/SDWebImage/Core/SDWebImageDownloaderConfig.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /// Operation execution order
 typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {

--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
@@ -7,7 +7,7 @@
 */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NSData * _Nullable (^SDWebImageDownloaderDecryptorBlock)(NSData * _Nonnull data, NSURLResponse * _Nullable response);
 

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.h
@@ -7,8 +7,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageDownloader.h"
-#import "SDWebImageOperation.h"
+#import <SDWebImage/SDWebImageDownloader.h>
+#import <SDWebImage/SDWebImageOperation.h>
 
 /**
  Describes a downloader operation. If one wants to use a custom downloader op, it needs to inherit from `NSOperation` and conform to this protocol

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSURLRequest * _Nonnull request);
 

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(NSURLResponse * _Nonnull response);
 

--- a/SDWebImage/Core/SDWebImageError.h
+++ b/SDWebImage/Core/SDWebImageError.h
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 FOUNDATION_EXPORT NSErrorDomain const _Nonnull SDWebImageErrorDomain;
 

--- a/SDWebImage/Core/SDWebImageIndicator.h
+++ b/SDWebImage/Core/SDWebImageIndicator.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_UIKIT || SD_MAC
 

--- a/SDWebImage/Core/SDWebImageManager.h
+++ b/SDWebImage/Core/SDWebImageManager.h
@@ -6,14 +6,14 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDWebImageOperation.h"
-#import "SDImageCacheDefine.h"
-#import "SDImageLoader.h"
-#import "SDImageTransformer.h"
-#import "SDWebImageCacheKeyFilter.h"
-#import "SDWebImageCacheSerializer.h"
-#import "SDWebImageOptionsProcessor.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageOperation.h>
+#import <SDWebImage/SDImageCacheDefine.h>
+#import <SDWebImage/SDImageLoader.h>
+#import <SDWebImage/SDImageTransformer.h>
+#import <SDWebImage/SDWebImageCacheKeyFilter.h>
+#import <SDWebImage/SDWebImageCacheSerializer.h>
+#import <SDWebImage/SDWebImageOptionsProcessor.h>
 
 typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL);
 

--- a/SDWebImage/Core/SDWebImageOptionsProcessor.h
+++ b/SDWebImage/Core/SDWebImageOptionsProcessor.h
@@ -7,8 +7,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
-#import "SDWebImageDefine.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageDefine.h>
 
 @class SDWebImageOptionsResult;
 

--- a/SDWebImage/Core/SDWebImagePrefetcher.h
+++ b/SDWebImage/Core/SDWebImagePrefetcher.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 @class SDWebImagePrefetcher;
 

--- a/SDWebImage/Core/SDWebImageTransition.h
+++ b/SDWebImage/Core/SDWebImageTransition.h
@@ -6,10 +6,10 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_UIKIT || SD_MAC
-#import "SDImageCache.h"
+#import <SDWebImage/SDImageCache.h>
 
 #if SD_UIKIT
 typedef UIViewAnimationOptions SDWebImageAnimationOptions;

--- a/SDWebImage/Core/UIButton+WebCache.h
+++ b/SDWebImage/Core/UIButton+WebCache.h
@@ -6,11 +6,11 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_UIKIT
 
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 /**
  * Integrates SDWebImage async downloading and caching of remote images with UIButton.

--- a/SDWebImage/Core/UIImage+ExtendedCacheData.h
+++ b/SDWebImage/Core/UIImage+ExtendedCacheData.h
@@ -8,7 +8,7 @@
 */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 @interface UIImage (ExtendedCacheData)
 

--- a/SDWebImage/Core/UIImage+ForceDecode.h
+++ b/SDWebImage/Core/UIImage+ForceDecode.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  UIImage category about force decode feature (avoid Image/IO's lazy decoding during rendering behavior).

--- a/SDWebImage/Core/UIImage+GIF.h
+++ b/SDWebImage/Core/UIImage+GIF.h
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directly use `SDImageCoder`.

--- a/SDWebImage/Core/UIImage+MemoryCacheCost.h
+++ b/SDWebImage/Core/UIImage+MemoryCacheCost.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 /**
  UIImage category for memory cache cost.

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "NSData+ImageContentType.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/NSData+ImageContentType.h>
 
 /**
  UIImage category for image metadata, including animation, loop count, format, incremental, etc.

--- a/SDWebImage/Core/UIImage+MultiFormat.h
+++ b/SDWebImage/Core/UIImage+MultiFormat.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "NSData+ImageContentType.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/NSData+ImageContentType.h>
 
 /**
  UIImage category for convenient image format decoding/encoding.

--- a/SDWebImage/Core/UIImage+Transform.h
+++ b/SDWebImage/Core/UIImage+Transform.h
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 typedef NS_ENUM(NSUInteger, SDImageScaleMode) {
     SDImageScaleModeFill = 0,

--- a/SDWebImage/Core/UIImageView+HighlightedWebCache.h
+++ b/SDWebImage/Core/UIImageView+HighlightedWebCache.h
@@ -6,11 +6,11 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
+#import <SDWebImage/SDWebImageCompat.h>
 
 #if SD_UIKIT
 
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageManager.h>
 
 /**
  * Integrates SDWebImage async downloading and caching of remote images with UIImageView for highlighted state.

--- a/SDWebImage/Core/UIImageView+WebCache.h
+++ b/SDWebImage/Core/UIImageView+WebCache.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDWebImageManager.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageManager.h>
 
 /**
  * Usage with a UITableViewCell sub-class:

--- a/SDWebImage/Core/UIView+WebCache.h
+++ b/SDWebImage/Core/UIView+WebCache.h
@@ -6,11 +6,11 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDWebImageDefine.h"
-#import "SDWebImageManager.h"
-#import "SDWebImageTransition.h"
-#import "SDWebImageIndicator.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDWebImageManager.h>
+#import <SDWebImage/SDWebImageTransition.h>
+#import <SDWebImage/SDWebImageIndicator.h>
 
 /**
  The value specify that the image progress unit count cannot be determined because the progressBlock is not been called.

--- a/SDWebImage/Core/UIView+WebCacheOperation.h
+++ b/SDWebImage/Core/UIView+WebCacheOperation.h
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCompat.h"
-#import "SDWebImageOperation.h"
+#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImage/SDWebImageOperation.h>
 
 /**
  These methods are used to support canceling for UIView image loading, it's designed to be used internal but not external.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Fix compile warning: Double-quoted include “XXX.h” in framework header

