### PR TITLE
[WIP] Refactory animated image playback, introduce global frame buffer caching to benefit when multiple SDAnimatedImageView rendering same SDAnimatedImage

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		320CAE172086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320CAE1B2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
 		320CAE1D2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		321AB241265A36570060EA59 /* SDAnimatedImageBufferPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 321AB23F265A36570060EA59 /* SDAnimatedImageBufferPool.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321AB243265A36570060EA59 /* SDAnimatedImageBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 321AB240265A36570060EA59 /* SDAnimatedImageBufferPool.m */; };
+		321AB244265A36570060EA59 /* SDAnimatedImageBufferPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 321AB240265A36570060EA59 /* SDAnimatedImageBufferPool.m */; };
 		321B37832083290E00C0EA77 /* SDImageLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 321B377D2083290D00C0EA77 /* SDImageLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		321B37872083290E00C0EA77 /* SDImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 321B377E2083290D00C0EA77 /* SDImageLoader.m */; };
 		321B37892083290E00C0EA77 /* SDImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 321B377E2083290D00C0EA77 /* SDImageLoader.m */; };
@@ -387,6 +390,8 @@
 		320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDAnimatedImageRep.m; path = Core/SDAnimatedImageRep.m; sourceTree = "<group>"; };
 		320CAE132086F50500CFFC80 /* SDWebImageError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDWebImageError.h; path = Core/SDWebImageError.h; sourceTree = "<group>"; };
 		320CAE142086F50500CFFC80 /* SDWebImageError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDWebImageError.m; path = Core/SDWebImageError.m; sourceTree = "<group>"; };
+		321AB23F265A36570060EA59 /* SDAnimatedImageBufferPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDAnimatedImageBufferPool.h; sourceTree = "<group>"; };
+		321AB240265A36570060EA59 /* SDAnimatedImageBufferPool.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDAnimatedImageBufferPool.m; sourceTree = "<group>"; };
 		321B377D2083290D00C0EA77 /* SDImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDImageLoader.h; path = Core/SDImageLoader.h; sourceTree = "<group>"; };
 		321B377E2083290D00C0EA77 /* SDImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDImageLoader.m; path = Core/SDImageLoader.m; sourceTree = "<group>"; };
 		321B377F2083290E00C0EA77 /* SDImageLoadersManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDImageLoadersManager.h; path = Core/SDImageLoadersManager.h; sourceTree = "<group>"; };
@@ -683,6 +688,8 @@
 				326E2F32236F1D58006F847F /* SDDeviceHelper.m */,
 				325C460022339330004CAE11 /* SDImageAssetManager.h */,
 				325C460122339330004CAE11 /* SDImageAssetManager.m */,
+				321AB23F265A36570060EA59 /* SDAnimatedImageBufferPool.h */,
+				321AB240265A36570060EA59 /* SDAnimatedImageBufferPool.m */,
 				325C460C223394D8004CAE11 /* SDImageCachesManagerOperation.h */,
 				325C460D223394D8004CAE11 /* SDImageCachesManagerOperation.m */,
 				32C78E39233371AD00C6B7F8 /* SDImageIOAnimatedCoderInternal.h */,
@@ -935,6 +942,7 @@
 				4A2CAE2B1AB4BB7500B6BC39 /* UIButton+WebCache.h in Headers */,
 				4A2CAE251AB4BB7000B6BC39 /* SDWebImagePrefetcher.h in Headers */,
 				3246A70323A567AC00FBEA10 /* SDGraphicsImageRenderer.h in Headers */,
+				321AB241265A36570060EA59 /* SDAnimatedImageBufferPool.h in Headers */,
 				328BB6CF2082581100760D6C /* SDMemoryCache.h in Headers */,
 				325C460F223394D8004CAE11 /* SDImageCachesManagerOperation.h in Headers */,
 				321E60881F38E8C800405457 /* SDImageCoder.h in Headers */,
@@ -1179,6 +1187,7 @@
 				32F21B5920788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m in Sources */,
 				321B37952083290E00C0EA77 /* SDImageLoadersManager.m in Sources */,
 				4A2CAE361AB4BB7500B6BC39 /* UIImageView+WebCache.m in Sources */,
+				321AB244265A36570060EA59 /* SDAnimatedImageBufferPool.m in Sources */,
 				4A2CAE1E1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.m in Sources */,
 				3298655E2337230C0071958B /* SDImageHEICCoder.m in Sources */,
 				32F7C0802030719600873181 /* UIImage+Transform.m in Sources */,
@@ -1293,6 +1302,7 @@
 				ABBE71A818C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m in Sources */,
 				4369C27E1D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				329A185F1FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
+				321AB243265A36570060EA59 /* SDAnimatedImageBufferPool.m in Sources */,
 				327F2E83245AE1650075F846 /* SDWebImageOperation.m in Sources */,
 				328BB6B02081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				325C4610223394D8004CAE11 /* SDImageCachesManagerOperation.m in Sources */,

--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -183,10 +183,8 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
             [frames addObject:frame];
         }
         self.loadedAnimatedImageFrames = frames;
+        self.loadedFrameOptions = [self effectiveFrameOptions];
         self.allFramesLoaded = YES;
-        if ([self.animatedCoder respondsToSelector:@selector(effectiveFrameOptions)]) {
-            self.loadedFrameOptions = [self effectiveFrameOptions];
-        }
     }
 }
 

--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -252,6 +252,10 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
     return [self.animatedCoder animatedImageFrameCount];
 }
 
+- (SDImageFrameOptions *)supportedFrameOptions {
+    return [self.animatedCoder supportedFrameOptions];
+}
+
 - (UIImage *)animatedImageFrameAtIndex:(NSUInteger)index {
     if (index >= self.animatedImageFrameCount) {
         return nil;

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -212,8 +212,8 @@
 - (void)clearFrameBuffer {
     SD_LOCK(_lock);
     [self.frameBuffer removeAllObjects];
-    [SDAnimatedImageBufferPool clearBufferForProvider:self.animatedProvider];
     SD_UNLOCK(_lock);
+    [SDAnimatedImageBufferPool clearBufferForProvider:self.animatedProvider];
 }
 
 #pragma mark - Animation Control

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -189,11 +189,17 @@
 - (void)compactFrameBuffer {
     NSUInteger maxBufferCount = self.maxBufferCount;
     NSUInteger currentFrameIndex = self.currentFrameIndex;
+    NSUInteger currentBufferCount;
     SD_LOCK(_lock);
-    if (self.frameBuffer.count > maxBufferCount) {
+    currentBufferCount = self.frameBuffer.count;
+    if (currentBufferCount > maxBufferCount) {
         [self.frameBuffer removeObjectForKey:@(currentFrameIndex)];
     }
     SD_UNLOCK(_lock);
+    if (currentBufferCount > maxBufferCount) {
+        // Remove buffer pool
+        [SDAnimatedImageBufferPool removeBufferForProvider:self.animatedProvider index:currentFrameIndex];
+    }
 }
 
 - (BOOL)shouldFetchFrameBufferWithIndex:(NSUInteger)index {

--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -165,34 +165,25 @@
 
 #pragma mark - Frame Buffer
 
-- (UIImage *)frameBufferWithIndex:(NSUInteger)index {
+- (nullable UIImage *)frameBufferWithIndex:(NSUInteger)index {
     SD_LOCK(_lock);
     UIImage *frame = self.frameBuffer[@(index)];
     SD_UNLOCK(_lock);
     return frame;
 }
 
-- (void)setFrameBuffer:(UIImage *)frame withIndex:(NSUInteger)index {
+- (void)setFrameBuffer:(nullable UIImage *)frame withIndex:(NSUInteger)index {
     SD_LOCK(_lock);
     self.frameBuffer[@(index)] = frame;
     SD_UNLOCK(_lock);
 }
 
 - (void)compactFrameBuffer {
-    NSUInteger bufferCount = self.frameBuffer.count;
     NSUInteger maxBufferCount = self.maxBufferCount;
+    NSUInteger currentFrameIndex = self.currentFrameIndex;
     SD_LOCK(_lock);
-    if (bufferCount > maxBufferCount) {
-        // Remove from lower to higher index
-        NSArray<NSNumber *> *frameIndexes = [self.frameBuffer.allKeys sortedArrayUsingSelector:@selector(compare:)];
-        NSUInteger remainCount = bufferCount - maxBufferCount;
-        for (NSNumber *index in frameIndexes) {
-            self.frameBuffer[index] = nil;
-            remainCount--;
-            if (remainCount == 0) {
-                break;;
-            }
-        }
+    if (self.frameBuffer.count > maxBufferCount) {
+        self.frameBuffer[@(currentFrameIndex)] = nil;
     }
     SD_UNLOCK(_lock);
 }

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -14,6 +14,10 @@ typedef NSString * SDImageCoderOption NS_STRING_ENUM;
 typedef NSDictionary<SDImageCoderOption, id> SDImageCoderOptions;
 typedef NSMutableDictionary<SDImageCoderOption, id> SDImageCoderMutableOptions;
 
+typedef NSString * SDImageFrameOption NS_STRING_ENUM;
+typedef NSDictionary<SDImageFrameOption, id> SDImageFrameOptions;
+typedef NSMutableDictionary<SDImageFrameOption, id> SDAnimatedImageFrameMutableOptions;
+
 #pragma mark - Coder Options
 // These options are for image decoding
 /**
@@ -94,6 +98,21 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeEmbedThumb
  See `SDWebImageContext` for more detailed information.
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext API_DEPRECATED("The coder component will be seperated from Core subspec in the future. Update your code to not rely on this context option.", macos(10.10, API_TO_BE_DEPRECATED), ios(8.0, API_TO_BE_DEPRECATED), tvos(9.0, API_TO_BE_DEPRECATED), watchos(2.0, API_TO_BE_DEPRECATED));
+
+#pragma mark - Frame Options for Animated Image
+// These options are used for animated image frame decoding and caching. The value should be serializable (String/Number/Value)
+/**
+ See `SDImageCoderDecodeThumbnailPixelSize`.
+ */
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionThumbnailPixelSize;
+/**
+ See `SDImageCoderDecodeScaleFactor`.
+ */
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionScaleFactor;
+/**
+ See `SDImageCoderDecodePreserveAspectRatio`.
+ */
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionPreserveAspectRatio;
 
 #pragma mark - Coder
 /**
@@ -227,6 +246,12 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext 
  */
 @property (nonatomic, assign, readonly) NSUInteger animatedImageLoopCount;
 /**
+ The supported animated image properties during decoding. For example, if the codec supports thumbnail decoding, provide `.thumbnailPixelSize:(a,b)` from the input.
+ @note This property is used for animated image frame decoding and caching currently. (Introduced in 5.12.0)
+ @note Which means, we will use (imageData, frameOptions, frameIndex) 3-tuple to identify the cache for each frame decoded by coder. This is shared globally by any imagView or imagePlayer.
+ */
+@property (nonatomic, copy, readonly, nullable) SDImageFrameOptions *supportedFrameOptions;
+/**
  Returns the frame image from a specified index.
  @note The index maybe randomly if one image was set to different imageViews, keep it re-entrant. (It's not recommend to store the images into array because it's memory consuming)
  
@@ -242,6 +267,14 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext 
  @return Frame's duration
  */
 - (NSTimeInterval)animatedImageDurationAtIndex:(NSUInteger)index;
+
+@end
+
+#pragma mark - Animated Provider which supports buffer sharing
+@protocol SDAnimatedImageBufferProvider <NSObject>
+
+@required
+@property (nonatomic, copy, readonly, nullable) NSData *animatedImageData;
 
 @end
 

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -104,15 +104,15 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext 
 /**
  See `SDImageCoderDecodeThumbnailPixelSize`.
  */
-FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionThumbnailPixelSize;
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameDecodeThumbnailPixelSize;
 /**
  See `SDImageCoderDecodeScaleFactor`.
  */
-FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionScaleFactor;
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameDecodeScaleFactor;
 /**
  See `SDImageCoderDecodePreserveAspectRatio`.
  */
-FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionPreserveAspectRatio;
+FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameDecodePreserveAspectRatio;
 
 #pragma mark - Coder
 /**
@@ -288,6 +288,7 @@ FOUNDATION_EXPORT SDImageFrameOption _Nonnull const SDImageFrameOptionPreserveAs
  */
 @protocol SDAnimatedImageCoder <SDImageCoder, SDAnimatedImageProvider>
 
+#pragma mark - Animated Decoding
 @required
 /**
  Because animated image coder should keep the original data, we will alloc a new instance with the same class for the specify animated image data

--- a/SDWebImage/Core/SDImageCoder.m
+++ b/SDWebImage/Core/SDImageCoder.m
@@ -21,3 +21,8 @@ SDImageCoderOption const SDImageCoderEncodeMaxFileSize = @"encodeMaxFileSize";
 SDImageCoderOption const SDImageCoderEncodeEmbedThumbnail = @"encodeEmbedThumbnail";
 
 SDImageCoderOption const SDImageCoderWebImageContext = @"webImageContext";
+
+SDImageFrameOption const SDImageFrameOptionThumbnailPixelSize = @"thumbnailPixelSize";
+SDImageFrameOption const SDImageFrameOptionScaleFactor = @"scaleFactor";
+SDImageFrameOption const SDImageFrameOptionPreserveAspectRatio = @"preserveAspectRatio";
+

--- a/SDWebImage/Core/SDImageCoder.m
+++ b/SDWebImage/Core/SDImageCoder.m
@@ -22,7 +22,7 @@ SDImageCoderOption const SDImageCoderEncodeEmbedThumbnail = @"encodeEmbedThumbna
 
 SDImageCoderOption const SDImageCoderWebImageContext = @"webImageContext";
 
-SDImageFrameOption const SDImageFrameOptionThumbnailPixelSize = @"thumbnailPixelSize";
-SDImageFrameOption const SDImageFrameOptionScaleFactor = @"scaleFactor";
-SDImageFrameOption const SDImageFrameOptionPreserveAspectRatio = @"preserveAspectRatio";
+SDImageFrameOption const SDImageFrameDecodeThumbnailPixelSize = SDImageCoderDecodeThumbnailPixelSize;
+SDImageFrameOption const SDImageFrameDecodeScaleFactor = SDImageCoderDecodeScaleFactor;
+SDImageFrameOption const SDImageFrameDecodePreserveAspectRatio = SDImageCoderDecodePreserveAspectRatio;
 

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -624,9 +624,9 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
 
 - (SDImageFrameOptions *)effectiveFrameOptions {
     return @{
-        SDImageFrameOptionScaleFactor: @(_scale),
-        SDImageFrameOptionThumbnailPixelSize: @(_thumbnailSize),
-        SDImageFrameOptionPreserveAspectRatio: @(_preserveAspectRatio)
+        SDImageFrameDecodeScaleFactor: @(_scale),
+        SDImageFrameDecodeThumbnailPixelSize: @(_thumbnailSize),
+        SDImageFrameDecodePreserveAspectRatio: @(_preserveAspectRatio)
     };
 }
 
@@ -663,12 +663,12 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
         (__bridge NSString *)kCGImageSourceShouldCache : @(YES) // Always cache to reduce CPU usage
     };
     CGFloat scale = _scale;
-    if (options[SDImageFrameOptionScaleFactor]) {
-        scale = [options[SDImageFrameOptionScaleFactor] doubleValue];
+    if (options[SDImageFrameDecodeScaleFactor]) {
+        scale = [options[SDImageFrameDecodeScaleFactor] doubleValue];
     }
     CGSize thumbnailSize = _thumbnailSize;
-    if (options[SDImageFrameOptionThumbnailPixelSize]) {
-        NSValue *thumbnailSizeValue = options[SDImageFrameOptionThumbnailPixelSize];
+    if (options[SDImageFrameDecodeThumbnailPixelSize]) {
+        NSValue *thumbnailSizeValue = options[SDImageFrameDecodeThumbnailPixelSize];
 #if SD_MAC
         thumbnailSize = thumbnailSizeValue.sizeValue;
 #else
@@ -676,8 +676,8 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
 #endif
     }
     BOOL preserveAspectRatio = _preserveAspectRatio;
-    if (options[SDImageFrameOptionPreserveAspectRatio]) {
-        preserveAspectRatio = [options[SDImageFrameOptionPreserveAspectRatio] boolValue];
+    if (options[SDImageFrameDecodePreserveAspectRatio]) {
+        preserveAspectRatio = [options[SDImageFrameDecodePreserveAspectRatio] boolValue];
     }
     UIImage *image = [self.class createFrameAtIndex:index source:_imageSource scale:scale preserveAspectRatio:preserveAspectRatio thumbnailSize:thumbnailSize options:extraOptions];
     if (!image) {

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -634,6 +634,14 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     return _frameCount;
 }
 
+- (SDImageFrameOptions *)supportedFrameOptions {
+    return @{
+        SDImageFrameOptionScaleFactor: @(_scale),
+        SDImageFrameOptionThumbnailPixelSize: @(_thumbnailSize),
+        SDImageFrameOptionPreserveAspectRatio: @(_preserveAspectRatio)
+    };
+}
+
 - (NSTimeInterval)animatedImageDurationAtIndex:(NSUInteger)index {
     if (index >= _frameCount) {
         return 0;

--- a/SDWebImage/Private/SDAnimatedImageBufferPool.h
+++ b/SDWebImage/Private/SDAnimatedImageBufferPool.h
@@ -1,10 +1,10 @@
-//
-//  SDAnimatedImageBufferPool.h
-//  SDWebImage
-//
-//  Created by 李卓立 on 2021/5/23.
-//  Copyright © 2021 Dailymotion. All rights reserved.
-//
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
 
 #import "SDWebImageCompat.h"
 #import "SDImageCoder.h"
@@ -12,6 +12,7 @@
 /// Buffer Pool is used to track all animated image frame buffer. A buffer can be shared only when `(image data, decoding options, index)` are all equal.
 /// The provide should implements `effectiveFrameOptions` to detect cache equality.
 /// @note: The current tracking use weak reference to avoid effect buffer's lifecycle.
+/// @note: In the future, we may use `cache key` instead of `image data` to detect cache equality. Which need to pass the cache key from top-level (`SDImageCacheDecodeImageData`/`SDImageLoaderDecodeImageData`) to the provider (`SDAnimatedImage`/`SDAnimatedImageCoder`)
 @interface SDAnimatedImageBufferPool : NSObject
 
 /// Query buffer from buffer pool.

--- a/SDWebImage/Private/SDAnimatedImageBufferPool.h
+++ b/SDWebImage/Private/SDAnimatedImageBufferPool.h
@@ -1,0 +1,36 @@
+//
+//  SDAnimatedImageBufferPool.h
+//  SDWebImage
+//
+//  Created by 李卓立 on 2021/5/23.
+//  Copyright © 2021 Dailymotion. All rights reserved.
+//
+
+#import "SDWebImageCompat.h"
+#import "SDImageCoder.h"
+
+/// Buffer Pool is used to track all animated image frame buffer. A buffer can be shared only when `(image data, decoding options, index)` are all equal.
+/// @note: The current tracking use weak reference to avoid effect buffer's lifecycle.
+@interface SDAnimatedImageBufferPool : NSObject
+
+/// Query buffer from buffer pool.
+/// @param provider The buffer provider
+/// @param index The frame index
++ (nullable UIImage *)bufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index;
+
+/// Store buffer into buffer pool.
+/// @param buffer The frame buffer
+/// @param provider The buffer provider
+/// @param index The frame index
++ (void)setBuffer:(nullable UIImage *)buffer forProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index;
+
+/// Remove the buffer from buffer pool.
+/// @param provider The buffer provider
+/// @param index The frame index
++ (void)removeBufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index;
+
+/// Clear buffer from buffer pool.
+/// @param provider The buffer provider
++ (void)clearBufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider;
+
+@end

--- a/SDWebImage/Private/SDAnimatedImageBufferPool.h
+++ b/SDWebImage/Private/SDAnimatedImageBufferPool.h
@@ -10,6 +10,7 @@
 #import "SDImageCoder.h"
 
 /// Buffer Pool is used to track all animated image frame buffer. A buffer can be shared only when `(image data, decoding options, index)` are all equal.
+/// The provide should implements `effectiveFrameOptions` to detect cache equality.
 /// @note: The current tracking use weak reference to avoid effect buffer's lifecycle.
 @interface SDAnimatedImageBufferPool : NSObject
 

--- a/SDWebImage/Private/SDAnimatedImageBufferPool.m
+++ b/SDWebImage/Private/SDAnimatedImageBufferPool.m
@@ -1,10 +1,10 @@
-//
-//  SDAnimatedImageBufferPool.m
-//  SDWebImage
-//
-//  Created by 李卓立 on 2021/5/23.
-//  Copyright © 2021 Dailymotion. All rights reserved.
-//
+/*
+* This file is part of the SDWebImage package.
+* (c) Olivier Poitrey <rs@dailymotion.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
 
 #import "SDAnimatedImageBufferPool.h"
 #import "SDInternalMacros.h"

--- a/SDWebImage/Private/SDAnimatedImageBufferPool.m
+++ b/SDWebImage/Private/SDAnimatedImageBufferPool.m
@@ -1,0 +1,157 @@
+//
+//  SDAnimatedImageBufferPool.m
+//  SDWebImage
+//
+//  Created by 李卓立 on 2021/5/23.
+//  Copyright © 2021 Dailymotion. All rights reserved.
+//
+
+#import "SDAnimatedImageBufferPool.h"
+#import "SDInternalMacros.h"
+#import <objc/runtime.h>
+
+// <BufferID, Buffer>, BufferID = Hash(ProviderID, Index>), strog -> weak
+static NSMapTable<NSString *, UIImage *> *_globalBufferTable;
+// <ProviderID, Indexes>, strong -> strong
+static NSMapTable<NSString *, NSMutableIndexSet *> *_globalProviderTable;
+
+static void *kSDAnimatedImageProviderIDKey = &kSDAnimatedImageProviderIDKey;
+
+SD_LOCK_DECLARE_STATIC(_globalBufferTableLock);
+SD_LOCK_DECLARE_STATIC(_globalProviderTableLock);
+
+static inline NSString * SDCalculateOptionsHash(SDImageFrameOptions *options) {
+    NSMutableString *optionsHash = [NSMutableString string];
+    [options enumerateKeysAndObjectsUsingBlock:^(SDImageFrameOption  _Nonnull key, id  _Nonnull option, BOOL * _Nonnull stop) {
+        [optionsHash appendFormat:@"-%@(%@)", key, option];
+    }];
+    return [optionsHash copy];
+}
+
+static inline NSString * SDCalculateProviderID(id<SDAnimatedImageProvider> provider) {
+    NSString *providerID = objc_getAssociatedObject(provider, &kSDAnimatedImageProviderIDKey);
+    if (providerID) {
+        return providerID;
+    }
+    NSUInteger frameCount = provider.animatedImageFrameCount;
+    SDImageFrameOptions *supportedFrameOptions = provider.supportedFrameOptions;
+    
+    NSData *imageData = provider.animatedImageData;
+    // 80 Bytes hashing, acceptable speed
+    // https://stackoverflow.com/questions/10768467/how-does-nsdatas-implementation-of-the-hash-method-work
+    NSUInteger dataHash = [imageData hash];
+    NSString *optionsHash = SDCalculateOptionsHash(supportedFrameOptions);
+    
+    // Final hash string
+    providerID = [NSString stringWithFormat:@"data(%lu)-frame(%lu)%@", dataHash, frameCount, optionsHash];
+    
+    objc_setAssociatedObject(provider, &kSDAnimatedImageProviderIDKey, providerID, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    
+    return providerID;
+}
+
+static inline NSString * SDCalculateBufferID(NSString *providerID, NSUInteger index) {
+    // Final hash string
+    return [providerID stringByAppendingFormat:@":%lu", index];
+}
+
+@implementation SDAnimatedImageBufferPool
+
++ (void)initialize {
+    _globalBufferTable = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsWeakMemory capacity:0];
+    _globalProviderTable = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsStrongMemory capacity:0];
+    SD_LOCK_INIT(_globalBufferTableLock);
+    SD_LOCK_INIT(_globalProviderTableLock);
+}
+
++ (UIImage *)bufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index {
+    NSParameterAssert(provider);
+    NSString *providerID = SDCalculateProviderID(provider);
+    NSString *bufferID = SDCalculateBufferID(providerID, index);
+    SD_LOCK(_globalBufferTableLock);
+    UIImage *buffer = [_globalBufferTable objectForKey:bufferID];
+    SD_UNLOCK(_globalBufferTableLock);
+    
+//    // Update index, slow but not necessary
+//    SD_LOCK(_globalProviderTableLock);
+//    NSMutableIndexSet *indexes = [_globalProviderTable objectForKey:providerID];
+//    NSAssert(indexes, @"Provider is not registered in buffer pool. Call `+registerProvider:` before using %@", NSStringFromSelector(_cmd));
+//    if (!buffer) {
+//        [indexes removeIndex:index];
+//    } else {
+//        [indexes addIndex:index];
+//    }
+//    SD_UNLOCK(_globalProviderTableLock);
+    
+    return buffer;
+}
+
++ (void)setBuffer:(UIImage *)buffer forProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index {
+    NSParameterAssert(provider);
+    if (!buffer) {
+        return [self removeBufferForProvider:provider index:index];
+    }
+    NSString *providerID = SDCalculateProviderID(provider);
+    NSString *bufferID = SDCalculateBufferID(providerID, index);
+    
+    // Store buffer
+    [_globalBufferTable setObject:buffer forKey:bufferID];
+    
+    // Update index
+    SD_LOCK(_globalProviderTableLock);
+    NSMutableIndexSet *indexes = [_globalProviderTable objectForKey:providerID];
+    if (!indexes) {
+        indexes = [NSMutableIndexSet indexSetWithIndex:index];
+        [_globalProviderTable setObject:indexes forKey:providerID];
+    } else {
+        [indexes addIndex:index];
+    }
+    SD_UNLOCK(_globalProviderTableLock);
+}
+
++ (void)removeBufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider index:(NSUInteger)index {
+    NSParameterAssert(provider);
+    NSString *providerID = SDCalculateProviderID(provider);
+    NSString *bufferID = SDCalculateBufferID(providerID, index);
+    
+    // Store buffer
+    [_globalBufferTable removeObjectForKey:bufferID];
+    
+    // Update index
+    SD_LOCK(_globalProviderTableLock);
+    NSMutableIndexSet *indexes = [_globalProviderTable objectForKey:providerID];
+    if (!indexes) {
+        indexes = [NSMutableIndexSet indexSetWithIndex:index];
+        [_globalProviderTable setObject:indexes forKey:providerID];
+    } else {
+        [indexes removeIndex:index];
+    }
+    SD_UNLOCK(_globalProviderTableLock);
+}
+
++ (void)clearBufferForProvider:(nonnull id<SDAnimatedImageProvider>)provider {
+    NSParameterAssert(provider);
+    NSString *providerID = SDCalculateProviderID(provider);
+    
+    // Query index
+    SD_LOCK(_globalProviderTableLock);
+    NSMutableIndexSet *indexes = [_globalProviderTable objectForKey:providerID];
+    if (!indexes) {
+        return;
+    }
+    NSMutableArray<NSString *> *bufferIDs = [NSMutableArray arrayWithCapacity:indexes.count];
+    [indexes enumerateIndexesUsingBlock:^(NSUInteger index, BOOL * _Nonnull stop) {
+        NSString *bufferID = SDCalculateBufferID(providerID, index);
+        [bufferIDs addObject:bufferID];
+    }];
+    SD_UNLOCK(_globalProviderTableLock);
+    
+    // Remove buffer
+    SD_LOCK(_globalBufferTableLock);
+    for (NSString *bufferID in bufferIDs) {
+        [_globalBufferTable removeObjectForKey:bufferID];
+    }
+    SD_UNLOCK(_globalBufferTableLock);
+}
+
+@end

--- a/SDWebImage/Private/SDImageAssetManager.h
+++ b/SDWebImage/Private/SDImageAssetManager.h
@@ -13,9 +13,8 @@
 /// Apple parse the Asset Catalog compiled file(`Assets.car`) by CoreUI.framework, however it's a private framework and there are no other ways to directly get the data. So we just process the normal bundle files :)
 @interface SDImageAssetManager : NSObject
 
-@property (nonatomic, strong, nonnull) NSMapTable<NSString *, UIImage *> *imageTable;
+@property (nonatomic, class, readonly, nonnull) SDImageAssetManager *sharedAssetManager;
 
-+ (nonnull instancetype)sharedAssetManager;
 - (nullable NSString *)getPathForName:(nonnull NSString *)name bundle:(nonnull NSBundle *)bundle preferredScale:(nonnull CGFloat *)scale;
 - (nullable UIImage *)imageForName:(nonnull NSString *)name;
 - (void)storeImage:(nonnull UIImage *)image forName:(nonnull NSString *)name;

--- a/SDWebImage/Private/SDImageAssetManager.m
+++ b/SDWebImage/Private/SDImageAssetManager.m
@@ -31,11 +31,15 @@ static NSArray *SDBundlePreferredScales() {
     return scales;
 }
 
+@interface SDImageAssetManager ()
+@property (nonatomic, strong, nonnull) NSMapTable<NSString *, UIImage *> *imageTable;
+@end
+
 @implementation SDImageAssetManager {
     SD_LOCK_DECLARE(_lock);
 }
 
-+ (instancetype)sharedAssetManager {
++ (SDImageAssetManager *)sharedAssetManager {
     static dispatch_once_t onceToken;
     static SDImageAssetManager *assetManager;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See the proposal talked in #3163.


### Issue

Currently, when one `SDAnimatedImage` play on multiple `SDAnimatedImageView`, because each of image view will create and manage their own `SDAnimatedImagePlayer`.

Since the different players will request different frame from this single `SDAnimatedImage`, and `SDAnimatedImage` proxy to `SDAnimatedImageCoder`, the coder will repeatlly decode same frame index once by once. And more seriouly. The frame buffer cache now placing on `SDAnimatedImagePlayer` level.

Which means, if I play 1 `SDAnimatedImage` on 2 `SDAnimatedImageView`, this will result double memory usage.

### Solution

This PR, re-design the current player and decoding part. Now, the decoded frame buffer from `SDAnimatedImageCoder`, will bind a global Weak map table. (Will change into strong later in the future version).

Each of player will ask and query the global map table firstly. 

The map table cache key is `(imageData, decodingOptions, index)`, this 3-tuple can define a identifiable image frame. (We assume that a valid decoder should produce the same result when we input these param to it).

### Weak or Strong

From the design part, it can be strong. However, since this changes may cause some issue, currently I use the weak map table. (But still, remove the entry when player dealloc, act as if it's a strong map table).

### Effect on API
Because we need the `(imageData, decodingOptions, index)` 3-tuple. However, current `SDAnimatedImageProvider` protocol does not have the `decodingOptions` information. So I update the protocal method with new `supportedFrameOptions`. This options will convert into string to use as part of the cache key.

For old codec which does not implements this new API, maybe I have to disable the global frame cache for it to keep compatibility...😣