### PR TITLE
Make SDAnimatedImageRep confirms to correct copy semantic

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageRep.m
+++ b/SDWebImage/Core/SDAnimatedImageRep.m
@@ -27,6 +27,12 @@
     }
 }
 
+- (instancetype)copyWithZone:(NSZone *)zone {
+  SDAnimatedImageRep *imageRep = [super copyWithZone:zone];
+  CFRetain(imageRep->_imageSource);
+  return imageRep;
+}
+
 // `NSBitmapImageRep`'s `imageRepWithData:` is not designed initializer
 + (instancetype)imageRepWithData:(NSData *)data {
     SDAnimatedImageRep *imageRep = [[SDAnimatedImageRep alloc] initWithData:data];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Recently I got `SDAnimatedImageRep` related crashes in my app when loading some specific animated webp images.

After spending some time diving deep into this issue, I found that `SDAnimatedImageRep` has wrong `copy` semantic and thus when copy operations performed on `NSImage`s with this type of backing source, the underlying `CGImageSourceRef` actually refers to released address space and thus crashes the whole app.

<img width="903" alt="Code to produce this issue" src="https://user-images.githubusercontent.com/8158163/129068144-9a362998-e003-47f0-9a74-ed4f30953eb5.png">

<img width="919" alt="resulting crash" src="https://user-images.githubusercontent.com/8158163/129068353-1331ab85-2cd5-41c5-a335-81c1f57d66f7.png">

This pull request make `SDAnimatedImageRep` confirm to correct copy semantic. Since [ImageIO](https://developer.apple.com/documentation/imageio) provides no public API for direct copying of `CGImageSource` instances, a retain operation is performed on the underlying `CGImageSource` instance. Technically, two `SDAnimatedImageRep` instances (the copied instance and the original one) referrers the same `_imageSource`, but since the it's a private class member, only be read for frame-sync logic, this modification should be acceptable. 