### PR TITLE
Bugfix/fix promotion display issues

### DIFF
--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -89,7 +89,12 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 #elif SD_IOS || SD_TV
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSTimeInterval duration = self.displayLink.duration * self.displayLink.frameInterval;
+    NSTimeInterval duration = 0;
+    if (@available(iOS 10.0, *)) {
+        duration = self.displayLink.targetTimestamp - CACurrentMediaTime();
+    } else {
+        duration = self.displayLink.duration * self.displayLink.frameInterval;
+    }
 #pragma clang diagnostic pop
 #else
     NSTimeInterval duration = 0;

--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -103,7 +103,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
         duration = nextFireDate - self.currentFireDate;
     }
 #endif
-    if (duration == 0) {
+    if (duration <= 0) {
         duration = kSDDisplayLinkInterval;
     }
     return duration;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3279

### Pull Request Description
This pull request fixes the duration calculation in `SDDisplayLink`, which fixes incorrect animation timing issues with the new ProMotion iPhones & iOS 15. More information about this can be found [here.](https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro)