### PR TITLE
Refactory the logic to handle force decode logic to avoid CA copy frame buffer, introduce SDImageForceDecodePolicy detailed control

### DIFF
--- a/Examples/SDWebImage Demo/DetailViewController.m
+++ b/Examples/SDWebImage Demo/DetailViewController.m
@@ -23,7 +23,9 @@
     }
     [self.imageView sd_setImageWithURL:self.imageURL
                       placeholderImage:nil
-                               options:SDWebImageProgressiveLoad | SDWebImageScaleDownLargeImages];
+                               options:SDWebImageProgressiveLoad | SDWebImageScaleDownLargeImages
+                               context:@{SDWebImageContextImageForceDecodePolicy: @(SDImageForceDecodePolicyNever)}
+    ];
     self.imageView.shouldCustomLoopCount = YES;
     self.imageView.animationRepeatCount = 0;
 }

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -37,8 +37,10 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
      * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
      * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
+     * @note 5.14.0 introduce `SDImageCoderDecodeUseLazyDecoding`, use that for better control from codec, instead of post-processing. Which acts the similar like this option but works for SDAnimatedImage as well (this one does not)
+     * @deprecated Deprecated in v5.17.0, if you don't want force-decode, pass [.imageForceDecodePolicy] = [SDImageForceDecodePolicy.never] in context option
      */
-    SDImageCacheAvoidDecodeImage = 1 << 4,
+    SDImageCacheAvoidDecodeImage API_DEPRECATED("Use SDWebImageContextImageForceDecodePolicy instead", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0)) = 1 << 4,
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produce the static image.
      */

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -883,6 +883,8 @@ static NSString * _defaultDiskCacheDirectory;
 }
 
 #pragma mark - Helper
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (SDWebImageOptions)imageOptionsFromCacheOptions:(SDImageCacheOptions)cacheOptions {
     SDWebImageOptions options = 0;
     if (cacheOptions & SDImageCacheScaleDownLargeImages) options |= SDWebImageScaleDownLargeImages;
@@ -893,6 +895,7 @@ static NSString * _defaultDiskCacheDirectory;
     
     return options;
 }
+#pragma clang diagnostic pop
 
 @end
 
@@ -904,6 +907,8 @@ static NSString * _defaultDiskCacheDirectory;
     return [self queryImageForKey:key options:options context:context cacheType:SDImageCacheTypeAll completion:completionBlock];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context cacheType:(SDImageCacheType)cacheType completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock {
     SDImageCacheOptions cacheOptions = 0;
     if (options & SDWebImageQueryMemoryData) cacheOptions |= SDImageCacheQueryMemoryData;
@@ -917,6 +922,7 @@ static NSString * _defaultDiskCacheDirectory;
     
     return [self queryCacheOperationForKey:key options:cacheOptions context:context cacheType:cacheType done:completionBlock];
 }
+#pragma clang diagnostic pop
 
 - (void)storeImage:(UIImage *)image imageData:(NSData *)imageData forKey:(nullable NSString *)key cacheType:(SDImageCacheType)cacheType completion:(nullable SDWebImageNoParamsBlock)completionBlock {
     [self storeImage:image imageData:imageData forKey:key options:0 context:nil cacheType:cacheType completion:completionBlock];

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -124,6 +124,10 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
     }
     if (image) {
         SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        NSNumber *polivyValue = context[SDWebImageContextImageForceDecodePolicy];
+        if (polivyValue != nil) {
+            policy = polivyValue.unsignedIntegerValue;
+        }
         // TODO: Deprecated, remove in SD 6.0...
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -123,15 +123,15 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         image = [imageCoder decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
-        BOOL shouldDecode = !SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage);
-        BOOL lazyDecode = [coderOptions[SDImageCoderDecodeUseLazyDecoding] boolValue];
-        if (lazyDecode) {
-            // lazyDecode = NO means we should not forceDecode, highest priority
-            shouldDecode = NO;
+        SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        // TODO: Deprecated, remove in SD 6.0...
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if (SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage)) {
+            policy = SDImageForceDecodePolicyNever;
         }
-        if (shouldDecode) {
-            image = [SDImageCoderHelper decodedImageWithImage:image];
-        }
+#pragma clang diagnostic pop
+        image = [SDImageCoderHelper decodedImageWithImage:image policy:policy];
         // assign the decode options, to let manager check whether to re-decode if needed
         image.sd_decodeOptions = coderOptions;
     }

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -20,6 +20,14 @@ typedef NS_ENUM(NSUInteger, SDImageCoderDecodeSolution) {
     SDImageCoderDecodeSolutionUIKit
 };
 
+/// Byte alignment the bytes size with alignment
+/// - Parameters:
+///   - size: The bytes size
+///   - alignment: The alignment, in bytes
+static inline size_t SDByteAlign(size_t size, size_t alignment) {
+    return ((size + (alignment - 1)) / alignment) * alignment;
+}
+
 /**
  Provide some common helper methods for building the image decoder/encoder.
  */
@@ -45,15 +53,31 @@ typedef NS_ENUM(NSUInteger, SDImageCoderDecodeSolution) {
  */
 + (NSArray<SDImageFrame *> * _Nullable)framesFromAnimatedImage:(UIImage * _Nullable)animatedImage NS_SWIFT_NAME(frames(from:));
 
+#pragma mark - Preferred Rendering Format
+/// For coders who use `CGImageCreate`, use the information below to create an effient CGImage which can be render on GPU without Core Animation's extra copy (`CA::Render::copy_image`), which can be debugged using `Color Copied Image` in Xcode Instruments
+/// `CGImageCreate`'s `bytesPerRow`, `space`, `bitmapInfo` params should use the information below.
 /**
  Return the shared device-dependent RGB color space. This follows The Get Rule.
- On iOS, it's created with deviceRGB (if available, use sRGB).
- On macOS, it's from the screen colorspace (if failed, use deviceRGB)
  Because it's shared, you should not retain or release this object.
+ Typically is sRGB, the color space defaults to rendering on Apple's devices.
  
  @return The device-dependent RGB color space
  */
 + (CGColorSpaceRef _Nonnull)colorSpaceGetDeviceRGB CF_RETURNS_NOT_RETAINED;
+
+/**
+ From v5.17.0, this returns the byte alignment used for bytesPerRow(stride) **Preferred from current hardward && OS using runtime detection**
+ Typically is 64, the system page size.
+ @note To calculate the bytesPerRow, use the formula `SDByteAlign(width * (bitsPerPixel / 8), alignment)`
+ */
++ (size_t)preferredByteAlignment;
+
+/**
+ From v5.17.0, this returns the bitmap info **Preferred from current hardward && OS using runtime detection**
+ Typically is pre-multiplied RGBA8888 for alpha image, RGBX8888 for non-alpha image.
+ @param containsAlpha Whether the image to render contains alpha channel
+ */
++ (CGBitmapInfo)preferredBitmapInfo:(BOOL)containsAlpha;
 
 /**
  Check whether CGImage contains alpha channel.

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -72,7 +72,7 @@ static inline size_t SDByteAlign(size_t size, size_t alignment) {
 /**
  Return the shared device-dependent RGB color space. This follows The Get Rule.
  Because it's shared, you should not retain or release this object.
- Typically is sRGB, the color space defaults to rendering on Apple's devices.
+ Typically is sRGB for iOS, screen color space (like Color LCD) for macOS.
  
  @return The device-dependent RGB color space
  */
@@ -80,7 +80,7 @@ static inline size_t SDByteAlign(size_t size, size_t alignment) {
 
 /**
  From v5.17.0, this returns the byte alignment used for bytesPerRow(stride) **Preferred from current hardward && OS using runtime detection**
- Typically is 64, the system page size.
+ Typically is 32, the 8 pixels bytesPerRow.
  @note To calculate the bytesPerRow, use the formula `SDByteAlign(width * (bitsPerPixel / 8), alignment)`
  */
 + (size_t)preferredByteAlignment;

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -41,6 +41,15 @@ static inline size_t SDByteAlign(size_t size, size_t alignment) {
     return ((size + (alignment - 1)) / alignment) * alignment;
 }
 
+/// The pixel format about the information to call `CGImageCreate` suitable for current hardware rendering
+/// 
+typedef struct SDImagePixelFormat {
+    /// Typically is pre-multiplied RGBA8888 for alpha image, RGBX8888 for non-alpha image.
+    CGBitmapInfo bitmapInfo;
+    /// Typically is 32, the 8 pixels bytesPerRow.
+    size_t alignment;
+} SDImagePixelFormat;
+
 /**
  Provide some common helper methods for building the image decoder/encoder.
  */
@@ -79,23 +88,15 @@ static inline size_t SDByteAlign(size_t size, size_t alignment) {
 + (CGColorSpaceRef _Nonnull)colorSpaceGetDeviceRGB CF_RETURNS_NOT_RETAINED;
 
 /**
- From v5.17.0, this returns the byte alignment used for bytesPerRow(stride) **Preferred from current hardward && OS using runtime detection**
- Typically is 32, the 8 pixels bytesPerRow.
- @note To calculate the bytesPerRow, use the formula `SDByteAlign(width * (bitsPerPixel / 8), alignment)`
- */
-+ (size_t)preferredByteAlignment;
-
-/**
- From v5.17.0, this returns the bitmap info **Preferred from current hardward && OS using runtime detection**
- Typically is pre-multiplied RGBA8888 for alpha image, RGBX8888 for non-alpha image.
+ Tthis returns the pixel format **Preferred from current hardward && OS using runtime detection**
  @param containsAlpha Whether the image to render contains alpha channel
  */
-+ (CGBitmapInfo)preferredBitmapInfo:(BOOL)containsAlpha;
++ (SDImagePixelFormat)preferredPixelFormat:(BOOL)containsAlpha;
 
 /**
  Check whether CGImage is hardware supported to rendering on screen, without the trigger of `CA::Render::copy_image`
  You can debug the copied image by using Xcode's `Color Copied Image`, the copied image will turn Cyan and occupy double RAM for bitmap buffer.
- Typically, when the CGImage's using the method above (`colorspace` / `byteAlignment` / `bitmapInfo`) can render withtout the copy.
+ Typically, when the CGImage's using the method above (`colorspace` / `alignment` / `bitmapInfo`) can render withtout the copy.
  */
 + (BOOL)CGImageIsHardwareSupported:(_Nonnull CGImageRef)cgImage;
 

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -80,6 +80,13 @@ static inline size_t SDByteAlign(size_t size, size_t alignment) {
 + (CGBitmapInfo)preferredBitmapInfo:(BOOL)containsAlpha;
 
 /**
+ Check whether CGImage is hardware supported to rendering on screen, without the trigger of `CA::Render::copy_image`
+ You can debug the copied image by using Xcode's `Color Copied Image`, the copied image will turn Cyan and occupy double RAM for bitmap buffer.
+ Typically, when the CGImage's using the method above (`colorspace` / `byteAlignment` / `bitmapInfo`) can render withtout the copy.
+ */
++ (BOOL)CGImageIsHardwareSupported:(_Nonnull CGImageRef)cgImage;
+
+/**
  Check whether CGImage contains alpha channel.
  
  @param cgImage The CGImage

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -816,11 +816,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (image == nil) {
         return NO;
     }
-    // Check policy (never/always)
+    // Check policy (never)
     if (policy == SDImageForceDecodePolicyNever) {
         return NO;
-    } else if (policy == SDImageForceDecodePolicyAlways) {
-        return YES;
     }
     // Avoid extra decode
     if (image.sd_isDecoded) {
@@ -834,17 +832,22 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (image.sd_isVector) {
         return NO;
     }
-    // Check policy (automatic)
-    CGImageRef cgImage = image.CGImage;
-    if (cgImage) {
-        CFStringRef uttype = CGImageGetUTType(cgImage);
-        if (uttype) {
-            // Only ImageIO can set `com.apple.ImageIO.imageSourceTypeIdentifier`
-            return YES;
-        } else {
-            // Now, let's check if the CGImage is hardware supported (not byte-aligned will cause extra copy)
-            BOOL isSupported = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
-            return !isSupported;
+    // Check policy (always)
+    if (policy == SDImageForceDecodePolicyAlways) {
+        return YES;
+    } else {
+        // Check policy (automatic)
+        CGImageRef cgImage = image.CGImage;
+        if (cgImage) {
+            CFStringRef uttype = CGImageGetUTType(cgImage);
+            if (uttype) {
+                // Only ImageIO can set `com.apple.ImageIO.imageSourceTypeIdentifier`
+                return YES;
+            } else {
+                // Now, let's check if the CGImage is hardware supported (not byte-aligned will cause extra copy)
+                BOOL isSupported = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
+                return !isSupported;
+            }
         }
     }
 

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -301,7 +301,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 + (size_t)preferredByteAlignment {
     // https://github.com/path/FastImageCache#byte-alignment
     // A properly aligned bytes-per-row value must be a multiple of 8 pixels × bytes per pixel.
-    // return [SDDeviceHelper cacheLineSize]; // Seems not the CPU cache line size
     return 32;
 }
 

--- a/SDWebImage/Core/SDImageGraphics.m
+++ b/SDWebImage/Core/SDImageGraphics.m
@@ -34,7 +34,6 @@ static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGF
     // Check #3330 for more detail about why this bitmap is choosen.
     // From v5.17.0, use runtime detection of bitmap info instead of hardcode.
     // However, macOS's runtime detection will also call this function, cause recursive, so still hardcode here
-//    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:hasAlpha];
     CGBitmapInfo bitmapInfo;
     if (!opaque) {
         // [NSImage imageWithSize:flipped:drawingHandler:] returns float(16-bits) RGBA8888 on alpha image, which we don't need

--- a/SDWebImage/Core/SDImageGraphics.m
+++ b/SDWebImage/Core/SDImageGraphics.m
@@ -32,14 +32,14 @@ static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGF
     CGColorSpaceRef space = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     // kCGImageAlphaNone is not supported in CGBitmapContextCreate.
     // Check #3330 for more detail about why this bitmap is choosen.
+    // From v5.17.0, use runtime detection of bitmap info instead of hardcode.
+    // However, macOS's runtime detection will also call this function, cause recursive, so still hardcode here
+//    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:hasAlpha];
     CGBitmapInfo bitmapInfo;
     if (!opaque) {
-        // iPhone GPU prefer to use BGRA8888, see: https://forums.raywenderlich.com/t/why-mtlpixelformat-bgra8unorm/53489
-        // BGRA8888
-        bitmapInfo = kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst;
+        // [NSImage imageWithSize:flipped:drawingHandler:] returns float(16-bits) RGBA8888 on alpha image, which we don't need
+        bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast;
     } else {
-        // BGR888 previously works on iOS 8~iOS 14, however, iOS 15+ will result a black image. FB9958017
-        // RGB888
         bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaNoneSkipLast;
     }
     CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, 0, space, bitmapInfo);

--- a/SDWebImage/Core/SDImageLoader.m
+++ b/SDWebImage/Core/SDImageLoader.m
@@ -74,15 +74,15 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         image = [imageCoder decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
-        BOOL shouldDecode = !SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage);
-        BOOL lazyDecode = [coderOptions[SDImageCoderDecodeUseLazyDecoding] boolValue];
-        if (lazyDecode) {
-            // lazyDecode = NO means we should not forceDecode, highest priority
-            shouldDecode = NO;
+        SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        // TODO: Deprecated, remove in SD 6.0...
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if (SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage)) {
+            policy = SDImageForceDecodePolicyNever;
         }
-        if (shouldDecode) {
-            image = [SDImageCoderHelper decodedImageWithImage:image];
-        }
+#pragma clang diagnostic pop
+        image = [SDImageCoderHelper decodedImageWithImage:image policy:policy];
         // assign the decode options, to let manager check whether to re-decode if needed
         image.sd_decodeOptions = coderOptions;
     }
@@ -151,15 +151,15 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         image = [progressiveCoder incrementalDecodedImageWithOptions:coderOptions];
     }
     if (image) {
-        BOOL shouldDecode = !SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage);
-        BOOL lazyDecode = [coderOptions[SDImageCoderDecodeUseLazyDecoding] boolValue];
-        if (lazyDecode) {
-            // lazyDecode = NO means we should not forceDecode, highest priority
-            shouldDecode = NO;
+        SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        // TODO: Deprecated, remove in SD 6.0...
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if (SD_OPTIONS_CONTAINS(options, SDWebImageAvoidDecodeImage)) {
+            policy = SDImageForceDecodePolicyNever;
         }
-        if (shouldDecode) {
-            image = [SDImageCoderHelper decodedImageWithImage:image];
-        }
+#pragma clang diagnostic pop
+        image = [SDImageCoderHelper decodedImageWithImage:image policy:policy];
         // assign the decode options, to let manager check whether to re-decode if needed
         image.sd_decodeOptions = coderOptions;
         // mark the image as progressive (completed one are not mark as progressive)

--- a/SDWebImage/Core/SDImageLoader.m
+++ b/SDWebImage/Core/SDImageLoader.m
@@ -75,6 +75,10 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
     }
     if (image) {
         SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        NSNumber *polivyValue = context[SDWebImageContextImageForceDecodePolicy];
+        if (polivyValue != nil) {
+            policy = polivyValue.unsignedIntegerValue;
+        }
         // TODO: Deprecated, remove in SD 6.0...
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -152,6 +156,10 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
     }
     if (image) {
         SDImageForceDecodePolicy policy = SDImageForceDecodePolicyAutomatic;
+        NSNumber *polivyValue = context[SDWebImageContextImageForceDecodePolicy];
+        if (polivyValue != nil) {
+            policy = polivyValue.unsignedIntegerValue;
+        }
         // TODO: Deprecated, remove in SD 6.0...
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -172,8 +172,9 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
      * However, this process may increase the memory usage as well. If you are experiencing an issue due to excessive memory consumption, This flag can prevent decode the image.
      * @note 5.14.0 introduce `SDImageCoderDecodeUseLazyDecoding`, use that for better control from codec, instead of post-processing. Which acts the similar like this option but works for SDAnimatedImage as well (this one does not)
+     * @deprecated Deprecated in v5.17.0, if you don't want force-decode, pass [.imageForceDecodePolicy] = [SDImageForceDecodePolicy.never] in context option
      */
-    SDWebImageAvoidDecodeImage = 1 << 18,
+    SDWebImageAvoidDecodeImage API_DEPRECATED("Use SDWebImageContextImageForceDecodePolicy instead", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0)) = 1 << 18,
     
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produce the static image.
@@ -255,6 +256,15 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageC
  @note When this value is used, we will trigger image transform after downloaded, and the callback's data **will be nil** (because this time the data saved to disk does not match the image return to you. If you need full size data, query the cache with full size url key)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageTransformer;
+
+#pragma mark - Force Decode Options
+
+/**
+ A  NSNumber instance which store the`SDImageForceDecodePolicy` enum. This is used to control how current image loading should force-decode the decoded image (CGImage, typically). See more what's force-decode means in `SDImageForceDecodePolicy` comment.
+ Defaults to `SDImageForceDecodePolicyAutomatic`, which will detect the input CGImage's metadata, and only force-decode if the input CGImage can not directly render on screen (need extra CoreAnimation Copied Image and increase RAM usage).
+ @note If you want to always the force-decode for this image request, pass `SDImageForceDecodePolicyAlways`, for example, some WebP images which does not created by ImageIO.
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageForceDecodePolicy;
 
 #pragma mark - Image Decoder Context Options
 

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -151,6 +151,7 @@ SDWebImageContextOption const SDWebImageContextImageCache = @"imageCache";
 SDWebImageContextOption const SDWebImageContextImageLoader = @"imageLoader";
 SDWebImageContextOption const SDWebImageContextImageCoder = @"imageCoder";
 SDWebImageContextOption const SDWebImageContextImageTransformer = @"imageTransformer";
+SDWebImageContextOption const SDWebImageContextImageForceDecodePolicy = @"imageForceDecodePolicy";
 SDWebImageContextOption const SDWebImageContextImageDecodeOptions = @"imageDecodeOptions";
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextImagePreserveAspectRatio = @"imagePreserveAspectRatio";

--- a/SDWebImage/Core/SDWebImageDownloader.h
+++ b/SDWebImage/Core/SDWebImageDownloader.h
@@ -74,8 +74,10 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
      * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
+     * @note 5.14.0 introduce `SDImageCoderDecodeUseLazyDecoding`, use that for better control from codec, instead of post-processing. Which acts the similar like this option but works for SDAnimatedImage as well (this one does not)
+     * @deprecated Deprecated in v5.17.0, if you don't want force-decode, pass [.imageForceDecodePolicy] = [SDImageForceDecodePolicy.never] in context option
      */
-    SDWebImageDownloaderAvoidDecodeImage = 1 << 9,
+    SDWebImageDownloaderAvoidDecodeImage API_DEPRECATED("Use SDWebImageContextImageForceDecodePolicy instead", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0)) = 1 << 9,
     
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produce the static image.

--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -288,6 +288,8 @@ void SDWebImageDownloaderOperationSetCompleted(id<SDWebImageDownloaderOperation>
 }
 
 #pragma mark Helper methods
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (SDWebImageOptions)imageOptionsFromDownloaderOptions:(SDWebImageDownloaderOptions)downloadOptions {
     SDWebImageOptions options = 0;
     if (downloadOptions & SDWebImageDownloaderScaleDownLargeImages) options |= SDWebImageScaleDownLargeImages;
@@ -298,6 +300,7 @@ void SDWebImageDownloaderOperationSetCompleted(id<SDWebImageDownloaderOperation>
     
     return options;
 }
+#pragma clang diagnostic pop
 
 - (nullable NSOperation<SDWebImageDownloaderOperation> *)createDownloaderOperationWithUrl:(nonnull NSURL *)url
                                                                                   options:(SDWebImageDownloaderOptions)options
@@ -625,6 +628,8 @@ didReceiveResponse:(NSURLResponse *)response
     return YES;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (id<SDWebImageOperation>)requestImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
     UIImage *cachedImage = context[SDWebImageContextLoaderCachedImage];
     
@@ -651,6 +656,7 @@ didReceiveResponse:(NSURLResponse *)response
     
     return [self downloadImageWithURL:url options:downloaderOptions context:context progress:progressBlock completed:completedBlock];
 }
+#pragma clang diagnostic pop
 
 - (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
     return [self shouldBlockFailedURLWithURL:url error:error options:0 context:nil];

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -671,6 +671,8 @@ didReceiveResponse:(NSURLResponse *)response
 }
 
 #pragma mark Helper methods
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (SDWebImageOptions)imageOptionsFromDownloaderOptions:(SDWebImageDownloaderOptions)downloadOptions {
     SDWebImageOptions options = 0;
     if (downloadOptions & SDWebImageDownloaderScaleDownLargeImages) options |= SDWebImageScaleDownLargeImages;
@@ -681,6 +683,7 @@ didReceiveResponse:(NSURLResponse *)response
     
     return options;
 }
+#pragma clang diagnostic pop
 
 - (BOOL)shouldContinueWhenAppEntersBackground {
     return SD_OPTIONS_CONTAINS(self.options, SDWebImageDownloaderContinueInBackground);

--- a/SDWebImage/Core/UIImage+ForceDecode.h
+++ b/SDWebImage/Core/UIImage+ForceDecode.h
@@ -20,7 +20,7 @@
  -- 2. for non-ImageIO created image (via `CGImageCreate` API), we can ensure it's alignment is suitable to render on screen without copy by CoreAnimation
  @note For coder plugin developer, always use the SDImageCoderHelper's `colorSpaceGetDeviceRGB`/`preferredByteAlignment`/`preferredBitmapInfo:` to create CGImage.
  @note For more information why force decode, see: https://github.com/path/FastImageCache#byte-alignment
- @note The defaults value is calculated based on UIImage's CGImage status. Do not assume it's always work as expected. Set the value to `true` if you don't need force decode
+ @note From v5.17.0, the default value is always NO. Use `SDImageForceDecodePolicy` to control complicated policy.
  */
 @property (nonatomic, assign) BOOL sd_isDecoded;
 

--- a/SDWebImage/Core/UIImage+ForceDecode.h
+++ b/SDWebImage/Core/UIImage+ForceDecode.h
@@ -18,7 +18,7 @@
  Force decode is used for 2 cases:
  -- 1. for ImageIO created image (via `CGImageCreateWithImageSource` SPI), it's lazy and we trigger the decode before rendering
  -- 2. for non-ImageIO created image (via `CGImageCreate` API), we can ensure it's alignment is suitable to render on screen without copy by CoreAnimation
- @note For coder plugin developer, always use the SDImageCoderHelper's `colorSpaceGetDeviceRGB`/`preferredByteAlignment`/`preferredBitmapInfo:` to create CGImage.
+ @note For coder plugin developer, always use the SDImageCoderHelper's `colorSpaceGetDeviceRGB`/`preferredPixelFormat` to create CGImage.
  @note For more information why force decode, see: https://github.com/path/FastImageCache#byte-alignment
  @note From v5.17.0, the default value is always NO. Use `SDImageForceDecodePolicy` to control complicated policy.
  */

--- a/SDWebImage/Core/UIImage+ForceDecode.h
+++ b/SDWebImage/Core/UIImage+ForceDecode.h
@@ -15,6 +15,12 @@
 
 /**
  A bool value indicating whether the image has already been decoded. This can help to avoid extra force decode.
+ Force decode is used for 2 cases:
+ -- 1. for ImageIO created image (via `CGImageCreateWithImageSource` SPI), it's lazy and we trigger the decode before rendering
+ -- 2. for non-ImageIO created image (via `CGImageCreate` API), we can ensure it's alignment is suitable to render on screen without copy by CoreAnimation
+ @note For coder plugin developer, always use the SDImageCoderHelper's `colorSpaceGetDeviceRGB`/`preferredByteAlignment`/`preferredBitmapInfo:` to create CGImage.
+ @note For more information why force decode, see: https://github.com/path/FastImageCache#byte-alignment
+ @note The defaults value is calculated based on UIImage's CGImage status. Do not assume it's always work as expected. Set the value to `true` if you don't need force decode
  */
 @property (nonatomic, assign) BOOL sd_isDecoded;
 

--- a/SDWebImage/Core/UIImage+ForceDecode.m
+++ b/SDWebImage/Core/UIImage+ForceDecode.m
@@ -15,28 +15,7 @@
 
 - (BOOL)sd_isDecoded {
     NSNumber *value = objc_getAssociatedObject(self, @selector(sd_isDecoded));
-    if (value != nil) {
-        return value.boolValue;
-    } else {
-        // Assume only CGImage based can use lazy decoding
-        CGImageRef cgImage = self.CGImage;
-        BOOL isDecoded;
-        if (cgImage) {
-            CFStringRef uttype = CGImageGetUTType(self.CGImage);
-            if (uttype) {
-                // Only ImageIO can set `com.apple.ImageIO.imageSourceTypeIdentifier`
-                isDecoded = NO;
-            } else {
-                // Now, let's check if the CGImage is hardware supported (not byte-aligned will cause extra copy)
-                isDecoded = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
-            }
-        } else {
-            // Assume others as non-decoded
-            isDecoded = NO;
-        }
-        objc_setAssociatedObject(self, @selector(sd_isDecoded), @(isDecoded), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        return isDecoded;
-    }
+    return [value boolValue];
 }
 
 - (void)setSd_isDecoded:(BOOL)sd_isDecoded {

--- a/SDWebImage/Private/SDDeviceHelper.h
+++ b/SDWebImage/Private/SDDeviceHelper.h
@@ -14,6 +14,5 @@
 
 + (NSUInteger)totalMemory;
 + (NSUInteger)freeMemory;
-+ (size_t)cacheLineSize;
 
 @end

--- a/SDWebImage/Private/SDDeviceHelper.h
+++ b/SDWebImage/Private/SDDeviceHelper.h
@@ -14,5 +14,6 @@
 
 + (NSUInteger)totalMemory;
 + (NSUInteger)freeMemory;
++ (size_t)cacheLineSize;
 
 @end

--- a/SDWebImage/Private/SDDeviceHelper.m
+++ b/SDWebImage/Private/SDDeviceHelper.m
@@ -8,6 +8,7 @@
 
 #import "SDDeviceHelper.h"
 #import <mach/mach.h>
+#import <sys/sysctl.h>
 
 @implementation SDDeviceHelper
 
@@ -27,6 +28,20 @@
     kern = host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size);
     if (kern != KERN_SUCCESS) return 0;
     return vm_stat.free_count * page_size;
+}
+
++ (size_t)cacheLineSize {
+    size_t size;
+    sysctlbyname("hw.cachelinesize", NULL, &size, NULL, 0);
+    char *info = malloc(size);
+    sysctlbyname("hw.cachelinesize", info, &size, NULL, 0);
+    if (strlen(info)) {
+        // hardcode
+        return 64;
+    }
+    char *end;
+    long result = strtol(info, &end, 10);
+    return result;
 }
 
 @end

--- a/SDWebImage/Private/SDDeviceHelper.m
+++ b/SDWebImage/Private/SDDeviceHelper.m
@@ -30,18 +30,4 @@
     return vm_stat.free_count * page_size;
 }
 
-+ (size_t)cacheLineSize {
-    size_t size;
-    sysctlbyname("hw.cachelinesize", NULL, &size, NULL, 0);
-    char *info = malloc(size);
-    sysctlbyname("hw.cachelinesize", info, &size, NULL, 0);
-    if (strlen(info)) {
-        // hardcode
-        return 64;
-    }
-    char *end;
-    long result = strtol(info, &end, 10);
-    return result;
-}
-
 @end

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -448,6 +448,62 @@
     expect(data2).notTo.beNil();
 }
 
+- (void)test28ThatNotTriggerCACopyImage {
+    // 10 * 8 pixels, RGBA8888
+    size_t width = 10;
+    size_t height = 8;
+    size_t bitsPerComponent = 8;
+    size_t components = 4;
+    size_t bitsPerPixel = bitsPerComponent * components;
+    size_t bytesPerRow = SDByteAlign(bitsPerPixel / 8 * width, SDImageCoderHelper.preferredByteAlignment);
+    size_t size = bytesPerRow * height;
+    uint8_t bitmap[size];
+    for (size_t i = 0; i < size; i++) {
+        bitmap[i] = 255;
+    }
+    CGColorSpaceRef colorspace = [SDImageCoderHelper colorSpaceGetDeviceRGB];
+    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:YES];
+    CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, bitmap, size, NULL);
+    CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+    BOOL shouldInterpolate = YES;
+    CGColorRenderingIntent intent = kCGRenderingIntentDefault;
+    CGImageRef cgImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorspace, bitmapInfo, provider, NULL, shouldInterpolate, intent);
+    XCTAssert(cgImage);
+    BOOL result = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
+    // Since it's 32 bytes aligned, return false
+    XCTAssertTrue(result);
+}
+
+- (void)test28ThatDoTriggerCACopyImage {
+    // 10 * 8 pixels, RGBA8888
+    size_t width = 10;
+    size_t height = 8;
+    size_t bitsPerComponent = 8;
+    size_t components = 4;
+    size_t bitsPerPixel = bitsPerComponent * components;
+    size_t bytesPerRow = bitsPerPixel / 8 * width;
+    size_t size = bytesPerRow * height;
+    uint8_t bitmap[size];
+    for (size_t i = 0; i < size; i++) {
+        bitmap[i] = 255;
+    }
+    CGColorSpaceRef colorspace = [SDImageCoderHelper colorSpaceGetDeviceRGB];
+    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:YES];
+    CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, bitmap, size, NULL);
+    CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+    BOOL shouldInterpolate = YES;
+    CGColorRenderingIntent intent = kCGRenderingIntentDefault;
+    CGImageRef cgImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorspace, bitmapInfo, provider, NULL, shouldInterpolate, intent);
+    XCTAssert(cgImage);
+    BOOL result = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
+    // Since it's not 32 bytes aligned, return false
+    XCTAssertFalse(result);
+    // Let's force-decode to check again
+    CGImageRef newCGImage = [SDImageCoderHelper CGImageCreateDecoded:cgImage];
+    BOOL newResult = [SDImageCoderHelper CGImageIsHardwareSupported:newCGImage];
+    XCTAssertTrue(newResult);
+}
+
 #pragma mark - Utils
 
 - (void)verifyCoder:(id<SDImageCoder>)coder

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -455,19 +455,21 @@
     size_t bitsPerComponent = 8;
     size_t components = 4;
     size_t bitsPerPixel = bitsPerComponent * components;
-    size_t bytesPerRow = SDByteAlign(bitsPerPixel / 8 * width, SDImageCoderHelper.preferredByteAlignment);
+    size_t bytesPerRow = SDByteAlign(bitsPerPixel / 8 * width, [SDImageCoderHelper preferredPixelFormat:YES].alignment);
     size_t size = bytesPerRow * height;
     uint8_t bitmap[size];
     for (size_t i = 0; i < size; i++) {
         bitmap[i] = 255;
     }
     CGColorSpaceRef colorspace = [SDImageCoderHelper colorSpaceGetDeviceRGB];
-    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:YES];
-    CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, bitmap, size, NULL);
+    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredPixelFormat:YES].bitmapInfo;
+    CFDataRef data = CFDataCreate(NULL, bitmap, size);
     CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+    CFRelease(data);
     BOOL shouldInterpolate = YES;
     CGColorRenderingIntent intent = kCGRenderingIntentDefault;
     CGImageRef cgImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorspace, bitmapInfo, provider, NULL, shouldInterpolate, intent);
+    CGDataProviderRelease(provider);
     XCTAssert(cgImage);
     BOOL result = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
     // Since it's 32 bytes aligned, return true
@@ -500,12 +502,14 @@
         bitmap[i] = 255;
     }
     CGColorSpaceRef colorspace = [SDImageCoderHelper colorSpaceGetDeviceRGB];
-    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredBitmapInfo:YES];
-    CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, bitmap, size, NULL);
+    CGBitmapInfo bitmapInfo = [SDImageCoderHelper preferredPixelFormat:YES].bitmapInfo;
+    CFDataRef data = CFDataCreate(NULL, bitmap, size);
     CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+    CFRelease(data);
     BOOL shouldInterpolate = YES;
     CGColorRenderingIntent intent = kCGRenderingIntentDefault;
     CGImageRef cgImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorspace, bitmapInfo, provider, NULL, shouldInterpolate, intent);
+    CGDataProviderRelease(provider);
     XCTAssert(cgImage);
     BOOL result = [SDImageCoderHelper CGImageIsHardwareSupported:cgImage];
     // Since it's not 32 bytes aligned, return false

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -478,6 +478,7 @@
 #else
     UIImage *image = [[UIImage alloc] initWithCGImage:cgImage scale:1 orientation:UIImageOrientationUp];
 #endif
+    CGImageRelease(cgImage);
     UIImage *newImage = [SDImageCoderHelper decodedImageWithImage:image policy:SDImageForceDecodePolicyAutomatic];
     // Check policy works, since it's supported by CA hardware, which return the input image object, using pointer compare
     XCTAssertTrue(image == newImage);
@@ -515,6 +516,7 @@
 #else
     UIImage *image = [[UIImage alloc] initWithCGImage:cgImage scale:1 orientation:UIImageOrientationUp];
 #endif
+    CGImageRelease(cgImage);
     UIImage *newImage = [SDImageCoderHelper decodedImageWithImage:image policy:SDImageForceDecodePolicyAutomatic];
     // Check policy works, since it's not supported by CA hardware, which return the different image object
     XCTAssertFalse(image == newImage);

--- a/Tests/Tests/SDUtilsTests.m
+++ b/Tests/Tests/SDUtilsTests.m
@@ -124,12 +124,15 @@
     CGSize size = CGSizeMake(100, 100);
     SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:size format:format];
     UIColor *color = UIColor.redColor;
+    NSLog(@"Draw Color ColorSpace: %@", color.CGColor);
     UIImage *image = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {
         CGContextSetFillColorWithColor(context, [color CGColor]);
         CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height));
     }];
     expect(image.scale).equal(format.scale);
-    expect([image sd_colorAtPoint:CGPointMake(50, 50)].sd_hexString).equal(color.sd_hexString);
+    UIColor *testColor = [image sd_colorAtPoint:CGPointMake(50, 50)];
+    NSLog(@"Draw Color ColorSpace: %@", testColor.CGColor);
+    expect(testColor.sd_hexString).equal(color.sd_hexString);
     
     UIColor *grayscaleColor = UIColor.blackColor;
     UIImage *grayscaleImage = [renderer imageWithActions:^(CGContextRef  _Nonnull context) {

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -10,6 +10,7 @@
 #import "SDWebImageTestTransformer.h"
 #import "SDWebImageTestCache.h"
 #import "SDWebImageTestLoader.h"
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 // Keep strong references for object
 @interface SDObjectContainer<ObjectType> : NSObject
@@ -317,7 +318,7 @@
 - (void)test13ThatScaleDownLargeImageEXIFOrientationImage {
     XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageScaleDownLargeImages works on EXIF orientation image"];
     NSURL *originalImageURL = [NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"];
-    [SDWebImageManager.sharedManager loadImageWithURL:originalImageURL options:SDWebImageScaleDownLargeImages | SDWebImageAvoidDecodeImage progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+    [SDWebImageManager.sharedManager loadImageWithURL:originalImageURL options:SDWebImageScaleDownLargeImages progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         expect(image).notTo.beNil();
 #if SD_UIKIT
         UIImageOrientation orientation = [SDImageCoderHelper imageOrientationFromEXIFOrientation:kCGImagePropertyOrientationUpMirrored];
@@ -617,6 +618,39 @@
         [expectation fulfill];
     }];
     
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test22ThatForceDecodePolicyAutomatic {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Automatic policy with ICC profile colorspace image should force-decode"];
+    NSURL *url = [NSURL URLWithString:@"http://photodb.illusdolphin.net/media/15292/browsertest.jpg"];
+    SDImageCoderHelper.defaultDecodeSolution = SDImageCoderDecodeSolutionCoreGraphics; // Temp set
+    [SDWebImageManager.sharedManager loadImageWithURL:url options:SDWebImageFromLoaderOnly context:@{SDWebImageContextImageForceDecodePolicy : @(SDImageForceDecodePolicyAutomatic)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        expect(image.sd_isDecoded).beTruthy();
+        CGImageRef cgImage = image.CGImage;
+        CGColorSpaceRef colorspace = CGImageGetColorSpace(cgImage);
+        expect(colorspace).equal([SDImageCoderHelper colorSpaceGetDeviceRGB]);
+        // Revert back
+        SDImageCoderHelper.defaultDecodeSolution = SDImageCoderDecodeSolutionAutomatic;
+        
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test22ThatForceDecodePolicyAlways {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Always policy with WebP image (libwebp) should force-decode"];
+    NSURL *url = [NSURL URLWithString:@"https://www.gstatic.com/webp/gallery/4.webp"];
+    [SDWebImageManager.sharedManager loadImageWithURL:url options:SDWebImageFromLoaderOnly context:@{SDWebImageContextImageCoder : SDImageWebPCoder.sharedCoder, SDWebImageContextImageForceDecodePolicy : @(SDImageForceDecodePolicyAlways)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        expect(image.sd_isDecoded).beTruthy();
+        CGImageRef cgImage = image.CGImage;
+        CGColorSpaceRef colorspace = CGImageGetColorSpace(cgImage);
+        expect(colorspace).equal([SDImageCoderHelper colorSpaceGetDeviceRGB]);
+        
+        [expectation fulfill];
+    }];
     [self waitForExpectationsWithCommonTimeout];
 }
 

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -298,8 +298,7 @@
     NSUInteger defaultLimitBytes = SDImageCoderHelper.defaultScaleDownLimitBytes;
     SDImageCoderHelper.defaultScaleDownLimitBytes = 1000 * 1000 * 4; // Limit 1000x1000 pixel
     // From v5.5.0, the `SDWebImageScaleDownLargeImages` translate to `SDWebImageContextImageThumbnailPixelSize`, and works for progressive loading
-    [SDImageCache.sharedImageCache removeImageFromDiskForKey:originalImageURL.absoluteString];
-    [SDWebImageManager.sharedManager loadImageWithURL:originalImageURL options:SDWebImageScaleDownLargeImages | SDWebImageProgressiveLoad progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+    [SDWebImageManager.sharedManager loadImageWithURL:originalImageURL options:SDWebImageFromLoaderOnly | SDWebImageScaleDownLargeImages | SDWebImageProgressiveLoad progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
         expect(image).notTo.beNil();
         expect(image.size).equal(CGSizeMake(1000, 1000));
         if (finished) {
@@ -310,7 +309,7 @@
         }
     }];
     
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:^(NSError * _Nullable error) {
+    [self waitForExpectationsWithTimeout:100 handler:^(NSError * _Nullable error) {
         SDImageCoderHelper.defaultScaleDownLimitBytes = defaultLimitBytes;
     }];
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close https://github.com/SDWebImage/SDWebImage/issues/3417

### Reason

This commit: ff6b3b9bb59613d1acde21258d45bfe83bd44fab cause to not force decode on `Non-ImageIO` created CGImage. In theory it's correct because like libwebp-created CGImage has already bitmap buffer in RAM.

However, this change has bad effect on final RAM usage. Because of https://github.com/path/FastImageCache#byte-alignment

When some bad coder (The SDWebImageWebPCoder in that example), does not handle the byte alignment correctly, CoreAnimation will try to copy the bitmap buffer when rendering, cause `2 * bitmap buffer` usage, instead of 1.

You can use Xcode's `Color Copied Image` to find this behavior.
See: 

<img width="1247" alt="image" src="https://github.com/SDWebImage/SDWebImage/assets/6919743/8105acc6-ae6f-4f94-9191-56ff07e597dc">

### Solution

1. SD itself provide the helper function to easily handle the bitmap info and byte alignment, using runtime detection (instead of hardcode). For example, previous hardcode BRRA8888/BGRX8888 is not correct.
2. WebPCoder need update its codebase to byte alignment the CGImage
3. (new) Users can control whether always force-decode, never, or use the automatic smart check provided by us
