### PR TITLE
Fix the wrong declaration of SDCallbackQueue's block, should be escaping to match GCD block

### DIFF
--- a/SDWebImage/Core/SDCallbackQueue.h
+++ b/SDWebImage/Core/SDCallbackQueue.h
@@ -45,10 +45,10 @@ typedef NS_ENUM(NSUInteger, SDCallbackPolicy) {
 
 /// Submits a block for execution and returns after that block finishes executing.
 /// - Parameter block: The block that contains the work to perform.
-- (void)sync:(nonnull NS_NOESCAPE dispatch_block_t)block;
+- (void)sync:(nonnull dispatch_block_t)block;
 
 /// Schedules a block asynchronously for execution.
 /// - Parameter block: The block that contains the work to perform.
-- (void)async:(nonnull NS_NOESCAPE dispatch_block_t)block;
+- (void)async:(nonnull dispatch_block_t)block;
 
 @end

--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -79,7 +79,7 @@ static void inline SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block
     return queue;
 }
 
-- (void)sync:(nonnull NS_NOESCAPE dispatch_block_t)block {
+- (void)sync:(nonnull dispatch_block_t)block {
     switch (self.policy) {
         case SDCallbackPolicySafeExecute:
             SDSafeExecute(self.queue, block, NO);
@@ -93,7 +93,7 @@ static void inline SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block
     }
 }
 
-- (void)async:(nonnull NS_NOESCAPE dispatch_block_t)block {
+- (void)async:(nonnull dispatch_block_t)block {
     switch (self.policy) {
         case SDCallbackPolicySafeExecute:
             SDSafeExecute(self.queue, block, YES);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This may cause the wrong lifecycle for block (earily release), from user report:

<img width="513" alt="WechatIMG27" src="https://user-images.githubusercontent.com/6919743/220330717-aafa45ec-da37-4f17-a59f-f961e29b913d.png">
