### PR TITLE
Fix the crash using the same synchornized to guard _cancelled status, which need recursive lock

### DIFF
--- a/SDWebImage/Core/SDWebImageManager.h
+++ b/SDWebImage/Core/SDWebImageManager.h
@@ -29,6 +29,9 @@ typedef void(^SDInternalCompletionBlock)(UIImage * _Nullable image, NSData * _Nu
  */
 - (void)cancel;
 
+/// Whether the operation has been cancelled.
+@property (nonatomic, assign, readonly, getter=isCancelled) BOOL cancelled;
+
 /**
  The cache operation from the image cache query
  */

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -803,12 +803,20 @@ static id<SDImageLoader> _defaultImageLoader;
 
 @implementation SDWebImageCombinedOperation
 
+- (BOOL)isCancelled {
+    // Need recursive lock (user's cancel block may check isCancelled), do not use SD_LOCK
+    @synchronized (self) {
+        return _cancelled;
+    }
+}
+
 - (void)cancel {
+    // Need recursive lock (user's cancel block may check isCancelled), do not use SD_LOCK
     @synchronized(self) {
-        if (self.isCancelled) {
+        if (_cancelled) {
             return;
         }
-        self.cancelled = YES;
+        _cancelled = YES;
         if (self.cacheOperation) {
             [self.cacheOperation cancel];
             self.cacheOperation = nil;

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -17,9 +17,7 @@
 static id<SDImageCache> _defaultImageCache;
 static id<SDImageLoader> _defaultImageLoader;
 
-@interface SDWebImageCombinedOperation () {
-    SD_LOCK_DECLARE(_cancelledLock); // a lock to keep the access to `cancelled` thread-safe
-}
+@interface SDWebImageCombinedOperation ()
 
 @property (assign, nonatomic, getter = isCancelled) BOOL cancelled;
 @property (strong, nonatomic, readwrite, nullable) id<SDWebImageOperation> loaderOperation;
@@ -805,39 +803,22 @@ static id<SDImageLoader> _defaultImageLoader;
 
 @implementation SDWebImageCombinedOperation
 
-- (instancetype)init {
-    if (self = [super init]) {
-        SD_LOCK_INIT(_cancelledLock);
-    }
-
-    return self;
-}
-
-- (BOOL)isCancelled {
-    BOOL isCancelled = NO;
-    SD_LOCK(_cancelledLock);
-    isCancelled = _cancelled;
-    SD_UNLOCK(_cancelledLock);
-    return isCancelled;
-}
-
 - (void)cancel {
-    SD_LOCK(_cancelledLock);
-    if (_cancelled) {
-        SD_UNLOCK(_cancelledLock);
-        return;
+    @synchronized(self) {
+        if (self.isCancelled) {
+            return;
+        }
+        self.cancelled = YES;
+        if (self.cacheOperation) {
+            [self.cacheOperation cancel];
+            self.cacheOperation = nil;
+        }
+        if (self.loaderOperation) {
+            [self.loaderOperation cancel];
+            self.loaderOperation = nil;
+        }
+        [self.manager safelyRemoveOperationFromRunning:self];
     }
-    _cancelled = YES;
-    if (self.cacheOperation) {
-        [self.cacheOperation cancel];
-        self.cacheOperation = nil;
-    }
-    if (self.loaderOperation) {
-        [self.loaderOperation cancel];
-        self.loaderOperation = nil;
-    }
-    [self.manager safelyRemoveOperationFromRunning:self];
-    SD_UNLOCK(_cancelledLock);
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Need recursive lock (user's cancel block may check isCancelled), do not use `SD_LOCK`
