### PR TITLE
Fix the issue when thumbnail and full size loading at the same time, the thumbnail image will write to memory with wrong key

### DIFF
--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
@@ -69,10 +69,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "SDWebImage Watch Demo Extension/PushNotificationPayload.apns">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SDWebImage iOS Demo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "43A629ED1D0E07600089D7DD"
@@ -80,7 +78,7 @@
             BlueprintName = "SDWebImage Watch Demo"
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -88,10 +86,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SDWebImage iOS Demo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "43A629ED1D0E07600089D7DD"
@@ -99,16 +95,7 @@
             BlueprintName = "SDWebImage Watch Demo"
             ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "43A629ED1D0E07600089D7DD"
-            BuildableName = "SDWebImage Watch Demo.app"
-            BlueprintName = "SDWebImage Watch Demo"
-            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3362

### Pull Request Description

Fix the issue when thumbnail first and full size loading at the same time, the thumbnail image will write to memory with wrong key

The disk cache key is correct and does not get effected by this issue

The bug is introduced from #3362 