### PR TITLE
Add SDWebImageDelayPlaceholderAfterDiskCache option

### DIFF
--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -201,7 +201,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * We usually don't apply transform on vector images, because vector images supports dynamically changing to any size, rasterize to a fixed size will loss details. To modify vector images, you can process the vector data at runtime (such as modifying PDF tag / SVG element).
      * Use this flag to transform them anyway.
      */
-    SDWebImageTransformVectorImage = 1 << 23
+    SDWebImageTransformVectorImage = 1 << 23,
+    
+    /**
+     * By default, placeholder images are loaded while the image is loading.
+     * This flag will delay the loading of the placeholder image until after check disk cache.
+     */
+    SDWebImageDelayPlaceholderAfterDiskCache = (SDWebImageDelayPlaceholder) | (1 << 24),
 };
 
 

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -282,6 +282,10 @@ static id<SDImageLoader> _defaultImageLoader;
                 // Have a chance to query original cache instead of downloading
                 [self callOriginalCacheProcessForOperation:operation url:url options:options context:context progress:progressBlock completed:completedBlock];
                 return;
+            } else if (!cachedImage && (options & SDWebImageDelayPlaceholderAfterDiskCache)) {
+                // Let complete block set placeholder
+                [self callCompletionBlockForOperation:operation completion:completedBlock error:nil url:url];
+                // Go on network download
             }
             
             // Continue download process


### PR DESCRIPTION
### New Pull Request Checklist

* [Y] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [Y] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [Y] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [Y] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [Y] I have added the required tests to prove the fix/feature I am adding
* [Y] I have updated the documentation (if necessary)
* [?] I have run the tests and they pass (how to run tests???)
* [Y] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3213

### Pull Request Description
In order to try fix issue #3213, I make a new option, and use such option, 
placeholder will not release current strong reference anymore. 
and difference from option SDWebImageDelayPlaceholder, it will displace placeholder after no disk cache.


