### PR TITLE
Fix the iOS 12 crash because the underlyingQueue is nil

### DIFF
--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -70,7 +70,7 @@
 
 - (void)didReceiveMemoryWarning:(NSNotification *)notification {
     [_fetchQueue cancelAllOperations];
-    [_fetchQueue addOperationWithBlock:^{
+    NSOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
         NSNumber *currentFrameIndex = @(self.currentFrameIndex);
         SD_LOCK(self->_lock);
         NSArray *keys = self.frameBuffer.allKeys;
@@ -82,6 +82,7 @@
         }
         SD_UNLOCK(self->_lock);
     }];
+    [_fetchQueue addOperation:operation];
 }
 
 #pragma mark - Private

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -104,7 +104,7 @@ typedef NS_ENUM(NSUInteger, SDImageCoderDecodeSolution) {
 + (CGSize)scaledSizeWithImageSize:(CGSize)imageSize scaleSize:(CGSize)scaleSize preserveAspectRatio:(BOOL)preserveAspectRatio shouldScaleUp:(BOOL)shouldScaleUp;
 
 /**
- Return the decoded image by the provided image. This one unlike `CGImageCreateDecoded:`, will not decode the image which contains alpha channel or animated image
+ Return the decoded image by the provided image. This one unlike `CGImageCreateDecoded:`, will not decode the image which contains alpha channel or animated image. On iOS 15+, this may use `UIImage.preparingForDisplay()` to use CMPhoto for better performance than the old solution.
  @param image The image to be decoded
  @return The decoded image
  */


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x]  I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes #3433

### Pull Request Description

Use NSOperation dependency to solve this issue

