### PR TITLE
fix: Eliminates accumulated floating point errors.

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -57,12 +57,12 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         durations[i] = frames[i].duration * 1000;
     }
     NSUInteger const gcd = gcdArray(frameCount, durations);
-    __block NSUInteger totalDuration = 0;
+    __block NSTimeInterval totalDuration = 0;
     NSMutableArray<UIImage *> *animatedImages = [NSMutableArray arrayWithCapacity:frameCount];
     [frames enumerateObjectsUsingBlock:^(SDImageFrame * _Nonnull frame, NSUInteger idx, BOOL * _Nonnull stop) {
         UIImage *image = frame.image;
         NSUInteger duration = frame.duration * 1000;
-        totalDuration += duration;
+        totalDuration += frame.duration;
         NSUInteger repeatCount;
         if (gcd) {
             repeatCount = duration / gcd;
@@ -74,7 +74,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         }
     }];
     
-    animatedImage = [UIImage animatedImageWithImages:animatedImages duration:totalDuration / 1000.f];
+    animatedImage = [UIImage animatedImageWithImages:animatedImages duration:totalDuration];
     
 #else
     


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:  fix https://github.com/SDWebImage/SDWebImage/issues/3311

### Pull Request Description

#### Issue
When we calculate totalDuration in [SDImageCoderHelper animatedImageWithFrames:], we have a serious floating point error.
For example, when we calculate totalDuration using an APNG file ( frame.duration is 0.02, frameCount is 313)，the result is 5.947, which should actually be 6.25.

Floating-point errors are caused by:
- frameDuration = [delayTimeUnclampedProp doubleValue]; 169 in SDImageIOAnimatedCoder.m （Floating point machine error）
- totalDuration += duration; 65 in SDImageCoderHelper.m(totalDur
ation should be NSTimeInterval not NSUInteger, NSUInteger duration = frame.duration * 1000 Magnify the error)

#### Fix
Set totalDuration to NSTimeInterval and add directly to frame.duration. 

#### Demo APNG(A White Image)
![直接网络下载A](https://user-images.githubusercontent.com/1916940/147720061-f959da63-734f-4801-a51d-1650351d4c35.png)

