### PR TITLE
Fix the missing lock for callbackTokens which may cause thread-safe issue

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -40,12 +40,13 @@
         }
         self.cancelled = YES;
         
-        dispatch_main_async_safe(^{
-            if (self.doneBlock) {
-                self.doneBlock(nil, nil, SDImageCacheTypeNone);
-                self.doneBlock = nil;
-            }
-        });
+        SDImageCacheQueryCompletionBlock doneBlock = self.doneBlock;
+        self.doneBlock = nil;
+        if (doneBlock) {
+            dispatch_main_async_safe(^{
+                doneBlock(nil, nil, SDImageCacheTypeNone);
+            });
+        }
     }
 }
 

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -244,7 +244,10 @@
             self.coderQueue.qualityOfService = NSQualityOfServiceDefault;
         }
         [self.dataTask resume];
-        NSArray<SDWebImageDownloaderOperationToken *> *tokens = [self.callbackTokens copy];
+        NSArray<SDWebImageDownloaderOperationToken *> *tokens;
+        @synchronized (self) {
+            tokens = [self.callbackTokens copy];
+        }
         for (SDWebImageDownloaderOperationToken *token in tokens) {
             if (token.progressBlock) {
                 token.progressBlock(0, NSURLResponseUnknownLength, self.request.URL);

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -158,11 +158,11 @@
             [self.callbackTokens removeObjectIdenticalTo:token];
         }
         SDWebImageDownloaderCompletedBlock completedBlock = ((SDWebImageDownloaderOperationToken *)token).completedBlock;
-        dispatch_main_async_safe(^{
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
                 completedBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorCancelled userInfo:@{NSLocalizedDescriptionKey : @"Operation cancelled by user during sending the request"}], YES);
-            }
-        });
+            });
+        }
     }
     return shouldCancel;
 }
@@ -697,11 +697,12 @@ didReceiveResponse:(NSURLResponse *)response
         tokens = [self.callbackTokens copy];
     }
     for (SDWebImageDownloaderOperationToken *token in tokens) {
-        dispatch_main_async_safe(^{
-            if (token.completedBlock) {
-                token.completedBlock(image, imageData, error, finished);
-            }
-        });
+        SDWebImageDownloaderCompletedBlock completedBlock = token.completedBlock;
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
+                completedBlock(image, imageData, error, finished);
+            });
+        }
     }
 }
 
@@ -710,11 +711,12 @@ didReceiveResponse:(NSURLResponse *)response
                            imageData:(nullable NSData *)imageData
                                error:(nullable NSError *)error
                             finished:(BOOL)finished {
-    dispatch_main_async_safe(^{
-        if (token.completedBlock) {
-            token.completedBlock(image, imageData, error, finished);
-        }
-    });
+    SDWebImageDownloaderCompletedBlock completedBlock = token.completedBlock;
+    if (completedBlock) {
+        dispatch_main_async_safe(^{
+            completedBlock(image, imageData, error, finished);
+        });
+    }
 }
 
 @end

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -672,11 +672,11 @@ static id<SDImageLoader> _defaultImageLoader;
                               cacheType:(SDImageCacheType)cacheType
                                finished:(BOOL)finished
                                     url:(nullable NSURL *)url {
-    dispatch_main_async_safe(^{
-        if (completionBlock) {
+    if (completionBlock) {
+        dispatch_main_async_safe(^{
             completionBlock(image, data, error, cacheType, finished, url);
-        }
-    });
+        });
+    }
 }
 
 - (BOOL)shouldBlockFailedURLWithURL:(nonnull NSURL *)url

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -229,12 +229,12 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 #if SD_UIKIT || SD_MAC
         [self sd_stopImageIndicator];
 #endif
-        dispatch_main_async_safe(^{
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
                 NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}];
                 completedBlock(nil, nil, error, SDImageCacheTypeNone, YES, url);
-            }
-        });
+            });
+        }
     }
     
     return operation;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This fix #3438 fix #3437 fix #3433 (see comments)

#### Reason

That `token` is not locked by the synchonized, so it's not thread safe.

#### Changes

Move block before sending to the main queue

This can avoid some life cycle issue and increase performance

