### PR TITLE
Update SDWebImageManager.m

### DIFF
--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -129,6 +129,13 @@ static id<SDImageLoader> _defaultImageLoader;
         key = url.absoluteString;
     }
     
+    // AnimatedImageClass Key Appending
+    Class desiredImageClass = context[SDWebImageContextAnimatedImageClass];
+    if (desiredImageClass != nil) {
+        NSString *animatedImageKey = [NSString stringWithFormat:@"AnimatedClass(%@)",NSStringFromClass(desiredImageClass)];
+        key = SDTransformedKeyForKey(key, animatedImageKey);
+    }
+    
     // Thumbnail Key Appending
     NSValue *thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
     if (thumbnailSizeValue != nil) {


### PR DESCRIPTION
Add AnimatedImageClass Key Appending for context[SDWebImageContextAnimatedImageClass]

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Fix issue: https://github.com/SDWebImage/SDWebImage/issues/3230

When the SDAnimatedImageView loads the animatedImage (eg WebP) and UIImageView later loads the same animatedImage, UIImageView will hit the SDAnimatedImage in the memory cache, At this point, UIImageView is showing a static image, the wrong cache was used.

当SDAnimatedImageView加载动图的时候（比如webp），之后UIImageView再加载这个动图时，UIImageView会命中内存缓存中的SDAnimatedImage，这时候UIImageView显示的是一个静态图片,使用了错误的缓存
...

