### PR TITLE
Change the default delegate method to allows optional cert in SSL verify, matches URLSession's behavior

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -565,7 +565,9 @@ didReceiveResponse:(NSURLResponse *)response
                 credential = self.credential;
                 disposition = NSURLSessionAuthChallengeUseCredential;
             } else {
-                disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
+                // Web Server like Nginx can set `ssl_verify_client` to optional but not always on
+                // We'd better use default handling here
+                disposition = NSURLSessionAuthChallengePerformDefaultHandling;
             }
         } else {
             disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See: https://github.com/SDWebImage/SDWebImageSwiftUI/issues/153

When the server, like Nginx, set `ssl_verify_client` to optional, client side can optional provide the cert, so the line changes here should not always use `cancelAuthenticationChallenge` to cancel the request.

Instead, use the `performDefaultHandling` will allows this request and matches URLSessions' default implementation

