### PR TITLE
Try to solve the strange dispatch group crash in SDSafeExecute by removing inline

### DIFF
--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -32,15 +32,17 @@ static void SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Non
     }
     // Check specific to detect queue equal
     void *specific = dispatch_queue_get_specific(queue, SDCallbackQueueKey);
-    void *currentSpecific = dispatch_get_specific(SDCallbackQueueKey);
-    if (specific && currentSpecific && CFGetTypeID(specific) == CFUUIDGetTypeID() && CFGetTypeID(currentSpecific) == CFUUIDGetTypeID() && CFEqual(specific, currentSpecific)) {
-        block();
-    } else {
-        if (async) {
-            dispatch_async(queue, block);
-        } else {
-            dispatch_sync(queue, block);
+    if (specific && CFGetTypeID(specific) == CFUUIDGetTypeID()) {
+        void *currentSpecific = dispatch_get_specific(SDCallbackQueueKey);
+        if (currentSpecific && CFGetTypeID(currentSpecific) == CFUUIDGetTypeID() && CFEqual(specific, currentSpecific)) {
+            block();
+            return;
         }
+    }
+    if (async) {
+        dispatch_async(queue, block);
+    } else {
+        dispatch_sync(queue, block);
     }
 }
 

--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -20,7 +20,9 @@ static void SDReleaseBlock(void *context) {
     CFRelease(context);
 }
 
-static void SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Nonnull block, BOOL async) {
+static void SDSafeExecute(SDCallbackQueue *callbackQueue, dispatch_block_t _Nonnull block, BOOL async) {
+    // Extendc gcd queue's life cycle
+    dispatch_queue_t queue = callbackQueue.queue;
     // Special handle for main queue label only (custom queue can have the same label)
     const char *label = dispatch_queue_get_label(queue);
     if (label && label == dispatch_queue_get_label(dispatch_get_main_queue())) {
@@ -84,7 +86,7 @@ static void SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Non
 - (void)sync:(nonnull dispatch_block_t)block {
     switch (self.policy) {
         case SDCallbackPolicySafeExecute:
-            SDSafeExecute(self.queue, block, NO);
+            SDSafeExecute(self, block, NO);
             break;
         case SDCallbackPolicyDispatch:
             dispatch_sync(self.queue, block);
@@ -98,7 +100,7 @@ static void SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Non
 - (void)async:(nonnull dispatch_block_t)block {
     switch (self.policy) {
         case SDCallbackPolicySafeExecute:
-            SDSafeExecute(self.queue, block, YES);
+            SDSafeExecute(self, block, YES);
             break;
         case SDCallbackPolicyDispatch:
             dispatch_async(self.queue, block);

--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -20,7 +20,7 @@ static void SDReleaseBlock(void *context) {
     CFRelease(context);
 }
 
-static void inline SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Nonnull block, BOOL async) {
+static void SDSafeExecute(dispatch_queue_t _Nonnull queue, dispatch_block_t _Nonnull block, BOOL async) {
     // Special handle for main queue label only (custom queue can have the same label)
     const char *label = dispatch_queue_get_label(queue);
     if (label && label == dispatch_queue_get_label(dispatch_get_main_queue())) {


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3512 

Guessing the queue ARC lifecycle is wrong during some of compiler optimization