### PR TITLE
Add linker settings to prevent warning: `linking against a dylib which is not safe for use in application extensions`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,12 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Core"),
                 .headerSearchPath("Private")
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-application-extension"])
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-application_extension"])
             ]
         ),
         .target(


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)



### Pull Request Description

When linking against `SDWebImage` as a Swift package, there are instances that can cause the following warning: `linking against a dylib which is not safe for use in application extensions`. 

Since this package doesn't actually use disallowed APIs, this PR:
* Forcefully tells the linker that it's okay.
* Sets the local build for `SDWebImage` to fail if we include a disallowed API. 