### PR TITLE
Fix imageFromCacheForKey with options and context behavior, matching the async version one.

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -383,6 +383,28 @@ static NSString * _defaultDiskCacheDirectory;
     // First check the in-memory cache...
     UIImage *image = [self imageFromMemoryCacheForKey:key];
     if (image) {
+        if (options & SDImageCacheDecodeFirstFrameOnly) {
+            // Ensure static image
+            Class animatedImageClass = image.class;
+            if (image.sd_isAnimated || ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)])) {
+#if SD_MAC
+                image = [[NSImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:kCGImagePropertyOrientationUp];
+#else
+                image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:image.imageOrientation];
+#endif
+            }
+        } else if (options & SDImageCacheMatchAnimatedImageClass) {
+            // Check image class matching
+            Class animatedImageClass = image.class;
+            Class desiredImageClass = context[SDWebImageContextAnimatedImageClass];
+            if (desiredImageClass && ![animatedImageClass isSubclassOfClass:desiredImageClass]) {
+                image = nil;
+            }
+        }
+    }
+    
+    // Since we don't need to query imageData, return image if exist
+    if (image) {
         return image;
     }
     

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -388,6 +388,10 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
         }];
     }];
     
+    // Test sync version API `imageFromCacheForKey` as well
+    expect([SDImageCache.sharedImageCache imageFromCacheForKey:kAnimatedImageKey options:SDImageCacheMatchAnimatedImageClass context:@{SDWebImageContextAnimatedImageClass : SDAnimatedImage.class}]).beNil();
+    expect([SDImageCache.sharedImageCache imageFromCacheForKey:kAnimatedImageKey options:0 context:@{SDWebImageContextAnimatedImageClass : SDAnimatedImage.class}]).notTo.beNil();
+    
     [self waitForExpectationsWithCommonTimeout];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x]  I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Support `SDImageCacheDecodeFirstFrameOnly` and `SDImageCacheMatchAnimatedImageClass`

This may be a little related to #3230 . But not solve them all.

From the design of this framework, the `SDAnimatedImage` custom class, should provide the top level priority.

Which means:

+ If there are `SDAnimatedImage` custom class instance in memory cache: Always query and return it, whatever caller is `UIImageView` or `SDAnimatedImageView`
+ If there are `UIImage` not custom class instance in memory cache: If `matchesImageClass`, ignore it and override with new created one `SDAnimatedImage`.


This can ensure we always prefer the `SDAnimatedImage` over `UIImage`, so that we do not replace same instance once by another. (If we put `UIImage` and `SDAnimatedImage` with the same level priority, this will cause huge issue)