### PR TITLE
Small improvements to SDDiskCache write perf.

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -43,6 +43,8 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     } else {
         self.fileManager = [NSFileManager new];
     }
+  
+    [self createDirectory];
 }
 
 - (BOOL)containsDataForKey:(NSString *)key {
@@ -80,9 +82,6 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
 - (void)setData:(NSData *)data forKey:(NSString *)key {
     NSParameterAssert(data);
     NSParameterAssert(key);
-    if (![self.fileManager fileExistsAtPath:self.diskCachePath]) {
-        [self createDirectory];
-    }
     
     // get cache Path for image key
     NSString *cachePathForKey = [self cachePathForKey:key];


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ X I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This pull request makes some small performance improvements to `SDDiskCache`'s `setData:forKey:` method. Namely it
1. Avoids checking if the cache directory exists on each write and instead just creates on init/migration/clear.
2. Avoid writing the backup metadata flag on each write and instead just applies this to the overall image cache directory.

Each of these was taking ~1-2 10ths of a millisecond per write and hitting the filesystem needlessly.

