### PR TITLE
Since `UTI` is an standard, we can use it directly to avoid warning on iOS 15

### DIFF
--- a/SDWebImage/Core/NSData+ImageContentType.h
+++ b/SDWebImage/Core/NSData+ImageContentType.h
@@ -45,7 +45,7 @@ static const SDImageFormat SDImageFormatSVG       = 8;
  *
  *  @param format Format as SDImageFormat
  *  @return The UTType as CFStringRef
- *  @note For unknown format, `kUTTypeImage` abstract type will return
+ *  @note For unknown format, `kSDUTTypeImage` abstract type will return
  */
 + (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED NS_SWIFT_NAME(sd_UTType(from:));
 

--- a/SDWebImage/Core/NSData+ImageContentType.m
+++ b/SDWebImage/Core/NSData+ImageContentType.m
@@ -87,16 +87,16 @@
     CFStringRef UTType;
     switch (format) {
         case SDImageFormatJPEG:
-            UTType = kUTTypeJPEG;
+            UTType = kSDUTTypeJPEG;
             break;
         case SDImageFormatPNG:
-            UTType = kUTTypePNG;
+            UTType = kSDUTTypePNG;
             break;
         case SDImageFormatGIF:
-            UTType = kUTTypeGIF;
+            UTType = kSDUTTypeGIF;
             break;
         case SDImageFormatTIFF:
-            UTType = kUTTypeTIFF;
+            UTType = kSDUTTypeTIFF;
             break;
         case SDImageFormatWebP:
             UTType = kSDUTTypeWebP;
@@ -108,14 +108,14 @@
             UTType = kSDUTTypeHEIF;
             break;
         case SDImageFormatPDF:
-            UTType = kUTTypePDF;
+            UTType = kSDUTTypePDF;
             break;
         case SDImageFormatSVG:
-            UTType = kUTTypeScalableVectorGraphics;
+            UTType = kSDUTTypeSVG;
             break;
         default:
             // default is kUTTypeImage abstract type
-            UTType = kUTTypeImage;
+            UTType = kSDUTTypeImage;
             break;
     }
     return UTType;
@@ -126,13 +126,13 @@
         return SDImageFormatUndefined;
     }
     SDImageFormat imageFormat;
-    if (CFStringCompare(uttype, kUTTypeJPEG, 0) == kCFCompareEqualTo) {
+    if (CFStringCompare(uttype, kSDUTTypeJPEG, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatJPEG;
-    } else if (CFStringCompare(uttype, kUTTypePNG, 0) == kCFCompareEqualTo) {
+    } else if (CFStringCompare(uttype, kSDUTTypePNG, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatPNG;
-    } else if (CFStringCompare(uttype, kUTTypeGIF, 0) == kCFCompareEqualTo) {
+    } else if (CFStringCompare(uttype, kSDUTTypeGIF, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatGIF;
-    } else if (CFStringCompare(uttype, kUTTypeTIFF, 0) == kCFCompareEqualTo) {
+    } else if (CFStringCompare(uttype, kSDUTTypeTIFF, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatTIFF;
     } else if (CFStringCompare(uttype, kSDUTTypeWebP, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatWebP;
@@ -140,9 +140,9 @@
         imageFormat = SDImageFormatHEIC;
     } else if (CFStringCompare(uttype, kSDUTTypeHEIF, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatHEIF;
-    } else if (CFStringCompare(uttype, kUTTypePDF, 0) == kCFCompareEqualTo) {
+    } else if (CFStringCompare(uttype, kSDUTTypePDF, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatPDF;
-    } else if (CFStringCompare(uttype, kUTTypeScalableVectorGraphics, 0) == kCFCompareEqualTo) {
+    } else if (CFStringCompare(uttype, kSDUTTypeSVG, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatSVG;
     } else {
         imageFormat = SDImageFormatUndefined;

--- a/SDWebImage/Core/SDAnimatedImageRep.m
+++ b/SDWebImage/Core/SDAnimatedImageRep.m
@@ -58,13 +58,13 @@
         if (!type) {
             return self;
         }
-        if (CFStringCompare(type, kUTTypeGIF, 0) == kCFCompareEqualTo) {
+        if (CFStringCompare(type, kSDUTTypeGIF, 0) == kCFCompareEqualTo) {
             // GIF
             // Fix the `NSBitmapImageRep` GIF loop count calculation issue
             // Which will use 0 when there are no loop count information metadata in GIF data
             NSUInteger loopCount = [SDImageGIFCoder imageLoopCountWithSource:imageSource];
             [self setProperty:NSImageLoopCount withValue:@(loopCount)];
-        } else if (CFStringCompare(type, kUTTypePNG, 0) == kCFCompareEqualTo) {
+        } else if (CFStringCompare(type, kSDUTTypePNG, 0) == kCFCompareEqualTo) {
             // APNG
             // Do initialize about frame count, current frame/duration and loop count
             [self setProperty:NSImageFrameCount withValue:@(frameCount)];
@@ -106,10 +106,10 @@
         }
         NSUInteger index = [value unsignedIntegerValue];
         NSTimeInterval frameDuration = 0;
-        if (CFStringCompare(type, kUTTypeGIF, 0) == kCFCompareEqualTo) {
+        if (CFStringCompare(type, kSDUTTypeGIF, 0) == kCFCompareEqualTo) {
             // GIF
             frameDuration = [SDImageGIFCoder frameDurationAtIndex:index source:imageSource];
-        } else if (CFStringCompare(type, kUTTypePNG, 0) == kCFCompareEqualTo) {
+        } else if (CFStringCompare(type, kSDUTTypePNG, 0) == kCFCompareEqualTo) {
             // APNG
             frameDuration = [SDImageAPNGCoder frameDurationAtIndex:index source:imageSource];
         } else if (CFStringCompare(type, kSDUTTypeHEICS, 0) == kCFCompareEqualTo) {

--- a/SDWebImage/Core/SDImageAPNGCoder.m
+++ b/SDWebImage/Core/SDImageAPNGCoder.m
@@ -7,6 +7,7 @@
  */
 
 #import "SDImageAPNGCoder.h"
+#import "SDImageIOAnimatedCoderInternal.h"
 #if SD_MAC
 #import <CoreServices/CoreServices.h>
 #else
@@ -31,7 +32,7 @@
 }
 
 + (NSString *)imageUTType {
-    return (__bridge NSString *)kUTTypePNG;
+    return (__bridge NSString *)kSDUTTypePNG;
 }
 
 + (NSString *)dictionaryProperty {

--- a/SDWebImage/Core/SDImageGIFCoder.m
+++ b/SDWebImage/Core/SDImageGIFCoder.m
@@ -7,6 +7,7 @@
  */
 
 #import "SDImageGIFCoder.h"
+#import "SDImageIOAnimatedCoderInternal.h"
 #if SD_MAC
 #import <CoreServices/CoreServices.h>
 #else
@@ -31,7 +32,7 @@
 }
 
 + (NSString *)imageUTType {
-    return (__bridge NSString *)kUTTypeGIF;
+    return (__bridge NSString *)kSDUTTypeGIF;
 }
 
 + (NSString *)dictionaryProperty {

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.h
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.h
@@ -24,7 +24,7 @@
  */
 @property (class, readonly) SDImageFormat imageFormat;
 /**
- The supported image format UTI Type. Such as `kUTTypeGIF`.
+ The supported image format UTI Type. Such as `kSDUTTypeGIF`.
  This can be used for cases when we can not detect `SDImageFormat. Such as progressive decoding's hint format `kCGImageSourceTypeIdentifierHint`.
  @note Subclass override.
  */

--- a/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
+++ b/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
@@ -9,13 +9,23 @@
 #import <Foundation/Foundation.h>
 #import "SDImageIOAnimatedCoder.h"
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 // AVFileTypeHEIC/AVFileTypeHEIF is defined in AVFoundation via iOS 11, we use this without import AVFoundation
-#define kSDUTTypeHEIC ((__bridge CFStringRef)@"public.heic")
-#define kSDUTTypeHEIF ((__bridge CFStringRef)@"public.heif")
+#define kSDUTTypeHEIC  ((__bridge CFStringRef)@"public.heic")
+#define kSDUTTypeHEIF  ((__bridge CFStringRef)@"public.heif")
 // HEIC Sequence (Animated Image)
 #define kSDUTTypeHEICS ((__bridge CFStringRef)@"public.heics")
-// kUTTypeWebP seems not defined in public UTI framework, Apple use the hardcode string, we define them :)
-#define kSDUTTypeWebP ((__bridge CFStringRef)@"org.webmproject.webp")
+// kSDUTTypeWebP seems not defined in public UTI framework, Apple use the hardcode string, we define them :)
+#define kSDUTTypeWebP  ((__bridge CFStringRef)@"org.webmproject.webp")
+
+#define kSDUTTypeImage ((__bridge CFStringRef)@"public.image")
+#define kSDUTTypeJPEG  ((__bridge CFStringRef)@"public.jpeg")
+#define kSDUTTypePNG   ((__bridge CFStringRef)@"public.png")
+#define kSDUTTypeTIFF  ((__bridge CFStringRef)@"public.tiff")
+#define kSDUTTypeSVG   ((__bridge CFStringRef)@"public.svg-image")
+#define kSDUTTypeGIF   ((__bridge CFStringRef)@"com.compuserve.gif")
+#define kSDUTTypePDF   ((__bridge CFStringRef)@"com.adobe.pdf")
 
 @interface SDImageIOAnimatedCoder ()
 

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -11,6 +11,7 @@
 #if SD_UIKIT
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
+#import "SDImageIOAnimatedCoderInternal.h"
 
 @interface SDCategoriesTests : SDTestCase
 
@@ -25,8 +26,8 @@
     
     // Test invalid format
     CFStringRef type = [NSData sd_UTTypeFromImageFormat:SDImageFormatUndefined];
-    expect(CFStringCompare(kUTTypeImage, type, 0)).equal(kCFCompareEqualTo);
-    expect([NSData sd_imageFormatFromUTType:kUTTypeImage]).equal(SDImageFormatUndefined);
+    expect(CFStringCompare(kSDUTTypeImage, type, 0)).equal(kCFCompareEqualTo);
+    expect([NSData sd_imageFormatFromUTType:kSDUTTypeImage]).equal(SDImageFormatUndefined);
 }
 
 - (void)test02UIImageMultiFormatCategory {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:  Fix #3278 

