### PR TITLE
Revert the "Don't encode/decode image when app will terminate"

### DIFF
--- a/SDWebImage/Core/SDImageIOCoder.m
+++ b/SDWebImage/Core/SDImageIOCoder.m
@@ -138,10 +138,6 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
 }
 
 - (void)updateIncrementalData:(NSData *)data finished:(BOOL)finished {
-    // Earily return when application will be terminated.
-    if (SDImageIOAnimatedCoder.willTerminate) {
-        return;
-    }
     if (_finished) {
         return;
     }

--- a/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
+++ b/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
@@ -24,6 +24,5 @@
 + (nullable UIImage *)createFrameAtIndex:(NSUInteger)index source:(nonnull CGImageSourceRef)source scale:(CGFloat)scale preserveAspectRatio:(BOOL)preserveAspectRatio thumbnailSize:(CGSize)thumbnailSize options:(nullable NSDictionary *)options;
 + (BOOL)canEncodeToFormat:(SDImageFormat)format;
 + (BOOL)canDecodeFromFormat:(SDImageFormat)format;
-+ (BOOL)willTerminate;
 
 @end

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -311,26 +311,6 @@
     }
 }
 
-- (void)test22DoNotDecodeImageWhenApplicationWillTerminate {
-    [[SDImageCodersManager sharedManager] addCoder:SDImageIOCoder.sharedCoder];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"doNotDecodeImageWhenApplicationWillTerminate"];
-    NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImageLarge" ofType:@"png"];
-    NSData *testImageData = [NSData dataWithContentsOfFile:testImagePath];
-    [[SDImageCache sharedImageCache] storeImageDataToDisk:testImageData forKey:@"TestImageLarge"];
-    NSOperation *operation = [[SDImageCache sharedImageCache] queryCacheOperationForKey:@"TestImageLarge" done:^(UIImage *image, NSData *data, SDImageCacheType cacheType) {
-        expect(data).to.equal(testImageData);
-        expect(image).to.beNil;
-        [[SDImageCache sharedImageCache] removeImageForKey:@"TestImageLarge" withCompletion:^{
-            [expectation fulfill];
-        }];
-    }];
-    expect(operation).toNot.beNil;
-    [operation start];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:nil];
-    
-    [self waitForExpectationsWithCommonTimeout];
-}
-
 #pragma mark - Utils
 
 - (void)verifyCoder:(id<SDImageCoder>)coder


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This MR revert the #3149 .

That #3149 seems result something testing failure, because the `UIApplicationWillTerminateNotification` will been sent from XCTest, or some rare cases which we don't want.

And the fix, actually has no meanings for then End-User. Because it happens when your App killed. This does only effect the metrics or crash report framework.

