### PR TITLE
Ensure the invalid URLSeesion will receive the cancel callback and does not trigger the any exception from framework

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -140,11 +140,12 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 }
 
 - (void)dealloc {
-    [self.session invalidateAndCancel];
-    self.session = nil;
-    
     [self.downloadQueue cancelAllOperations];
     [self.config removeObserver:self forKeyPath:NSStringFromSelector(@selector(maxConcurrentDownloads)) context:SDWebImageDownloaderContext];
+    
+    // Invalide the URLSession after all operations been cancelled
+    [self.session invalidateAndCancel];
+    self.session = nil;
 }
 
 - (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations {

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -194,6 +194,13 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
             }
         }
         
+        if (!session.delegate) {
+            // Session been invalid and has no delegate at all
+            [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidDownloadOperation userInfo:@{NSLocalizedDescriptionKey : @"Session delegate is nil and invalid"}]];
+            [self reset];
+            return;
+        }
+        
         self.dataTask = [session dataTaskWithRequest:self.request];
         self.executing = YES;
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This fix the NSException from URLSession in rare cases:

> Task created in a session that has been invalidated