### PR TITLE
[B] Fixes operations responding in the wrong context

### DIFF
--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -95,6 +95,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             [((SDImageCache *)manager.imageCache) imageFromMemoryCacheForKey:key];
         }
         dispatch_main_async_safe(^{
+            if (![validOperationKey isEqual:self.sd_latestOperationKey]) { return; }
             [self sd_setImage:placeholder imageData:nil basedOnClassOrViaCustomSetImageBlock:setImageBlock cacheType:SDImageCacheTypeNone imageURL:url];
         });
     }
@@ -214,11 +215,13 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             }
 #endif
             dispatch_main_async_safe(^{
+                if ([validOperationKey isEqual:self.sd_latestOperationKey]) {
 #if SD_UIKIT || SD_MAC
-                [self sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
+                    [self sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
 #else
-                [self sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock cacheType:cacheType imageURL:imageURL];
+                    [self sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock cacheType:cacheType imageURL:imageURL];
 #endif
+                }
                 callCompletedBlockClosure();
             });
         }];

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -318,7 +318,30 @@
         [expectation fulfill];
     }];
     [imageView sd_cancelCurrentImageLoad];
-    
+
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)testUIViewCancelShouldNotSetPlaceholder {
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"UIView internalSetImageWithURL call 1"];
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"UIView internalSetImageWithURL call 2"];
+
+    UIView *imageView = [[UIView alloc] init];
+    NSURL *originalImageURL = [NSURL URLWithString:kTestJPEGURL];
+    [SDImageCache.sharedImageCache removeImageFromDiskForKey:kTestJPEGURL];
+    [SDImageCache.sharedImageCache removeImageFromMemoryForKey:kTestJPEGURL];
+
+    [imageView sd_internalSetImageWithURL:originalImageURL placeholderImage:nil options:SDWebImageDelayPlaceholder context:@{ SDWebImageContextSetImageOperationKey: NSUUID.UUID.UUIDString } setImageBlock:^(UIImage * _Nullable image_, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        XCTAssert(NO, @"Should not get called");
+    } progress:nil completed:^(UIImage * _Nullable image_, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        [expectation1 fulfill];
+    }];
+    [imageView sd_cancelCurrentImageLoad];
+
+    [imageView sd_internalSetImageWithURL:originalImageURL placeholderImage:UIImage.new options:0 context:@{ SDWebImageContextSetImageOperationKey: NSUUID.UUID.UUIDString } setImageBlock:nil progress:nil completed:^(UIImage * _Nullable image_, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        [expectation2 fulfill];
+    }];
+
     [self waitForExpectationsWithCommonTimeout];
 }
 


### PR DESCRIPTION
Fixes operations responding in the wrong context, setting previous placeholder on other URLs

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

We encountered problems with rapid calls on `-[UIImageView sd_setImageWithURL:]` which causes wrong images to be assigned to the underlying UIImageView. This happens because we had exactly one async main loop which allows the images to come from the cache the operation already completes but does a few more hops within the main loop. This allows a second call to `setImageWithURL:` to overwrite some behavior with placeholders. Like typically with cells in UIKit I added the necessary checks on the operation key to ensure we're still in the right context to perform actions.

