### PR TITLE
Fix wrong handling of maxPixelSize

### DIFF
--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -233,18 +233,10 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
         imageRef = CGImageSourceCreateImageAtIndex(source, index, (__bridge CFDictionaryRef)[decodingOptions copy]);
     } else {
         decodingOptions[(__bridge NSString *)kCGImageSourceCreateThumbnailWithTransform] = @(preserveAspectRatio);
-        CGFloat maxPixelSize;
-        if (preserveAspectRatio) {
-            CGFloat pixelRatio = pixelWidth / pixelHeight;
-            CGFloat thumbnailRatio = thumbnailSize.width / thumbnailSize.height;
-            if (pixelRatio > thumbnailRatio) {
-                maxPixelSize = thumbnailSize.width;
-            } else {
-                maxPixelSize = thumbnailSize.height;
-            }
-        } else {
-            maxPixelSize = MAX(thumbnailSize.width, thumbnailSize.height);
-        }
+
+        CGFloat maxPixelSizeForOriginal = MAX(pixelWidth, pixelHeight);
+        CGFloat maxPixelSizeForThumbnail = MAX(thumbnailSize.width, thumbnailSize.height);
+        CGFloat maxPixelSize = MIN(maxPixelSizeForOriginal, maxPixelSizeForThumbnail);
         decodingOptions[(__bridge NSString *)kCGImageSourceThumbnailMaxPixelSize] = @(maxPixelSize);
         decodingOptions[(__bridge NSString *)kCGImageSourceCreateThumbnailFromImageAlways] = @(YES);
         imageRef = CGImageSourceCreateThumbnailAtIndex(source, index, (__bridge CFDictionaryRef)[decodingOptions copy]);
@@ -498,15 +490,10 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     }
     NSUInteger pixelWidth = CGImageGetWidth(imageRef);
     NSUInteger pixelHeight = CGImageGetHeight(imageRef);
-    CGFloat finalPixelSize = 0;
     if (maxPixelSize.width > 0 && maxPixelSize.height > 0 && pixelWidth > maxPixelSize.width && pixelHeight > maxPixelSize.height) {
-        CGFloat pixelRatio = pixelWidth / pixelHeight;
-        CGFloat maxPixelSizeRatio = maxPixelSize.width / maxPixelSize.height;
-        if (pixelRatio > maxPixelSizeRatio) {
-            finalPixelSize = maxPixelSize.width;
-        } else {
-            finalPixelSize = maxPixelSize.height;
-        }
+        CGFloat maxPixelSizeForOriginal = MAX(pixelWidth, pixelHeight);
+        CGFloat maxPixelSizeForDestination = MAX(maxPixelSize.width, maxPixelSize.height);
+        CGFloat finalPixelSize = MIN(maxPixelSizeForOriginal, maxPixelSizeForDestination);
         properties[(__bridge NSString *)kCGImageDestinationImageMaxPixelSize] = @(finalPixelSize);
     }
     NSUInteger maxFileSize = [options[SDImageCoderEncodeMaxFileSize] unsignedIntegerValue];

--- a/SDWebImage/Core/SDImageIOCoder.m
+++ b/SDWebImage/Core/SDImageIOCoder.m
@@ -253,14 +253,9 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     NSUInteger pixelWidth = CGImageGetWidth(imageRef);
     NSUInteger pixelHeight = CGImageGetHeight(imageRef);
     if (maxPixelSize.width > 0 && maxPixelSize.height > 0 && pixelWidth > maxPixelSize.width && pixelHeight > maxPixelSize.height) {
-        CGFloat pixelRatio = pixelWidth / pixelHeight;
-        CGFloat maxPixelSizeRatio = maxPixelSize.width / maxPixelSize.height;
-        CGFloat finalPixelSize;
-        if (pixelRatio > maxPixelSizeRatio) {
-            finalPixelSize = maxPixelSize.width;
-        } else {
-            finalPixelSize = maxPixelSize.height;
-        }
+        CGFloat maxPixelSizeForOriginal = MAX(pixelWidth, pixelHeight);
+        CGFloat maxPixelSizeForDestination = MAX(maxPixelSize.width, maxPixelSize.height);
+        CGFloat finalPixelSize = MIN(maxPixelSizeForOriginal, maxPixelSizeForDestination);
         properties[(__bridge NSString *)kCGImageDestinationImageMaxPixelSize] = @(finalPixelSize);
     }
     NSUInteger maxFileSize = [options[SDImageCoderEncodeMaxFileSize] unsignedIntegerValue];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

There are several places where `maxPixelSize` not handled correctly. For example, in line 236 of file `SDImageIOAnimatedCoder.m`

```objc
        CGFloat maxPixelSize;
        if (preserveAspectRatio) {
            CGFloat pixelRatio = pixelWidth / pixelHeight;
            CGFloat thumbnailRatio = thumbnailSize.width / thumbnailSize.height;
            if (pixelRatio > thumbnailRatio) {
                maxPixelSize = thumbnailSize.width;
            } else {
                maxPixelSize = thumbnailSize.height;
            }
        } else {
            maxPixelSize = MAX(thumbnailSize.width, thumbnailSize.height);
        }
```

The `pixelWidth` and `pixelHeight` are both `NSUInteger` here, so the result `pixelRatio` is always wrong. Then even if the result is correct, why compare with `thumbnailRatio` to choose the final size?
If you want the thumbnail image not blurred, you need to set the largest edge in the thumbnail, at the same time, if you want keep it in the size of the original image, you can compare it with the largest edge of the original image before setting.
Like this

```objc
        CGFloat maxPixelSizeForOriginal = MAX(pixelWidth, pixelHeight);
        CGFloat maxPixelSizeForThumbnail = MAX(thumbnailSize.width, thumbnailSize.height);
        CGFloat maxPixelSize = MIN(maxPixelSizeForOriginal, maxPixelSizeForThumbnail);
```

Is there anything I didn't considered?
