### PR TITLE
Introduce SDWebImageContextImageDecodeOptions, deprecate SDImageCoderWebImageContext

### DIFF
--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -13,37 +13,6 @@
 #import "UIImage+Metadata.h"
 #import "SDInternalMacros.h"
 
-static NSArray<NSString *>* GetKnownContextOptions(void) {
-    static NSArray<NSString *> *knownContextOptions;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        knownContextOptions =
-        [NSArray arrayWithObjects:
-         SDWebImageContextSetImageOperationKey,
-         SDWebImageContextCustomManager,
-         SDWebImageContextImageCache,
-         SDWebImageContextImageLoader,
-         SDWebImageContextImageCoder,
-         SDWebImageContextImageTransformer,
-         SDWebImageContextImageScaleFactor,
-         SDWebImageContextImagePreserveAspectRatio,
-         SDWebImageContextImageThumbnailPixelSize,
-         SDWebImageContextQueryCacheType,
-         SDWebImageContextStoreCacheType,
-         SDWebImageContextOriginalQueryCacheType,
-         SDWebImageContextOriginalStoreCacheType,
-         SDWebImageContextOriginalImageCache,
-         SDWebImageContextAnimatedImageClass,
-         SDWebImageContextDownloadRequestModifier,
-         SDWebImageContextDownloadResponseModifier,
-         SDWebImageContextDownloadDecryptor,
-         SDWebImageContextCacheKeyFilter,
-         SDWebImageContextCacheSerializer
-         , nil];
-    });
-    return knownContextOptions;
-}
-
 SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext * _Nullable context, SDWebImageOptions options, NSString * _Nonnull cacheKey) {
     BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
     NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
@@ -62,20 +31,23 @@ SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext *
     NSString *typeIdentifierHint = context[SDWebImageContextImageTypeIdentifierHint];
     NSString *fileExtensionHint = cacheKey.pathExtension; // without dot
     
-    SDImageCoderMutableOptions *mutableCoderOptions = [NSMutableDictionary dictionaryWithCapacity:6];
+    // First check if user provided decode options
+    SDImageCoderMutableOptions *mutableCoderOptions;
+    if (context[SDWebImageContextImageDecodeOptions] != nil) {
+        mutableCoderOptions = [NSMutableDictionary dictionaryWithDictionary:context[SDWebImageContextImageDecodeOptions]];
+    } else {
+        mutableCoderOptions = [NSMutableDictionary dictionaryWithCapacity:6];
+    }
+    
+    // Override individual options
     mutableCoderOptions[SDImageCoderDecodeFirstFrameOnly] = @(decodeFirstFrame);
     mutableCoderOptions[SDImageCoderDecodeScaleFactor] = @(scale);
     mutableCoderOptions[SDImageCoderDecodePreserveAspectRatio] = preserveAspectRatioValue;
     mutableCoderOptions[SDImageCoderDecodeThumbnailPixelSize] = thumbnailSizeValue;
     mutableCoderOptions[SDImageCoderDecodeTypeIdentifierHint] = typeIdentifierHint;
     mutableCoderOptions[SDImageCoderDecodeFileExtensionHint] = fileExtensionHint;
-    // Hack to remove all known context options before SDWebImage 5.14.0
-    SDImageCoderMutableOptions *mutableContext = [NSMutableDictionary dictionaryWithDictionary:context];
-    [mutableContext removeObjectsForKeys:GetKnownContextOptions()];
-    mutableCoderOptions[SDImageCoderWebImageContext] = [mutableContext copy];
-    SDImageCoderOptions *coderOptions = [mutableCoderOptions copy];
     
-    return coderOptions;
+    return [mutableCoderOptions copy];
 }
 
 UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -109,9 +109,9 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeEmbedThumb
  But this may be useful for some custom coders, because some business logic may dependent on things other than image or image data information only.
  Only the unknown context from top-level API (See SDWebImageDefine.h) may be passed in during image loading.
  See `SDWebImageContext` for more detailed information.
- @warning This option will be removed in 5.14.0
+ @warning Deprecated. This does nothing from 5.14.0. Use `SDWebImageContextImageDecodeOptions` to pass additional information in top-level API, and use `SDImageCoderOptions` to retrieve options from coder.
  */
-FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext API_DEPRECATED("The coder component will be seperated from Core subspec in the future. Update your code to not rely on this context option.", macos(10.10, API_TO_BE_DEPRECATED), ios(8.0, API_TO_BE_DEPRECATED), tvos(9.0, API_TO_BE_DEPRECATED), watchos(2.0, API_TO_BE_DEPRECATED));
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext API_DEPRECATED("No longer supported. Use SDWebImageContextDecodeOptions in loader API to provide options. Use SDImageCoderOptions in coder API to retrieve options.", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0));
 
 #pragma mark - Coder
 /**

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -207,7 +207,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
 };
 
 
-#pragma mark - Context Options
+#pragma mark - Manager Context Options
 
 /**
  A String to be used as the operation key for view category to store the image load operation. This is used for view instance which supports different image loading process. If nil, will use the class name as operation key. (NSString *)
@@ -244,6 +244,16 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageC
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageTransformer;
 
+#pragma mark - Image Decoder Context Options
+
+/**
+ A Dictionary (SDImageCoderOptions) value, which pass the extra decoding options to the SDImageCoder. Introduced in SDWebImage 5.14.0
+ You can pass additional decoding related options to the decoder, extensible and control by you. And pay attention this dictionary may be retained by decoded image via `UIImage.sd_decodeOptions` 
+ This context option replace the deprecated `SDImageCoderWebImageContext`, which may cause retain cycle (cache -> image -> options -> context -> cache)
+ @note There are already individual options below like `.imageScaleFactor`, `.imagePreserveAspectRatio`, each of individual options will override the same filed for this dictionary.
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageDecodeOptions;
+
 /**
  A CGFloat raw value which specify the image scale factor. The number should be greater than or equal to 1.0. If not provide or the number is invalid, we will use the cache key to specify the scale factor. (NSNumber)
  */
@@ -270,6 +280,8 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageT
  @note If you really don't want any hint which effect the image result, pass `NSNull.null` instead
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageTypeIdentifierHint;
+
+#pragma mark - Cache Context Options
 
 /**
  A SDImageCacheType raw value which specify the source of cache to query. Specify `SDImageCacheTypeDisk` to query from disk cache only; `SDImageCacheTypeMemory` to query from memory only. And `SDImageCacheTypeAll` to query from both memory cache and disk cache. Specify `SDImageCacheTypeNone` is invalid and totally ignore the cache query.
@@ -308,6 +320,8 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextOrigin
  This can be used to improve animated images rendering performance (especially memory usage on big animated images) with `SDAnimatedImageView` (Class).
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextAnimatedImageClass;
+
+#pragma mark - Download Context Options
 
 /**
  A id<SDWebImageDownloaderRequestModifier> instance to modify the image download request. It's used for downloader to modify the original request from URL and options. If you provide one, it will ignore the `requestModifier` in downloader and use provided one instead. (id<SDWebImageDownloaderRequestModifier>)

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -131,6 +131,7 @@ SDWebImageContextOption const SDWebImageContextImageCache = @"imageCache";
 SDWebImageContextOption const SDWebImageContextImageLoader = @"imageLoader";
 SDWebImageContextOption const SDWebImageContextImageCoder = @"imageCoder";
 SDWebImageContextOption const SDWebImageContextImageTransformer = @"imageTransformer";
+SDWebImageContextOption const SDWebImageContextImageDecodeOptions = @"imageDecodeOptions";
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextImagePreserveAspectRatio = @"imagePreserveAspectRatio";
 SDWebImageContextOption const SDWebImageContextImageThumbnailPixelSize = @"imageThumbnailPixelSize";

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -538,13 +538,16 @@
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout * 5 handler:nil];
 }
 
-- (void)test20ThatContextPassedToLoaderDoesNotContainsBuiltIn {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"The SDImageCoderWebImageContext should contains only unknown context to avoid retain cycle"];
+- (void)test20ThatContextPassDecodeOptionsWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"The SDWebImageContextImageDecodeOptions should passed to the coder"];
     NSURL *url = [NSURL URLWithString:@"http://via.placeholder.com/502x502.png"];
-    [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageScaleFactor : @(2), @"Foo": @"Bar"} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+    SDImageCoderOptions *originalDecodeOptions = @{@"Foo": @"Bar", SDImageCoderDecodeScaleFactor : @(2)}; // This will be override
+    
+    [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageScaleFactor : @(1), SDWebImageContextImageDecodeOptions : originalDecodeOptions} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         SDImageCoderOptions *decodeOptions = image.sd_decodeOptions;
-        SDWebImageContext *retrievedContext = decodeOptions[SDImageCoderWebImageContext];
-        expect(retrievedContext[@"Foo"]).equal(@"Bar");
+        expect(decodeOptions.count).beGreaterThan(originalDecodeOptions.count);
+        expect(decodeOptions[@"Foo"]).equal(@"Bar");
+        expect(decodeOptions[SDImageCoderDecodeScaleFactor]).equal(1);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithCommonTimeout];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This can solve the retain cycle from the scratch, instead of hacking. See more in previous #3420 

And also, all the coders maintained by SDWebImage org and me, has already use the built-in coder options instead of custom web context option, this migration is not hard.

### Additional Reason

This PR is one the way to solve the issue that previous using hack in #3362 
From 5.14.0, if you request like below:

```swift
view.sd_setImage(with: url, options: [], context: [.thumnailPixelSize: CGSize(width: 100, height: 200)])
view.sd_setImage(with: url, options: [], context: [.thumnailPixelSize: CGSize(width: 101, height: 201)])
view.sd_setImage(with: url, options: [], context: [.thumnailPixelSize: CGSize(width: 102, height: 202)])
view.sd_setImage(with: url, options: [], context: [.thumnailPixelSize: CGSize(width: 103, height: 203)])
```

This will actually create 4 individual loading operations if the network speed is not fast enough. This is because the SDWebImageDownloader's design will to take `url + decoding effect` as the key. So these 4 requests can not share the same UIImage as a result, so it can not share the URLSessionTask and decoding pipeline. (Currently 1 operation use 1 decoding pipeline)

In the future if we can break APIs, the `SDWebImageDownloaderOperation` will be removed, and we can share the same URLSessionTask, then dispatch to decode 4 individual decoding request, save bandwidth but loss CPU.