### PR TITLE
Fix sd_colorAtPoint and sd_colorsWithRect support for grayscale image (white and alpha)

### DIFF
--- a/Tests/Tests/SDUtilsTests.m
+++ b/Tests/Tests/SDUtilsTests.m
@@ -127,11 +127,18 @@
     SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:size format:format];
     UIColor *color = UIColor.redColor;
     UIImage *image = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
-        [color setFill];
+        CGContextSetFillColorWithColor(context, [color CGColor]);
         CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height));
     }];
     expect(image.scale).equal(format.scale);
-    expect([[image sd_colorAtPoint:CGPointMake(50, 50)].sd_hexString isEqualToString:color.sd_hexString]).beTruthy();
+    expect([image sd_colorAtPoint:CGPointMake(50, 50)].sd_hexString).equal(color.sd_hexString);
+    
+    UIColor *grayscaleColor = UIColor.blackColor;
+    UIImage *grayscaleImage = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+        CGContextSetFillColorWithColor(context, [grayscaleColor CGColor]);
+        CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height));
+    }];
+    expect([grayscaleImage sd_colorAtPoint:CGPointMake(50, 50)].sd_hexString).equal(grayscaleColor.sd_hexString);
 }
 
 - (void)testSDScaledImageForKey {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: `testSDGraphicsImageRenderer`

### Pull Request Description

This fix the test cases for #3368
