### PR TITLE
Small performance improvement to generating file URLs in SDDiskCache -setData:forKey:

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -87,7 +87,7 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     // get cache Path for image key
     NSString *cachePathForKey = [self cachePathForKey:key];
     // transform to NSURL
-    NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey];
+    NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey isDirectory:NO];
     
     [data writeToURL:fileURL options:self.config.diskCacheWritingOptions error:nil];
     


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

While experimenting with an app using SDWebImage today I noticed that SDWebImage is using the flavor of `+fileURLWithPath:` that doesn't specify whether or not the path is to a directory or a file. In this case we know that the path is to a file, and the version of `+fileURLWithPath:` where you specify `isDirectory` is faster and requires less i/o than the the one that doesn't.

<img width="1434" alt="Screen Shot 2022-05-12 at 5 12 10 PM" src="https://user-images.githubusercontent.com/522951/168187000-2814ae9a-a51a-45ef-afee-53175a799a1e.png">

I ran some light tests locally comparing the two versions of this method, the change this PR introduces is ~5x faster.

<img width="1125" alt="SDWebImage Perf" src="https://user-images.githubusercontent.com/522951/168187124-6a6e397e-66bd-4b7c-83fc-45f4755ce113.png">
 
The overall magnitude of the speedup isn't tremendous, just fractions of milliseconds, but still it's a small improvement!