### PR TITLE
Fix the unbalanced lock which cause crash

### DIFF
--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -824,6 +824,7 @@ static id<SDImageLoader> _defaultImageLoader;
 - (void)cancel {
     SD_LOCK(_cancelledLock);
     if (_cancelled) {
+        SD_UNLOCK(_cancelledLock);
         return;
     }
     _cancelled = YES;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3393 

### Pull Request Description

This fix the unbalanced of using lock (os_unfair_lock), which will cause crash
