### PR TITLE
Fix the bug that when querying original cache miss, the download process will be skipped. This is not designed behavior.

### DIFF
--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -333,6 +333,10 @@ static id<SDImageLoader> _defaultImageLoader;
                 [self callCompletionBlockForOperation:operation completion:completedBlock error:[NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorCancelled userInfo:@{NSLocalizedDescriptionKey : @"Operation cancelled by user during querying the cache"}] url:url];
                 [self safelyRemoveOperationFromRunning:operation];
                 return;
+            } else if (context[SDWebImageContextImageTransformer] && !cachedImage) {
+                // Original image cache miss. Continue download process
+                [self callDownloadProcessForOperation:operation url:url options:options context:context cachedImage:nil cachedData:nil cacheType:originalQueryCacheType progress:progressBlock completed:completedBlock];
+                return;
             }
                         
             // Use the store cache process instead of downloading, and ignore .refreshCached option for now


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This is a bug that breaks current transformer function.

Seems related to #2360 refactory changes. Mistake code.

