### PR TITLE
Fix #3320 `decodedAndScaledDownImageWithImage` does not render the image completely

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -448,7 +448,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                     float dify = destTile.size.height;
                     destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale;
                     dify -= destTile.size.height;
-                    destTile.origin.y += dify;
+                    destTile.origin.y = MIN(0, destTile.origin.y + dify);
                 }
                 CGContextDrawImage( destContext, destTile, sourceTileImageRef );
                 CGImageRelease( sourceTileImageRef );

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -96,6 +96,25 @@
     expect(decodedImage.size.height).to.equal(1);
 }
 
+- (void)test07ThatDecodeAndScaleDownAlwaysCompleteRendering {
+    // Check that when the height of the image used is not evenly divisible by the height of the tile, the output image can also be rendered completely.
+    
+    UIColor *imageColor = UIColor.blackColor;
+    CGSize imageSize = CGSizeMake(3024, 4032);
+    CGRect imageRect = CGRectMake(0, 0, imageSize.width, imageSize.height);
+    SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] init];
+    format.scale = 1;
+    SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:imageSize format:format];
+    UIImage *image = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+        CGContextSetFillColorWithColor(context, [imageColor CGColor]);
+        CGContextFillRect(context, imageRect);
+    }];
+    
+    UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:20 * 1024 * 1024];
+    UIColor *testColor = [decodedImage sd_colorAtPoint:CGPointMake(0, decodedImage.size.height - 1)];
+    expect(testColor.sd_hexString).equal(imageColor.sd_hexString);
+}
+
 - (void)test08ThatEncodeAlphaImageToJPGWithBackgroundColor {
     NSString *testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"png"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];


### PR DESCRIPTION
… the image completely due to the loss of precision.

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This code is handling the rendering of the last tile if the height of the tile is not equally distributed to the height of the image.

SDImageCoderHelper:451
```
if( y == iterations - 1 && remainder ) {
    float dify = destTile.size.height;
    destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale;
    dify -= destTile.size.height;
    // !!! Problems in this line !!!
    destTile.origin.y += dify;
}
```

Since `sourceTile` is always divisible, there is no loss of precision.

SDImageCoderHelper:417
```
sourceTile.size.height = MAX(1, (int)(tileTotalPixels / sourceTile.size.width));
```

The last `sourceTile` always fills the image just right. 

So when rendering the last tile, `destTile.origin.y` should always be less than or equal to 0 to be correct. If `destTile.origin.y` is greater than 0, the image will not be fully rendered.

