### PR TITLE
3.7.3 | Merge Wristcam changes.

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
-
+@class BFTask;
 typedef NS_ENUM(NSInteger, SDImageCacheType) {
     /**
      * The image wasn't available the SDWebImage caches, but was downloaded from the web.
@@ -122,7 +122,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * @param key         The unique image cache key, usually it's image absolute URL
  * @param toDisk      Store the image to disk cache if YES
  */
-- (void)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk;
+- (BFTask*)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk;
 
 /**
  * Query the disk cache asynchronously.

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -323,9 +323,10 @@
         [self.cacheOperation cancel];
         self.cacheOperation = nil;
     }
-    if (self.cancelBlock) {
-        self.cancelBlock();
-        
+    //FIXED BY: Jonathan rose see IOS-7828
+    dispatch_block_t cancelBlockCopy = [self.cancelBlock copy];
+    if (cancelBlockCopy){
+        cancelBlockCopy();
         // TODO: this is a temporary fix to #809.
         // Until we can figure the exact cause of the crash, going with the ivar instead of the setter
 //        self.cancelBlock = nil;

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -63,13 +63,17 @@
 
         if (image) {
             if (self.progressBlock) {
-                self.progressBlock(self.finishedCount,[self.prefetchURLs count]);
+                //CHANGED BY: Jonathan rose see IOS-7986
+                SDWebImagePrefetcherProgressBlock progressBlockCopy = [self.progressBlock copy];
+                progressBlockCopy(self.finishedCount,[self.prefetchURLs count]);
             }
             NSLog(@"Prefetched %@ out of %@", @(self.finishedCount), @(self.prefetchURLs.count));
         }
         else {
             if (self.progressBlock) {
-                self.progressBlock(self.finishedCount,[self.prefetchURLs count]);
+                //CHANGED BY: Jonathan rose see IOS-7986
+                SDWebImagePrefetcherProgressBlock progressBlockCopy = [self.progressBlock copy];
+                progressBlockCopy(self.finishedCount,[self.prefetchURLs count]);
             }
             NSLog(@"Prefetched %@ out of %@ (Failed)", @(self.finishedCount), @(self.prefetchURLs.count));
 
@@ -91,7 +95,9 @@
         else if (self.finishedCount == self.requestedCount) {
             [self reportStatus];
             if (self.completionBlock) {
-                self.completionBlock(self.finishedCount, self.skippedCount);
+                //CHANGED BY: Jonathan rose see IOS-7986
+                SDWebImagePrefetcherCompletionBlock completionBlockCopy = [self.completionBlock copy];
+                completionBlockCopy(self.finishedCount, self.skippedCount);
                 self.completionBlock = nil;
             }
             self.progressBlock = nil;

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -17,6 +17,108 @@
 
 @implementation UIImage (MultiFormat)
 
++ (UIImage *)sd_imageOrientationUp:(UIImage *)image
+{
+    CGImageRef imgRef = image.CGImage;
+    CGFloat width = (CGFloat)CGImageGetWidth(imgRef);
+    CGFloat height = (CGFloat)CGImageGetHeight(imgRef);
+    CGAffineTransform transform = CGAffineTransformIdentity;
+    CGRect bounds = CGRectMake(0, 0, width, height);
+    
+    CGFloat scaleRatio = bounds.size.width / width;
+    CGSize imageSize = CGSizeMake(width, height);
+    CGFloat boundHeight;
+    UIImageOrientation orient = image.imageOrientation;
+    
+    switch(orient) {
+        case UIImageOrientationUp: //EXIF = 1
+            transform = CGAffineTransformIdentity;
+            //shouldSwitchHeightAndWidth = YES;
+            break;
+            
+        case UIImageOrientationUpMirrored: //EXIF = 2
+            transform = CGAffineTransformMakeTranslation(imageSize.width, 0.0);
+            transform = CGAffineTransformScale(transform, -1.0, 1.0);
+            //shouldSwitchHeightAndWidth = YES;
+            break;
+            
+        case UIImageOrientationDown: //EXIF = 3
+            transform = CGAffineTransformMakeTranslation(imageSize.width, imageSize.
+                                                         height);
+            transform = CGAffineTransformRotate(transform, M_PI);
+            //shouldSwitchHeightAndWidth = YES;
+            break;
+            
+        case UIImageOrientationDownMirrored: //EXIF = 4
+            transform = CGAffineTransformMakeTranslation(0.0, imageSize.height);
+            transform = CGAffineTransformScale(transform, 1.0, -1.0);
+            //shouldSwitchHeightAndWidth = YES;
+            break;
+            
+        case UIImageOrientationLeftMirrored: //EXIF = 5
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(imageSize.height, imageSize.width);
+            transform = CGAffineTransformScale(transform, -1.0, 1.0);
+            transform = CGAffineTransformRotate(transform, 3.0 * M_PI_2);
+            break;
+            
+        case UIImageOrientationLeft: //EXIF = 6
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(0.0, imageSize.width);
+            transform = CGAffineTransformRotate(transform, 3.0 * M_PI_2);
+            break;
+            
+        case UIImageOrientationRightMirrored: //EXIF = 7
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeScale(-1.0, 1.0);
+            transform = CGAffineTransformRotate(transform, M_PI_2);
+            break;
+            
+        case UIImageOrientationRight: //EXIF = 8
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(imageSize.height, 0.0);
+            transform = CGAffineTransformRotate(transform, M_PI_2);
+            break;
+            
+        default:
+            break;
+    }
+    
+    UIGraphicsBeginImageContext(bounds.size);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+    CGContextSetShouldAntialias(context, YES);
+    
+    if (orient == UIImageOrientationRight || orient == UIImageOrientationLeft)
+    {
+        CGContextScaleCTM(context, -scaleRatio, scaleRatio);
+        CGContextTranslateCTM(context, -height, 0);
+    }
+    else
+    {
+        CGContextScaleCTM(context, scaleRatio, -scaleRatio);
+        CGContextTranslateCTM(context, 0, -height);
+    }
+    
+    CGContextConcatCTM(context, transform);
+    CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
+    
+    UIImage *imageCopy = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return imageCopy;		//returned as autorelease
+}
+
 + (UIImage *)sd_imageWithData:(NSData *)data {
     if (!data) {
         return nil;
@@ -37,9 +139,7 @@
         image = [[UIImage alloc] initWithData:data];
         UIImageOrientation orientation = [self sd_imageOrientationFromImageData:data];
         if (orientation != UIImageOrientationUp) {
-            image = [UIImage imageWithCGImage:image.CGImage
-                                        scale:image.scale
-                                  orientation:orientation];
+            image = [self sd_imageOrientationUp:image];
         }
     }
 


### PR DESCRIPTION
Content of ChangeLog.txt(track changes manually):
SDWebImage updated to 3.7.3

SDWebImageDownloaderOperation.m:53
SDWebImageDownloaderOperation was given a name for debug purposes

SDWebImageDownloaderOperation.m:122
SDWebImageDownloaderOperation.m:152
SDWebImageDownloaderOperation.m:216
SDWebImageDownloaderOperation.m:236
SDWebImageDownloaderOperation.m:311
SDWebImageDownloaderOperation.m:325
SDWebImageDownloaderOperation.m:405
SDWebImageManager.m:320
SDWebImagePrefetcher.m:65
SDWebImagePrefetcher.m:73
SDWebImagePrefetcher.m:99
blocks that are instance variables are called via a copy

UIImage+MultiFormat.m:20 - UIImage+MultiFormat.m:120
UIImage+MultiFormat.m:142
IOS-8733 | Make sure images are rotated based on their EXIF information

SDImageCache.m:193, SDImageCache.m:197
IOS-8789 - allow calling storeImage:recalculateFromImage:imageData:forKey:toDisk: without an image when there is imageData and recalculate is NO

SDImageCache.m:193-250
IOS-9064 make storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk  return a BFTask
