### PR TITLE
Remove useless import with `UniformTypeIdentifiers `

### DIFF
--- a/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
+++ b/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
@@ -9,8 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "SDImageIOAnimatedCoder.h"
 
-#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-
 // AVFileTypeHEIC/AVFileTypeHEIF is defined in AVFoundation via iOS 11, we use this without import AVFoundation
 #define kSDUTTypeHEIC  ((__bridge CFStringRef)@"public.heic")
 #define kSDUTTypeHEIF  ((__bridge CFStringRef)@"public.heif")


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)



