### PR TITLE
Feature: Change thumbnail cache behavior as expected, share cache through different loading pipeline without extra download

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -373,7 +373,11 @@ static NSString * _defaultDiskCacheDirectory;
         SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
         shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
     }
-    if (diskImage && self.config.shouldCacheImagesInMemory && shouldCacheToMomery) {
+    if (context[SDWebImageContextImageThumbnailPixelSize]) {
+        // Query full size cache key which generate a thumbnail, should not write back to full size memory cache
+        shouldCacheToMomery = NO;
+    }
+    if (shouldCacheToMomery && diskImage && self.config.shouldCacheImagesInMemory) {
         NSUInteger cost = diskImage.sd_memoryCost;
         [self.memoryCache setObject:diskImage forKey:key cost:cost];
     }
@@ -580,6 +584,10 @@ static NSString * _defaultDiskCacheDirectory;
             if (context[SDWebImageContextStoreCacheType]) {
                 SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
                 shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
+            }
+            if (context[SDWebImageContextImageThumbnailPixelSize]) {
+                // Query full size cache key which generate a thumbnail, should not write back to full size memory cache
+                shouldCacheToMomery = NO;
             }
             // decode image data only if in-memory cache missed
             diskImage = [self diskImageForKey:key data:diskData options:options context:context];

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -10,6 +10,7 @@
 #import "SDWebImageCompat.h"
 #import "SDWebImageOperation.h"
 #import "SDWebImageDefine.h"
+#import "SDImageCoder.h"
 
 /// Image Cache Type
 typedef NS_ENUM(NSInteger, SDImageCacheType) {
@@ -53,6 +54,12 @@ typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCach
  @return The decoded image for current image data query from cache
  */
 FOUNDATION_EXPORT UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context);
+
+/// Get the decode options from the loading context options and cache key. This is the built-in translate between the web loading part to the decoding part (which does not depens on).
+/// @param context The options arg from the input
+/// @param options The context arg from the input
+/// @param cacheKey The image cache key from the input. Should not be nil
+FOUNDATION_EXPORT SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext * _Nullable context, SDWebImageOptions options, NSString * _Nonnull cacheKey);
 
 /**
  This is the image cache protocol to provide custom image cache for `SDWebImageManager`.

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -14,6 +14,8 @@
 #import "SDInternalMacros.h"
 
 UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
+    NSCParameterAssert(imageData);
+    NSCParameterAssert(cacheKey);
     UIImage *image;
     BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
     NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
@@ -79,6 +81,8 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         if (shouldDecode) {
             image = [SDImageCoderHelper decodedImageWithImage:image];
         }
+        // mark the image as thumbnail, to let manager check whether to re-decode if needed
+        image.sd_isThumbnail = thumbnailSizeValue != nil;
     }
     
     return image;

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -13,10 +13,7 @@
 #import "UIImage+Metadata.h"
 #import "SDInternalMacros.h"
 
-UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
-    NSCParameterAssert(imageData);
-    NSCParameterAssert(cacheKey);
-    UIImage *image;
+SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext * _Nullable context, SDWebImageOptions options, NSString * _Nonnull cacheKey) {
     BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
     NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
     CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey);
@@ -39,6 +36,17 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
     mutableCoderOptions[SDImageCoderDecodeThumbnailPixelSize] = thumbnailSizeValue;
     mutableCoderOptions[SDImageCoderWebImageContext] = context;
     SDImageCoderOptions *coderOptions = [mutableCoderOptions copy];
+    
+    return coderOptions;
+}
+
+UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
+    NSCParameterAssert(imageData);
+    NSCParameterAssert(cacheKey);
+    UIImage *image;
+    SDImageCoderOptions *coderOptions = SDGetDecodeOptionsFromContext(context, options, cacheKey);
+    BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
+    CGFloat scale = [coderOptions[SDImageCoderDecodeScaleFactor] doubleValue];
     
     // Grab the image coder
     id<SDImageCoder> imageCoder;
@@ -81,8 +89,8 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         if (shouldDecode) {
             image = [SDImageCoderHelper decodedImageWithImage:image];
         }
-        // mark the image as thumbnail, to let manager check whether to re-decode if needed
-        image.sd_isThumbnail = thumbnailSizeValue != nil;
+        // assign the decode options, to let manager check whether to re-decode if needed
+        image.sd_decodeOptions = coderOptions;
     }
     
     return image;

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -311,11 +311,14 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     // Which decode frames in time and reduce memory usage
     if (thumbnailSize.width == 0 || thumbnailSize.height == 0) {
         SDAnimatedImageRep *imageRep = [[SDAnimatedImageRep alloc] initWithData:data];
-        NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
-        imageRep.size = size;
-        NSImage *animatedImage = [[NSImage alloc] initWithSize:size];
-        [animatedImage addRepresentation:imageRep];
-        return animatedImage;
+        if (imageRep) {
+            NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
+            imageRep.size = size;
+            NSImage *animatedImage = [[NSImage alloc] initWithSize:size];
+            [animatedImage addRepresentation:imageRep];
+            animatedImage.sd_imageFormat = self.class.imageFormat;
+            return animatedImage;
+        }
     }
 #endif
     

--- a/SDWebImage/Core/SDImageLoader.m
+++ b/SDWebImage/Core/SDImageLoader.m
@@ -106,6 +106,8 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         if (shouldDecode) {
             image = [SDImageCoderHelper decodedImageWithImage:image];
         }
+        // mark the image as thumbnail, to let manager check whether to re-decode if needed
+        image.sd_isThumbnail = thumbnailSizeValue != nil;
     }
     
     return image;
@@ -204,6 +206,8 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         }
         // mark the image as progressive (completed one are not mark as progressive)
         image.sd_isIncremental = !finished;
+        // mark the image as thumbnail, to let manager check whether to re-decode if needed
+        image.sd_isThumbnail = thumbnailSizeValue != nil;
     }
     
     return image;

--- a/SDWebImage/Core/SDImageLoader.m
+++ b/SDWebImage/Core/SDImageLoader.m
@@ -13,6 +13,7 @@
 #import "SDAnimatedImage.h"
 #import "UIImage+Metadata.h"
 #import "SDInternalMacros.h"
+#import "SDImageCacheDefine.h"
 #import "objc/runtime.h"
 
 SDWebImageContextOption const SDWebImageContextLoaderCachedImage = @"loaderCachedImage";
@@ -41,28 +42,9 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
     } else {
         cacheKey = imageURL.absoluteString;
     }
+    SDImageCoderOptions *coderOptions = SDGetDecodeOptionsFromContext(context, options, cacheKey);
     BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
-    NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
-    CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey);
-    NSNumber *preserveAspectRatioValue = context[SDWebImageContextImagePreserveAspectRatio];
-    NSValue *thumbnailSizeValue;
-    BOOL shouldScaleDown = SD_OPTIONS_CONTAINS(options, SDWebImageScaleDownLargeImages);
-    if (shouldScaleDown) {
-        CGFloat thumbnailPixels = SDImageCoderHelper.defaultScaleDownLimitBytes / 4;
-        CGFloat dimension = ceil(sqrt(thumbnailPixels));
-        thumbnailSizeValue = @(CGSizeMake(dimension, dimension));
-    }
-    if (context[SDWebImageContextImageThumbnailPixelSize]) {
-        thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
-    }
-    
-    SDImageCoderMutableOptions *mutableCoderOptions = [NSMutableDictionary dictionaryWithCapacity:2];
-    mutableCoderOptions[SDImageCoderDecodeFirstFrameOnly] = @(decodeFirstFrame);
-    mutableCoderOptions[SDImageCoderDecodeScaleFactor] = @(scale);
-    mutableCoderOptions[SDImageCoderDecodePreserveAspectRatio] = preserveAspectRatioValue;
-    mutableCoderOptions[SDImageCoderDecodeThumbnailPixelSize] = thumbnailSizeValue;
-    mutableCoderOptions[SDImageCoderWebImageContext] = context;
-    SDImageCoderOptions *coderOptions = [mutableCoderOptions copy];
+    CGFloat scale = [coderOptions[SDImageCoderDecodeScaleFactor] doubleValue];
     
     // Grab the image coder
     id<SDImageCoder> imageCoder;
@@ -106,8 +88,8 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         if (shouldDecode) {
             image = [SDImageCoderHelper decodedImageWithImage:image];
         }
-        // mark the image as thumbnail, to let manager check whether to re-decode if needed
-        image.sd_isThumbnail = thumbnailSizeValue != nil;
+        // assign the decode options, to let manager check whether to re-decode if needed
+        image.sd_decodeOptions = coderOptions;
     }
     
     return image;
@@ -206,8 +188,8 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         }
         // mark the image as progressive (completed one are not mark as progressive)
         image.sd_isIncremental = !finished;
-        // mark the image as thumbnail, to let manager check whether to re-decode if needed
-        image.sd_isThumbnail = thumbnailSizeValue != nil;
+        // assign the decode options, to let manager check whether to re-decode if needed
+        image.sd_decodeOptions = coderOptions;
     }
     
     return image;

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -661,7 +661,7 @@ static id<SDImageLoader> _defaultImageLoader;
         // transformed/thumbnailed cache key
         NSString *key = [self cacheKeyForURL:url context:context];
         [self storeImage:image imageData:cacheData forKey:key imageCache:imageCache cacheType:storeCacheType waitStoreCache:waitStoreCache completion:^{
-            [self callCompletionBlockForOperation:operation completion:completedBlock image:image data:data error:nil cacheType:SDImageCacheTypeNone finished:finished url:url];
+            [self callCompletionBlockForOperation:operation completion:completedBlock image:image data:data error:nil cacheType:cacheType finished:finished url:url];
         }];
     } else {
         [self callCompletionBlockForOperation:operation completion:completedBlock image:image data:data error:nil cacheType:cacheType finished:finished url:url];

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -568,7 +568,8 @@ static id<SDImageLoader> _defaultImageLoader;
     // thumbnail check
     // This exist when previous thumbnail pipeline callback into next full size pipeline, because we share the same URL download but need different image
     // Actually this is a hack, we attach the metadata into image object, which should design a better concept like `ImageInfo` and keep that around
-    BOOL shouldRedecodeFullImage = cacheType == SDImageCacheTypeNone;
+    // Redecode need the full size data (progressive decoding or third-party loaders may callback nil data)
+    BOOL shouldRedecodeFullImage = originalData && cacheType == SDImageCacheTypeNone;
     if (shouldRedecodeFullImage) {
         // If the retuened image decode options exist (some loaders impl does not use `SDImageLoaderDecode`) but does not match the options we provide, redecode
         SDImageCoderOptions *returnedDecodeOptions = originalImage.sd_decodeOptions;

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -65,4 +65,9 @@
  */
 @property (nonatomic, assign) BOOL sd_isIncremental;
 
+/**
+ A bool value indicating whether the image is from thumbnail decoding and may be smaller than the full image data pixel size.
+ */
+@property (nonatomic, assign) BOOL sd_isThumbnail;
+
 @end

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -8,6 +8,7 @@
 
 #import "SDWebImageCompat.h"
 #import "NSData+ImageContentType.h"
+#import "SDImageCoder.h"
 
 /**
  UIImage category for image metadata, including animation, loop count, format, incremental, etc.
@@ -66,8 +67,11 @@
 @property (nonatomic, assign) BOOL sd_isIncremental;
 
 /**
- A bool value indicating whether the image is from thumbnail decoding and may be smaller than the full image data pixel size.
+ A dictionary value contains the decode options when decoded from SDWebImage loading system (say, `SDImageCacheDecodeImageData/SDImageLoaderDecode[Progressive]ImageData`)
+ It may not always available and only image decoding related options will be saved. (including [.decodeScaleFactor, .decodeThumbnailPixelSize, .decodePreserveAspectRatio, .decodeFirstFrameOnly])
+ @note This is used to identify and check the image from downloader when multiple different request (which want different image thumbnail size, image class, etc) share the same URLOperation.
+ @warning This API exist only because of current SDWebImageDownloader bad design which does not callback the context we call it. There will be refactory in future (API break) and you SHOULD NOT rely on this property at all.
  */
-@property (nonatomic, assign) BOOL sd_isThumbnail;
+@property (nonatomic, copy) SDImageCoderOptions *sd_decodeOptions;
 
 @end

--- a/SDWebImage/Core/UIImage+Metadata.m
+++ b/SDWebImage/Core/UIImage+Metadata.m
@@ -186,4 +186,13 @@
     return value.boolValue;
 }
 
+- (void)setSd_isThumbnail:(BOOL)sd_isThumbnail {
+    objc_setAssociatedObject(self, @selector(sd_isThumbnail), @(sd_isThumbnail), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)sd_isThumbnail {
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_isThumbnail));
+    return value.boolValue;
+}
+
 @end

--- a/SDWebImage/Core/UIImage+Metadata.m
+++ b/SDWebImage/Core/UIImage+Metadata.m
@@ -186,13 +186,16 @@
     return value.boolValue;
 }
 
-- (void)setSd_isThumbnail:(BOOL)sd_isThumbnail {
-    objc_setAssociatedObject(self, @selector(sd_isThumbnail), @(sd_isThumbnail), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (void)setSd_decodeOptions:(SDImageCoderOptions *)sd_decodeOptions {
+    objc_setAssociatedObject(self, @selector(sd_decodeOptions), sd_decodeOptions, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
-- (BOOL)sd_isThumbnail {
-    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_isThumbnail));
-    return value.boolValue;
+- (SDImageCoderOptions *)sd_decodeOptions {
+    SDImageCoderOptions *value = objc_getAssociatedObject(self, @selector(sd_decodeOptions));
+    if ([value isKindOfClass:NSDictionary.class]) {
+        return value;
+    }
+    return nil;
 }
 
 @end

--- a/SDWebImage/Private/SDAssociatedObject.m
+++ b/SDWebImage/Private/SDAssociatedObject.m
@@ -18,6 +18,7 @@ void SDImageCopyAssociatedObject(UIImage * _Nullable source, UIImage * _Nullable
     }
     // Image Metadata
     target.sd_isIncremental = source.sd_isIncremental;
+    target.sd_isThumbnail = source.sd_isThumbnail;
     target.sd_imageLoopCount = source.sd_imageLoopCount;
     target.sd_imageFormat = source.sd_imageFormat;
     // Force Decode

--- a/SDWebImage/Private/SDAssociatedObject.m
+++ b/SDWebImage/Private/SDAssociatedObject.m
@@ -18,7 +18,7 @@ void SDImageCopyAssociatedObject(UIImage * _Nullable source, UIImage * _Nullable
     }
     // Image Metadata
     target.sd_isIncremental = source.sd_isIncremental;
-    target.sd_isThumbnail = source.sd_isThumbnail;
+    target.sd_decodeOptions = source.sd_decodeOptions;
     target.sd_imageLoopCount = source.sd_imageLoopCount;
     target.sd_imageFormat = source.sd_imageFormat;
     // Force Decode

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -265,6 +265,7 @@
     NSUInteger defaultLimitBytes = SDImageCoderHelper.defaultScaleDownLimitBytes;
     SDImageCoderHelper.defaultScaleDownLimitBytes = 1000 * 1000 * 4; // Limit 1000x1000 pixel
     // From v5.5.0, the `SDWebImageScaleDownLargeImages` translate to `SDWebImageContextImageThumbnailPixelSize`, and works for progressive loading
+    [SDImageCache.sharedImageCache removeImageFromDiskForKey:originalImageURL.absoluteString];
     [SDWebImageManager.sharedManager loadImageWithURL:originalImageURL options:SDWebImageScaleDownLargeImages | SDWebImageProgressiveLoad progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         expect(image).notTo.beNil();
         expect(image.size).equal(CGSizeMake(1000, 1000));

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -417,6 +417,108 @@
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout * 10 handler:nil];
 }
 
+- (void)test17ThatThumbnailCacheQueryNotWriteToWrongKey {
+    // 1. When query thumbnail decoding for SDImageCache, the thumbnailed image should not stored into full size key
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Thumbnail for cache should not store the wrong key"];
+    
+    // 500x500
+    CGSize fullSize = CGSizeMake(500, 500);
+    SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:fullSize];
+    UIImage *fullSizeImage = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+        CGContextSetRGBFillColor(context, 1.0, 0.0, 0.0, 1.0);
+        CGContextSetRGBStrokeColor(context, 1.0, 0.0, 0.0, 1.0);
+        CGContextFillRect(context, CGRectMake(0, 0, fullSize.width, fullSize.height));
+    }];
+    expect(fullSizeImage.size).equal(fullSize);
+    
+    NSString *fullSizeKey = @"kTestRectangle";
+    // Disk only
+    [SDImageCache.sharedImageCache storeImageDataToDisk:fullSizeImage.sd_imageData forKey:fullSizeKey];
+    
+    CGSize thumbnailSize = CGSizeMake(100, 100);
+    NSString *thumbnailKey = SDThumbnailedKeyForKey(fullSizeKey, thumbnailSize, YES);
+    // thumbnail size key miss, full size key hit
+    [SDImageCache.sharedImageCache queryCacheOperationForKey:fullSizeKey options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+        expect(image.size).equal(thumbnailSize);
+        expect(cacheType).equal(SDImageCacheTypeDisk);
+        // Currently, thumbnail decoding does not write back to the original key's memory cache
+        // But this may change in the future once I change the API for `SDImageCacheProtocol`
+        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:fullSizeKey]).beNil();
+        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey]).beNil();
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test18ThatThumbnailLoadingCanUseFullSizeCache {
+    // 2. When using SDWebImageManager to load thumbnail image, it will prefers the full size image and thumbnail decoding on the fly, no network
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Thumbnail for loading should prefers full size cache when thumbnail cache miss, like Transformer behavior"];
+    
+    // 500x500
+    CGSize fullSize = CGSizeMake(500, 500);
+    SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:fullSize];
+    UIImage *fullSizeImage = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+        CGContextSetRGBFillColor(context, 1.0, 0.0, 0.0, 1.0);
+        CGContextSetRGBStrokeColor(context, 1.0, 0.0, 0.0, 1.0);
+        CGContextFillRect(context, CGRectMake(0, 0, fullSize.width, fullSize.height));
+    }];
+    expect(fullSizeImage.size).equal(fullSize);
+    NSURL *url = [NSURL URLWithString:@"http://via.placeholder.com/500x500.png"];
+    NSString *fullSizeKey = [SDWebImageManager.sharedManager cacheKeyForURL:url];
+    [SDImageCache.sharedImageCache storeImageDataToDisk:fullSizeImage.sd_imageData forKey:fullSizeKey];
+    
+    CGSize thumbnailSize = CGSizeMake(100, 100);
+    NSString *thumbnailKey = SDThumbnailedKeyForKey(fullSizeKey, thumbnailSize, YES);
+    [SDImageCache.sharedImageCache removeImageFromDiskForKey:thumbnailKey];
+    // Load with thumbnail, should use full size cache instead to decode and scale down
+    [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image.size).equal(thumbnailSize);
+        expect(cacheType).equal(SDImageCacheTypeDisk);
+        expect(finished).beTruthy();
+        
+        // The thumbnail one should stored into memory and disk cache with thumbnail key as well
+        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey].size).equal(thumbnailSize);
+        expect([SDImageCache.sharedImageCache imageFromDiskCacheForKey:thumbnailKey].size).equal(thumbnailSize);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test19ThatDifferentThumbnailLoadShouldCallbackDifferentSize {
+    // 3. Current SDWebImageDownloader use the **URL** as primiary key to bind operation, however, different loading pipeline may ask different image size for same URL, this design does not match
+    // We use a hack logic to do a re-decode check when the callback image's decode options does not match the loading pipeline provided, it will re-decode the full data with global queue :)
+    // Ugly unless we re-define the design of SDWebImageDownloader, maybe change that `addHandlersForProgress` with context options args as well. Different context options need different callback image
+    
+    NSURL *url = [NSURL URLWithString:@"http://via.placeholder.com/501x501.png"];
+    NSString *fullSizeKey = [SDWebImageManager.sharedManager cacheKeyForURL:url];
+    [SDImageCache.sharedImageCache removeImageFromDiskForKey:fullSizeKey];
+    for (int i = 490; i < 500; i++) {
+        // 490x490, ..., 499x499
+        CGSize thumbnailSize = CGSizeMake(i, i);
+        NSString *thumbnailKey = SDThumbnailedKeyForKey(fullSizeKey, thumbnailSize, YES);
+        [SDImageCache.sharedImageCache removeImageFromDiskForKey:thumbnailKey];
+        XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"Different thumbnail loading for same URL should callback different image size: (%dx%d)", i, i]];
+        [SDImageCache.sharedImageCache removeImageFromDiskForKey:url.absoluteString];
+        __block SDWebImageCombinedOperation *operation;
+        operation = [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+            expect(image.size).equal(thumbnailSize);
+            expect(cacheType).equal(SDImageCacheTypeNone);
+            expect(finished).beTruthy();
+            
+            NSURLRequest *request = ((SDWebImageDownloadToken *)operation.loaderOperation).request;
+            NSLog(@"thumbnail image size: (%dx%d) loaded with the shared request: %p", i, i, request);
+            [expectation fulfill];
+        }];
+    }
+    
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout * 5 handler:nil];
+}
+
 - (NSString *)testJPEGPath {
     NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Background (Current Bug)

See talk in #3360 

Current (5.10.0-5.12) SDWebImage's [Thumbnail Decoding](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#thumbnail-decoding-550) feature does not work as expected, or can treat as bugs, including:

1. The thumbnail is always query and stored using the `Thumbnail-prefix` cache key, even if there are a full size image data in disk, it still need to download again and again. However, transformer image works as expected and will prefer full size data to do transforming without network.
2. The transformer image from full size disk cache, will always callback with `cacheType = none`, assume it from network. This is logic error.
3. The current `originalStoreCacheType` and `originalQueryCacheType` context options does not take any effect to thumbnail decoding at all. 
4. When query an image with `thumbnailPixelSize` context option, the SDImageCache will automatically cache the **Smaller Size Image** into memory cache, associated with the **Full Size Cache Key**. This is a logic error and will cause next time query a different `thumbnailPixelSize` work unexpected.


This PR aims to fix them all, by go through the design and logic and make things happens as expected (at least, for default context option)

### After Changes

Now, on default context option, the `originalStoreCacheType = .disk && originalQueryCacheType = .all`. Which means, when user only call like this:

```swift
imageView.sd_setImage(with: url, context: [.imageThumbnailPixelSize: CGSize(width: 100, height: 100)]
```

1. Query the `Thumbnail-prefix(100,100)` cache key to get from memory or disk
2. If failed, query the full size cache key to get from memory or disk
3. If query cache miss, continue to download the full size data
4. If query cache hit, skip download and into store cache process
5. If image is thumbnail or transformer, **store the full size data into disk with full size cache key** and **store the thumbnail/transformed small image into memory with `Thumbnail-prefix(100,100)` cache key**
6. If finished, the callback `cacheType` should match where it from

Extra Note:
1. For thumbnail, skip CacheSerializer because the image is thumbnail, the data is full size data, which may cause misunderstanding to user. This need an API break in the future version if we really want to support this.
2. For SDImageCache, when query with thumbnail, the returned image will not stored into memory cache, because we can't ensure that the cache key is thumbnail cache key or full size cache key

### Demo

For example like this. Previouslly each thumbnail will cause an extra **network request** (18 times), now it does not use any network request at all, all done in CPU and Disk.

![screenshot-20220623-173332](https://user-images.githubusercontent.com/6919743/175269857-8dc79c6f-3e8b-4b51-96a6-bffed00056bb.png)

