### PR TITLE
Fix a crash of accessing -[NSScreen backingScaleFactor] from background thread.

### DIFF
--- a/SDWebImage/Core/SDGraphicsImageRenderer.m
+++ b/SDWebImage/Core/SDGraphicsImageRenderer.m
@@ -132,7 +132,13 @@
 #elif SD_UIKIT
             CGFloat screenScale = [UIScreen mainScreen].scale;
 #elif SD_MAC
-            CGFloat screenScale = [NSScreen mainScreen].backingScaleFactor;
+            NSScreen *mainScreen = nil;
+            if (@available(macOS 10.12, *)) {
+                mainScreen = [NSScreen mainScreen];
+            } else {
+                mainScreen = [NSScreen screens].firstObject;
+            }
+            CGFloat screenScale = mainScreen.backingScaleFactor ?: 1.0f;
 #endif
             self.scale = screenScale;
             self.opaque = NO;
@@ -166,7 +172,13 @@
 #elif SD_UIKIT
             CGFloat screenScale = [UIScreen mainScreen].scale;
 #elif SD_MAC
-            CGFloat screenScale = [NSScreen mainScreen].backingScaleFactor;
+            NSScreen *mainScreen = nil;
+            if (@available(macOS 10.12, *)) {
+                mainScreen = [NSScreen mainScreen];
+            } else {
+                mainScreen = [NSScreen screens].firstObject;
+            }
+            CGFloat screenScale = mainScreen.backingScaleFactor ?: 1.0f;
 #endif
             self.scale = screenScale;
             self.opaque = NO;

--- a/SDWebImage/Core/SDImageGraphics.m
+++ b/SDWebImage/Core/SDImageGraphics.m
@@ -17,7 +17,13 @@ static void *kNSGraphicsContextScaleFactorKey;
 static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
     if (scale == 0) {
         // Match `UIGraphicsBeginImageContextWithOptions`, reset to the scale factor of the device’s main screen if scale is 0.
-        scale = [NSScreen mainScreen].backingScaleFactor;
+        NSScreen *mainScreen = nil;
+        if (@available(macOS 10.12, *)) {
+            mainScreen = [NSScreen mainScreen];
+        } else {
+            mainScreen = [NSScreen screens].firstObject;
+        }
+        scale = mainScreen.backingScaleFactor ?: 1.0f;
     }
     size_t width = ceil(size.width * scale);
     size_t height = ceil(size.height * scale);
@@ -106,7 +112,13 @@ UIImage * SDGraphicsGetImageFromCurrentImageContext(void) {
     }
     if (!scale) {
         // reset to the scale factor of the device’s main screen if scale is 0.
-        scale = [NSScreen mainScreen].backingScaleFactor;
+        NSScreen *mainScreen = nil;
+        if (@available(macOS 10.12, *)) {
+            mainScreen = [NSScreen mainScreen];
+        } else {
+            mainScreen = [NSScreen screens].firstObject;
+        }
+        scale = mainScreen.backingScaleFactor ?: 1.0f;
     }
     NSImage *image = [[NSImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
     CGImageRelease(imageRef);

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -28,7 +28,13 @@ inline CGFloat SDImageScaleFactorForKey(NSString * _Nullable key) {
 #elif SD_UIKIT
     if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
 #elif SD_MAC
-    if ([[NSScreen mainScreen] respondsToSelector:@selector(backingScaleFactor)])
+    NSScreen *mainScreen = nil;
+    if (@available(macOS 10.12, *)) {
+        mainScreen = [NSScreen mainScreen];
+    } else {
+        mainScreen = [NSScreen screens].firstObject;
+    }
+    if ([mainScreen respondsToSelector:@selector(backingScaleFactor)])
 #endif
     {
         // a@2x.png -> 8

--- a/SDWebImage/Private/SDImageAssetManager.m
+++ b/SDWebImage/Private/SDImageAssetManager.m
@@ -18,7 +18,13 @@ static NSArray *SDBundlePreferredScales() {
 #elif SD_UIKIT
         CGFloat screenScale = [UIScreen mainScreen].scale;
 #elif SD_MAC
-        CGFloat screenScale = [NSScreen mainScreen].backingScaleFactor;
+      NSScreen *mainScreen = nil;
+      if (@available(macOS 10.12, *)) {
+          mainScreen = [NSScreen mainScreen];
+      } else {
+          mainScreen = [NSScreen screens].firstObject;
+      }
+      CGFloat screenScale = mainScreen.backingScaleFactor ?: 1.0f;
 #endif
         if (screenScale <= 1) {
             scales = @[@1,@2,@3];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

I got the following crash from our production app:
```
Incident Identifier: null
CrashReporter Key:   null
Hardware Model:      null
Code Type:           X86-64 (Native)
Parent Process:      ??? [1]
Date/Time:           2022-01-19 09:06:20.300 +0800
OS Version:          Mac OS X 10.11.6 (15G22010)
Report Version:      11
Exception Type:  EXC_CRASH
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Note: EXC_CORPSE_NOTIFY
Triggered by Thread:  120
Application Specific Information:
abort() called
*** error for object 0x7ff2a3af1e50: double free
Thread 120 Crashed:
0   libsystem_kernel.dylib          0x00007fff87566f06 __pthread_kill + 10
1   libsystem_pthread.dylib         0x00007fff9124c4ec pthread_kill + 90
2   libsystem_c.dylib               0x00007fff912ae77f __abort + 145
3   libsystem_c.dylib               0x00007fff912ae6ee abort + 144
4   libsystem_malloc.dylib          0x00007fff87cbd396 szone_error + 626
5   com.apple.CoreFoundation        0x00007fff8d3d9ea5 CFRelease + 1397
6   com.apple.CoreGraphics          0x00007fff8983bae3 CGSCopyActiveMenuBarDisplayIdentifier + 338
7   com.apple.AppKit                0x00007fff85ea17ad +[NSScreen mainScreen] + 192
8   ***                             0x0000000108e45f89 -[SDGraphicsImageRendererFormat init] (in ***) (SDGraphicsImageRenderer.m:135)
9   ***                             0x0000000108e69250 -[NSImage(Transform) sd_resizedImageWithSize:scaleMode:] (in ***) (UIImage+Transform.m:204)
10  ***                             0x0000000108975d19 -[ImageTransformer transformedImageWithImage:forKey:] (in ***) (ImageImageLoader.m:72)
11  ***                             0x0000000108e64aae __129-[SDWebImageManager callTransformProcessForOperation:url:options:context:originalImage:originalData:finished:progress:completed:]_block_invoke (in ***) (SDWebImageManager.m:534)
12  libdispatch.dylib               0x00007fff8375193d _dispatch_call_block_and_release + 12
13  libdispatch.dylib               0x00007fff8374640b _dispatch_client_callout + 8
14  libdispatch.dylib               0x00007fff8374a29b _dispatch_root_queue_drain + 1890
15  libdispatch.dylib               0x00007fff83749b00 _dispatch_worker_thread3 + 91
16  libsystem_pthread.dylib         0x00007fff912494de _pthread_wqthread + 1129
17  libsystem_pthread.dylib         0x00007fff91247341 start_wqthread + 13
```

`NSScreen` may not be safely accessed on a background thread and here is a fix to this problem.