### PR TITLE
UImageView sometimes uses the wrong memory cache. 

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -512,6 +512,12 @@ static NSString * _defaultDiskCacheDirectory;
             if (desiredImageClass && ![animatedImageClass isSubclassOfClass:desiredImageClass]) {
                 image = nil;
             }
+        }else if(image.sd_isAnimated){
+            // Check image class not matching @protocol(SDAnimatedImage)
+            Class animatedImageClass = image.class;
+            if (([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)])) {
+                image = nil;
+            }
         }
     }
 

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -129,6 +129,13 @@ static id<SDImageLoader> _defaultImageLoader;
         key = url.absoluteString;
     }
     
+    // AnimatedImageClass Key Appending
+    Class desiredImageClass = context[SDWebImageContextAnimatedImageClass];
+    if (desiredImageClass != nil) {
+        NSString *animatedImageKey = [NSString stringWithFormat:@"AnimatedClass(%@)",NSStringFromClass(desiredImageClass)];
+        key = SDTransformedKeyForKey(key, animatedImageKey);
+    }
+    
     // Thumbnail Key Appending
     NSValue *thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
     if (thumbnailSizeValue != nil) {

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -129,13 +129,6 @@ static id<SDImageLoader> _defaultImageLoader;
         key = url.absoluteString;
     }
     
-    // AnimatedImageClass Key Appending
-    Class desiredImageClass = context[SDWebImageContextAnimatedImageClass];
-    if (desiredImageClass != nil) {
-        NSString *animatedImageKey = [NSString stringWithFormat:@"AnimatedClass(%@)",NSStringFromClass(desiredImageClass)];
-        key = SDTransformedKeyForKey(key, animatedImageKey);
-    }
-    
     // Thumbnail Key Appending
     NSValue *thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
     if (thumbnailSizeValue != nil) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

Fix: https://github.com/SDWebImage/SDWebImage/issues/3230

### Pull Request Description

When we display a GIF with `UIImageView`, if the memory cache hits the `SDAnimatedImage`, we update the memory cache so that `UIImageView` can display a GIF

