### PR TITLE
Fix #3352 Include necessary CoreImage import

### DIFF
--- a/SDWebImage/Core/SDWebImageIndicator.m
+++ b/SDWebImage/Core/SDWebImageIndicator.m
@@ -12,6 +12,7 @@
 
 #if SD_MAC
 #import <QuartzCore/QuartzCore.h>
+#import <CoreImage/CIFilter.h>
 #endif
 
 #pragma mark - Activity Indicator


### PR DESCRIPTION
This merge request fixes / refers to the following issues: #3352

### Pull Request Description

Xcode 14 beta 1 broke compilation because there was no explicit include of `CoreImage` in `SDWebImageIndicator`. This was filed as #3352.
