### PR TITLE
Fix imageView blinks with option 'SDImageCacheQueryDiskDataSync'

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -552,51 +552,60 @@ static NSString * _defaultDiskCacheDirectory;
     // 2. in-memory cache miss & diskDataSync
     BOOL shouldQueryDiskSync = ((image && options & SDImageCacheQueryMemoryDataSync) ||
                                 (!image && options & SDImageCacheQueryDiskDataSync));
-    void(^queryDiskBlock)(void) =  ^{
+    NSData* (^queryDiskDataBlock)(void) = ^NSData* {
         if (operation.isCancelled) {
-            if (doneBlock) {
-                doneBlock(nil, nil, SDImageCacheTypeNone);
-            }
-            return;
+            return nil;
         }
         
-        @autoreleasepool {
-            NSData *diskData = [self diskImageDataBySearchingAllPathsForKey:key];
-            UIImage *diskImage;
-            if (image) {
-                // the image is from in-memory cache, but need image data
-                diskImage = image;
-            } else if (diskData) {
-                BOOL shouldCacheToMomery = YES;
-                if (context[SDWebImageContextStoreCacheType]) {
-                    SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
-                    shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
-                }
-                // decode image data only if in-memory cache missed
-                diskImage = [self diskImageForKey:key data:diskData options:options context:context];
-                if (shouldCacheToMomery && diskImage && self.config.shouldCacheImagesInMemory) {
-                    NSUInteger cost = diskImage.sd_memoryCost;
-                    [self.memoryCache setObject:diskImage forKey:key cost:cost];
-                }
+        return [self diskImageDataBySearchingAllPathsForKey:key];
+    };
+    
+    UIImage* (^queryDiskImageBlock)(NSData*) = ^UIImage*(NSData* diskData) {
+        if (operation.isCancelled) {
+            return nil;
+        }
+        
+        UIImage *diskImage;
+        if (image) {
+            // the image is from in-memory cache, but need image data
+            diskImage = image;
+        } else if (diskData) {
+            BOOL shouldCacheToMomery = YES;
+            if (context[SDWebImageContextStoreCacheType]) {
+                SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
+                shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
             }
-            
-            if (doneBlock) {
-                if (shouldQueryDiskSync) {
-                    doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
-                } else {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
-                    });
-                }
+            // decode image data only if in-memory cache missed
+            diskImage = [self diskImageForKey:key data:diskData options:options context:context];
+            if (shouldCacheToMomery && diskImage && self.config.shouldCacheImagesInMemory) {
+                NSUInteger cost = diskImage.sd_memoryCost;
+                [self.memoryCache setObject:diskImage forKey:key cost:cost];
             }
         }
+        return diskImage;
     };
     
     // Query in ioQueue to keep IO-safe
     if (shouldQueryDiskSync) {
-        dispatch_sync(self.ioQueue, queryDiskBlock);
+        __block NSData* diskData;
+        __block UIImage* diskImage;
+        dispatch_sync(self.ioQueue, ^{
+            diskData = queryDiskDataBlock();
+            diskImage = queryDiskImageBlock(diskData);
+        });
+        if (doneBlock) {
+            doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
+        }
     } else {
-        dispatch_async(self.ioQueue, queryDiskBlock);
+        dispatch_async(self.ioQueue, ^{
+            NSData* diskData = queryDiskDataBlock();
+            UIImage* diskImage = queryDiskImageBlock(diskData);
+            if (doneBlock) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
+                });
+            }
+        });
     }
     
     return operation;

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -35,6 +35,30 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)testUIImageViewSetImageWithURLDiskSync {
+    NSData *imageData = [NSData dataWithContentsOfFile:[self testJPEGPath]];
+    
+    // Ensure the image is cached in disk but not memory
+    [SDImageCache.sharedImageCache removeImageFromMemoryForKey:kTestJPEGURL];
+    [SDImageCache.sharedImageCache removeImageFromDiskForKey:kTestJPEGURL];
+    [SDImageCache.sharedImageCache storeImageDataToDisk:imageData forKey:kTestJPEGURL];
+    
+    UIImageView *imageView = [[UIImageView alloc] init];
+    NSURL *originalImageURL = [NSURL URLWithString:kTestJPEGURL];
+    
+    [imageView sd_setImageWithURL:originalImageURL
+                 placeholderImage:nil
+                          options:SDWebImageQueryDiskDataSync
+                        completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+                            expect(image).toNot.beNil();
+                            expect(error).to.beNil();
+                            expect(originalImageURL).to.equal(imageURL);
+                            expect(imageView.image).to.equal(image);
+                        }];
+    expect(imageView.sd_imageURL).equal(originalImageURL);
+    expect(imageView.image).toNot.beNil();
+}
+
 #if SD_UIKIT
 - (void)testUIImageViewSetHighlightedImageWithURL {
     XCTestExpectation *expectation = [self expectationWithDescription:@"UIImageView setHighlightedImageWithURL"];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: https://github.com/SDWebImage/SDWebImage/issues/3042

### Pull Request Description
I expected that when I gave ```SDimageCacheQueryDiskDataSync``` with sd_setImage, the whole disk query process would be synchronous.
```
imageView.sd_setImage(
        with: url,
        options: [.queryDiskDataSync],
        context: nil
 )
```
However, internally, the completion was being called async. And it caused cell blink.


The reason is to perform the queryDiskBlock in ioQueue as shown below.
```
 // Query in ioQueue to keep IO-safe
 if (shouldQueryDiskSync) {
     dispatch_sync(self.ioQueue, queryDiskBlock);
 } else {
     dispatch_async(self.ioQueue, queryDiskBlock);
 }
```
And in the ioQueue, a completion was called with dispatch_main_asyc_safe, which was performed asynchronously.
(jumping to next runloop)

```
dispatch_main_async_safe(^{
    if (completionBlock) {
        completionBlock(image, data, error, cacheType, finished, url);
    }
});
```

![call_stack](https://user-images.githubusercontent.com/36469244/146939883-6426a0ac-8091-43d8-9732-fb30ab40eb9c.jpg)

So I move ```doneBlock (disk Image, disk Data, SDimageCacheTypeDisk)``` outside the ioQueue.

