### PR TITLE
Code garden to change Objc bool from true/false to YES/NO

### DIFF
--- a/SDWebImage/Core/SDAnimatedImagePlayer.m
+++ b/SDWebImage/Core/SDAnimatedImagePlayer.m
@@ -249,9 +249,9 @@
     } else if (self.playbackMode == SDAnimatedImagePlaybackModeBounce ||
                self.playbackMode == SDAnimatedImagePlaybackModeReversedBounce) {
         if (currentFrameIndex == 0) {
-            self.shouldReverse = false;
+            self.shouldReverse = NO;
         } else if (currentFrameIndex == totalFrameCount - 1) {
-            self.shouldReverse = true;
+            self.shouldReverse = YES;
         }
         nextFrameIndex = self.shouldReverse ? (currentFrameIndex - 1) : (currentFrameIndex + 1);
         nextFrameIndex %= totalFrameCount;

--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -518,7 +518,7 @@ didReceiveResponse:(NSURLResponse *)response
     if (dataOperation) {
         @synchronized (dataOperation) {
             // Mark the downloader operation `isCompleted = YES`, no longer re-use this operation when new request comes in
-            SDWebImageDownloaderOperationSetCompleted(dataOperation, true);
+            SDWebImageDownloaderOperationSetCompleted(dataOperation, YES);
         }
     }
     if ([dataOperation respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -477,8 +477,10 @@ didReceiveResponse:(NSURLResponse *)response
                     return;
                 }
                 // When cancelled or transfer finished (`didCompleteWithError`), cancel the progress callback, only completed block is called and enough
-                if (self.isCancelled || SDWebImageDownloaderOperationGetCompleted(self)) {
-                    return;
+                @synchronized (self) {
+                    if (self.isCancelled || SDWebImageDownloaderOperationGetCompleted(self)) {
+                        return;
+                    }
                 }
                 UIImage *image = SDImageLoaderDecodeProgressiveImageData(imageData, self.request.URL, NO, self, [[self class] imageOptionsFromDownloaderOptions:self.options], self.context);
                 if (image) {

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -680,7 +680,7 @@ static BOOL _isCalled;
     player.playbackMode = SDAnimatedImagePlaybackModeBounce;
 
     __block NSInteger i = 0;
-    __block BOOL flag = false;
+    __block BOOL flag = NO;
     __block NSUInteger cnt = 0;
     __weak typeof(imageView) wimageView = imageView;
     [player setAnimationFrameHandler:^(NSUInteger index, UIImage * _Nonnull frame) {
@@ -689,10 +689,10 @@ static BOOL _isCalled;
         
         if (index >= player.totalFrameCount - 1) {
             cnt++;
-            flag = true;
+            flag = YES;
         } else if (cnt != 0 && index == 0) {
             cnt++;
-            flag = false;
+            flag = NO;
         }
         
         if (!flag) {
@@ -745,7 +745,7 @@ static BOOL _isCalled;
             flag = false;
         } else if (index == 0) {
             cnt++;
-            flag = true;
+            flag = YES;
         }
         
         if (flag) {

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -233,7 +233,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [SDImageCache.sharedImageCache removeImageFromDiskForKey:key];
     __block BOOL callced = NO;
     SDImageCacheToken *token = [SDImageCache.sharedImageCache queryCacheOperationForKey:key done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
-        callced = true;
+        callced = YES;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0), dispatch_get_main_queue(), ^{
             [expectation fulfill]; // callback once fulfill once
         });


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The Objc BOOL is typedef to `char` in 32-bit OS. So it's better to use `YES/NO`

```c
#if (TARGET_OS_IPHONE && __LP64__)  ||  TARGET_OS_WATCH
#define OBJC_BOOL_IS_BOOL 1
typedef bool BOOL;
#else
#define OBJC_BOOL_IS_CHAR 1
typedef signed char BOOL; 
#endif
```

Though there are no logic error here in SDWebImage all codebase, it makes the code style clear.

