### PR TITLE
Refactor the hack when multiple different thumbnail image requests called at the same time

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -409,7 +409,16 @@ static NSString * _defaultDiskCacheDirectory;
         SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
         shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
     }
-    if (context[SDWebImageContextImageThumbnailPixelSize]) {
+    CGSize thumbnailSize = CGSizeZero;
+    NSValue *thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
+    if (thumbnailSizeValue != nil) {
+#if SD_MAC
+        thumbnailSize = thumbnailSizeValue.sizeValue;
+#else
+        thumbnailSize = thumbnailSizeValue.CGSizeValue;
+#endif
+    }
+    if (thumbnailSize.width > 0 && thumbnailSize.height > 0) {
         // Query full size cache key which generate a thumbnail, should not write back to full size memory cache
         shouldCacheToMomery = NO;
     }
@@ -626,7 +635,16 @@ static NSString * _defaultDiskCacheDirectory;
                 SDImageCacheType cacheType = [context[SDWebImageContextStoreCacheType] integerValue];
                 shouldCacheToMomery = (cacheType == SDImageCacheTypeAll || cacheType == SDImageCacheTypeMemory);
             }
-            if (context[SDWebImageContextImageThumbnailPixelSize]) {
+            CGSize thumbnailSize = CGSizeZero;
+            NSValue *thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
+            if (thumbnailSizeValue != nil) {
+        #if SD_MAC
+                thumbnailSize = thumbnailSizeValue.sizeValue;
+        #else
+                thumbnailSize = thumbnailSizeValue.CGSizeValue;
+        #endif
+            }
+            if (thumbnailSize.width > 0 && thumbnailSize.height > 0) {
                 // Query full size cache key which generate a thumbnail, should not write back to full size memory cache
                 shouldCacheToMomery = NO;
             }

--- a/SDWebImage/Core/SDImageCacheDefine.h
+++ b/SDWebImage/Core/SDImageCacheDefine.h
@@ -55,11 +55,17 @@ typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCach
  */
 FOUNDATION_EXPORT UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context);
 
-/// Get the decode options from the loading context options and cache key. This is the built-in translate between the web loading part to the decoding part (which does not depens on).
-/// @param context The options arg from the input
-/// @param options The context arg from the input
+/// Get the decode options from the loading context options and cache key. This is the built-in translate between the web loading part to the decoding part (which does not depends on).
+/// @param context The context arg from the input
+/// @param options The options arg from the input
 /// @param cacheKey The image cache key from the input. Should not be nil
 FOUNDATION_EXPORT SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext * _Nullable context, SDWebImageOptions options, NSString * _Nonnull cacheKey);
+
+/// Set the decode options to the loading context options. This is the built-in translate between the web loading part from the decoding part (which does not depends on).
+/// @param mutableContext The context arg to override
+/// @param mutableOptions The options arg to override
+/// @param decodeOptions The image decoding options
+FOUNDATION_EXPORT void SDSetDecodeOptionsToContext(SDWebImageMutableContext * _Nonnull mutableContext, SDWebImageOptions * _Nonnull mutableOptions, SDImageCoderOptions * _Nonnull decodeOptions);
 
 /**
  This is the image cache protocol to provide custom image cache for `SDWebImageManager`.

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -31,7 +31,11 @@ SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext *
         thumbnailSizeValue = context[SDWebImageContextImageThumbnailPixelSize];
     }
     NSString *typeIdentifierHint = context[SDWebImageContextImageTypeIdentifierHint];
-    NSString *fileExtensionHint = cacheKey.pathExtension; // without dot
+    NSString *fileExtensionHint;
+    if (!typeIdentifierHint) {
+        // UTI has high priority
+        fileExtensionHint = cacheKey.pathExtension; // without dot
+    }
     
     // First check if user provided decode options
     SDImageCoderMutableOptions *mutableCoderOptions;

--- a/SDWebImage/Core/SDWebImageCacheSerializer.h
+++ b/SDWebImage/Core/SDWebImageCacheSerializer.h
@@ -19,7 +19,7 @@ typedef NSData * _Nullable(^SDWebImageCacheSerializerBlock)(UIImage * _Nonnull i
 
 /// Provide the image data associated to the image and store to disk cache
 /// @param image The loaded image
-/// @param data The original loaded image data
+/// @param data The original loaded image data. May be nil when image is transformed (UIImage.sd_isTransformed = YES)
 /// @param imageURL The image URL
 - (nullable NSData *)cacheDataWithImage:(nonnull UIImage *)image originalData:(nullable NSData *)data imageURL:(nullable NSURL *)imageURL;
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -241,6 +241,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageC
 
 /**
  A id<SDImageTransformer> instance which conforms `SDImageTransformer` protocol. It's used for image transform after the image load finished and store the transformed image to cache. If you provide one, it will ignore the `transformer` in manager and use provided one instead. If you pass NSNull, the transformer feature will be disabled. (id<SDImageTransformer>)
+ @note When this value is used, we will trigger image transform after downloaded, and the callback's data **will be nil** (because this time the data saved to disk does not match the image return to you. If you need full size data, query the cache with full size url key)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageTransformer;
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -269,6 +269,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageP
  A CGSize raw value indicating whether or not to generate the thumbnail images (or bitmap images from vector format). When this value is provided, the decoder will generate a thumbnail image which pixel size is smaller than or equal to (depends the `.imagePreserveAspectRatio`) the value size.
  @note When you pass `.preserveAspectRatio == NO`, the thumbnail image is stretched to match each dimension. When `.preserveAspectRatio == YES`, the thumbnail image's width is limited to pixel size's width, the thumbnail image's height is limited to pixel size's height. For common cases, you can just pass a square size to limit both.
  Defaults to CGSizeZero, which means no thumbnail generation at all. (NSValue)
+ @note When this value is used, we will trigger thumbnail decoding for url, and the callback's data **will be nil** (because this time the data saved to disk does not match the image return to you. If you need full size data, query the cache with full size url key)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageThumbnailPixelSize;
 

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.h
@@ -29,6 +29,10 @@
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                             completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock;
 
+- (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                            completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock
+                        decodeOptions:(nullable SDImageCoderOptions *)decodeOptions;
+
 - (BOOL)cancel:(nullable id)token;
 
 @property (strong, nonatomic, readonly, nullable) NSURLRequest *request;
@@ -159,6 +163,21 @@
  */
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                             completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock;
+
+/**
+ *  Adds handlers for progress and completion, and optional decode options (which need another image other than the initial one). Returns a token that can be passed to -cancel: to cancel this set of
+ *  callbacks.
+ *
+ *  @param progressBlock  the block executed when a new chunk of data arrives.
+ *                        @note the progress block is executed on a background queue
+ *  @param completedBlock the block executed when the download is done.
+ *                        @note the completed block is executed on the main queue for success. If errors are found, there is a chance the block will be executed on a background queue
+ *  @param decodeOptions The optional decode options, used when in thumbnail decoding for current completion block callback. For example, request <url1, {thumbnail: 100x100}> and then <url1, {thumbnail: 200x200}>, we may callback these two completion block with different size.
+ *  @return the token to use to cancel this set of handlers
+ */
+- (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                            completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock
+                        decodeOptions:(nullable SDImageCoderOptions *)decodeOptions;
 
 /**
  *  Cancels a set of callbacks. Once all callbacks are canceled, the operation is cancelled.

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -67,6 +67,11 @@
 @property (nonatomic, assign) BOOL sd_isIncremental;
 
 /**
+ A bool value indicating that the image is transformed from original image, so the image data may not always match original download one.
+ */
+@property (nonatomic, assign) BOOL sd_isTransformed;
+
+/**
  A dictionary value contains the decode options when decoded from SDWebImage loading system (say, `SDImageCacheDecodeImageData/SDImageLoaderDecode[Progressive]ImageData`)
  It may not always available and only image decoding related options will be saved. (including [.decodeScaleFactor, .decodeThumbnailPixelSize, .decodePreserveAspectRatio, .decodeFirstFrameOnly])
  @note This is used to identify and check the image from downloader when multiple different request (which want different image thumbnail size, image class, etc) share the same URLOperation.

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -74,8 +74,9 @@
 /**
  A dictionary value contains the decode options when decoded from SDWebImage loading system (say, `SDImageCacheDecodeImageData/SDImageLoaderDecode[Progressive]ImageData`)
  It may not always available and only image decoding related options will be saved. (including [.decodeScaleFactor, .decodeThumbnailPixelSize, .decodePreserveAspectRatio, .decodeFirstFrameOnly])
- @note This is used to identify and check the image from downloader when multiple different request (which want different image thumbnail size, image class, etc) share the same URLOperation.
- @warning This API exist only because of current SDWebImageDownloader bad design which does not callback the context we call it. There will be refactory in future (API break) and you SHOULD NOT rely on this property at all.
+ @note This is used to identify and check the image is from thumbnail decoding, and the callback's data **will be nil** (because this time the data saved to disk does not match the image return to you. If you need full size data, query the cache with full size url key)
+ @warning You should not store object inside which keep strong reference to image itself, which will cause retain cycle.
+ @warning This API exist only because of current SDWebImageDownloader bad design which does not callback the context we call it. There will be refactor in future (API break), use with caution.
  */
 @property (nonatomic, copy) SDImageCoderOptions *sd_decodeOptions;
 

--- a/SDWebImage/Core/UIImage+Metadata.m
+++ b/SDWebImage/Core/UIImage+Metadata.m
@@ -184,6 +184,15 @@
     return value.boolValue;
 }
 
+- (void)setSd_isTransformed:(BOOL)sd_isTransformed {
+    objc_setAssociatedObject(self, @selector(sd_isTransformed), @(sd_isTransformed), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)sd_isTransformed {
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_isTransformed));
+    return value.boolValue;
+}
+
 - (void)setSd_decodeOptions:(SDImageCoderOptions *)sd_decodeOptions {
     objc_setAssociatedObject(self, @selector(sd_decodeOptions), sd_decodeOptions, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -510,8 +510,8 @@
 
 - (void)test19ThatDifferentThumbnailLoadShouldCallbackDifferentSize {
     // 3. Current SDWebImageDownloader use the **URL** as primiary key to bind operation, however, different loading pipeline may ask different image size for same URL, this design does not match
-    // We use a hack logic to do a re-decode check when the callback image's decode options does not match the loading pipeline provided, it will re-decode the full data with global queue :)
-    // Ugly unless we re-define the design of SDWebImageDownloader, maybe change that `addHandlersForProgress` with context options args as well. Different context options need different callback image
+    // We move the logic into SDWebImageDownloaderOperation, which decode each callback's thumbnail size with different decoding pipeline, and callback independently
+    // Note the progressiveLoad does not support this and always callback first size
     
     NSURL *url = [NSURL URLWithString:@"http://via.placeholder.com/501x501.png"];
     NSString *fullSizeKey = [SDWebImageManager.sharedManager cacheKeyForURL:url];

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -389,6 +389,7 @@
         [SDWebImageManager.sharedManager loadImageWithURL:url options:SDWebImageFromCacheOnly context:@{SDWebImageContextImageTransformer : transformer, SDWebImageContextOriginalQueryCacheType : @(SDImageCacheTypeAll)} progress:nil completed:^(UIImage * _Nullable image2, NSData * _Nullable data2, NSError * _Nullable error2, SDImageCacheType cacheType2, BOOL finished2, NSURL * _Nullable imageURL2) {
             // Get the transformed image
             expect(image2).equal(transformer.testImage);
+            expect(data).beNil(); // Currently, the thumbnailed and transformed image always data is nil, to avoid confuse user (the image and data represent no longer match)
             [SDImageCache.sharedImageCache removeImageFromMemoryForKey:originalKey];
             [SDImageCache.sharedImageCache removeImageFromDiskForKey:originalKey];
             [expectation fulfill];
@@ -417,6 +418,7 @@
        SDWebImageContextStoreCacheType: @(SDImageCacheTypeMemory)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         // Get the transformed image
         expect(image).equal(transformer.testImage);
+        expect(data).beNil(); // Currently, the thumbnailed and transformed image always data is nil, to avoid confuse user (the image and data represent no longer match)
         // Now, the original image is stored into originalCache
         UIImage *originalImage = [originalCache imageFromMemoryCacheForKey:originalKey];
         expect(originalImage.size).equal(CGSizeMake(103, 103));
@@ -487,7 +489,8 @@
     expect(fullSizeImage.size).equal(fullSize);
     NSURL *url = [NSURL URLWithString:@"http://via.placeholder.com/500x500.png"];
     NSString *fullSizeKey = [SDWebImageManager.sharedManager cacheKeyForURL:url];
-    [SDImageCache.sharedImageCache storeImageDataToDisk:fullSizeImage.sd_imageData forKey:fullSizeKey];
+    NSData *fullSizeData = fullSizeImage.sd_imageData;
+    [SDImageCache.sharedImageCache storeImageDataToDisk:fullSizeData forKey:fullSizeKey];
     
     CGSize thumbnailSize = CGSizeMake(100, 100);
     NSString *thumbnailKey = SDThumbnailedKeyForKey(fullSizeKey, thumbnailSize, YES);
@@ -495,6 +498,7 @@
     // Load with thumbnail, should use full size cache instead to decode and scale down
     [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         expect(image.size).equal(thumbnailSize);
+        expect(data).beNil(); // Currently, the thumbnailed and transformed image always data is nil, to avoid confuse user (the image and data represent no longer match)
         expect(cacheType).equal(SDImageCacheTypeDisk);
         expect(finished).beTruthy();
         
@@ -526,6 +530,7 @@
         __block SDWebImageCombinedOperation *operation;
         operation = [SDWebImageManager.sharedManager loadImageWithURL:url options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
             expect(image.size).equal(thumbnailSize);
+            expect(data).beNil(); // Currently, the thumbnailed and transformed image always data is nil, to avoid confuse user (the image and data represent no longer match)
             expect(cacheType).equal(SDImageCacheTypeNone);
             expect(finished).beTruthy();
             

--- a/Tests/Tests/SDWebImageTestDownloadOperation.m
+++ b/Tests/Tests/SDWebImageTestDownloadOperation.m
@@ -67,6 +67,12 @@
 
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                             completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock {
+    return [self addHandlersForProgress:progressBlock completed:completedBlock decodeOptions:nil];
+}
+
+- (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                            completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock
+                        decodeOptions:(nullable SDImageCoderOptions *)decodeOptions {
     if (completedBlock) {
         [self.completedBlocks addObject:completedBlock];
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #3362 

### Pull Request Description


### Reason
This PR try to refactor current massive logic. **Because user may query the same URL multiple times, but with different thumbnail pixel size**.

Demo:

```swift
// assume url1 full size is 1000x1000 PNG
imageView1.sd_setImage(with: url1, options: [], context: [.imageThumbnailPixelSize: CGSize(width: 100, height: 100)])
imageView2.sd_setImage(with: url1, options: [], context: [.imageThumbnailPixelSize: CGSize(width: 200, height: 200)])
imageView3.sd_setImage(with: url1, options: [], context: [.imageThumbnailPixelSize: CGSize(width: 300, height: 300)])
imageView4.sd_setImage(with: url1, options: [], context: [.imageThumbnailPixelSize: CGSize(width: 400, height: 400)])
imageView5.sd_setImage(with: url1, options: [], context: [.imageThumbnailPixelSize: CGSize(width: 500, height: 500)])
```

User expected to show different size of images for each image views, but **Only one actual HTTP request should be sent**

PS: Note [Kingfisher](https://github.com/onevcat/Kingfisher) has this issue as well, this is not what SDWebImage only design bug :)

This breaks the design that `same URL give back the same data and image`, but with `same URL give back the same data, but different image`

Until 6.x, I can not break APIs to solve this design bug from the stratch. So in 5.13 I hack the logic `When we detect this case, we re-decode from full size data just in time, and on arbitery global queue`

However, I dislike this, and this cause performance regression. So this time 5.14, I do the changes below to solve this issue.

### Changes

1. Put the hack logic into SDWebImageDownloadOperation, each different thumbnail image request will have its callback with desired size of image using different decoding call.
2. Progressive Thumbnail decoding (use together) does not have this behavior, because I think progressive thumbnail is really rare and tolerant, people just use the first thumbnail size image for preview and OK.
3. The manager logic refactor with separate steps, focus on clear to understand the complicated logic and maintainess
4. The thumbnail decode/transformed will callback valid image, but with **nil data**, this matches the behavior as wiki pages.


