### PR TITLE
refactor:use SDGraphicsImageRenderer

### DIFF
--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -706,10 +706,13 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
     if (CGImageGetBitsPerPixel(imageRef) != 32 ||
         CGImageGetBitsPerComponent(imageRef) != 8 ||
         !((CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask))) {
-        SDGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
-        [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
-        imageRef = SDGraphicsGetImageFromCurrentImageContext().CGImage;
-        SDGraphicsEndImageContext();
+        SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] init];
+        format.scale = self.scale;
+        format.opaque = NO;
+        SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:self.size format:format];
+        imageRef = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
+            [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
+        }].CGImage;
     }
     
     vImage_Buffer effect = {}, scratch = {};


### PR DESCRIPTION
refactor:use SDGraphicsImageRenderer to render image instead of SDGraphicsBeginImageContextWithOptions/SDGraphicsEndImageContext directly.

as SDGraphicsImageRenderer will use UIGraphicsImageRenderer a better performance api for iOS 10 later

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

