### PR TITLE
Fix the warning, enable `APPLICATION_EXTENSION_API_ONLY` for all framework target

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -229,3 +229,6 @@ SUPPORTS_MACCATALYST = YES
 
 // macOS Catalyst support
 DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO
+
+// When enabled, this causes the compiler and linker to disallow use of APIs that are not available to app extensions and to disallow linking to frameworks that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -1337,7 +1337,6 @@
 		4A2CAE131AB4BB5400B6BC39 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = WebImage/Info.plist;
 			};
 			name = Debug;
@@ -1345,7 +1344,6 @@
 		4A2CAE141AB4BB5400B6BC39 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = WebImage/Info.plist;
 			};
 			name = Release;
@@ -1381,7 +1379,6 @@
 		80B6DFEC2142B71600BCB334 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = WebImage/Info.plist;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2,3";
@@ -1392,7 +1389,6 @@
 		80B6DFED2142B71600BCB334 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = WebImage/Info.plist;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2,3";

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -283,7 +283,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             if (transition.prepares) {
                 transition.prepares(view, image, imageData, cacheType, imageURL);
             }
-        } completion:^(BOOL finished) {
+        } completion:^(BOOL tempFinished) {
             [UIView transitionWithView:view duration:transition.duration options:transition.animationOptions animations:^{
                 if (!view.sd_latestOperationKey || ![originalOperationKey isEqualToString:view.sd_latestOperationKey]) {
                     return;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x]  I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Just warning fixes.

