### PR TITLE
Fix bug #3564

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -721,7 +721,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             sourceTileImageRef = CGImageCreateWithImageInRect( sourceImageRef, sourceTile );
             if( y == iterations - 1 && remainder ) {
                 float dify = destTile.size.height;
-                destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale;
+                destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale + kDestSeemOverlap;
                 dify -= destTile.size.height;
                 destTile.origin.y = MIN(0, destTile.origin.y + dify);
             }

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -96,11 +96,13 @@
     expect(decodedImage.size.height).to.equal(1);
 }
 
-- (void)test07ThatDecodeAndScaleDownAlwaysCompleteRendering {
+-(void)test07ThatDecodeAndScaleDownAlwaysCompleteRendering {
     // Check that when the height of the image used is not evenly divisible by the height of the tile, the output image can also be rendered completely.
     
+    // Check that when the height of the image used will led to loss of precision. the output image can also be rendered completely,
+    
     UIColor *imageColor = UIColor.blackColor;
-    CGSize imageSize = CGSizeMake(3024, 4032);
+    CGSize imageSize = CGSizeMake(1029, 1029);
     CGRect imageRect = CGRectMake(0, 0, imageSize.width, imageSize.height);
     SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] init];
     format.scale = 1;
@@ -110,9 +112,11 @@
         CGContextFillRect(context, imageRect);
     }];
     
-    UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:20 * 1024 * 1024];
-    UIColor *testColor = [decodedImage sd_colorAtPoint:CGPointMake(0, decodedImage.size.height - 1)];
-    expect(testColor.sd_hexString).equal(imageColor.sd_hexString);
+    UIImage *decodedImage = [UIImage sd_decodedAndScaledDownImageWithImage:image limitBytes:1 * 1024 * 1024];
+    UIColor *testColor1 = [decodedImage sd_colorAtPoint:CGPointMake(0, decodedImage.size.height - 1)];
+    UIColor *testColor2 = [decodedImage sd_colorAtPoint:CGPointMake(0, decodedImage.size.height - 9)];
+    expect(testColor1.sd_hexString).equal(imageColor.sd_hexString);
+    expect(testColor2.sd_hexString).equal(imageColor.sd_hexString);
 }
 
 - (void)test08ThatEncodeAlphaImageToJPGWithBackgroundColor {


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found [#3321 ](https://github.com/SDWebImage/SDWebImage/pull/3321)

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes: [#3564]

### Pull Request Description
## How I fix it:
It's a patch of this PR [#3321 ](https://github.com/SDWebImage/SDWebImage/pull/3321)

In File SDImageCoderHelper.m + 717
```
 destTile.size.height += kDestSeemOverlap;
```
use ```kDestSeemOverlap``` to avoid the loss of precision. but when the original height can not be evenly divided by the target height, use the code below to avoid the content missing.

``` SDImageCoderHelper.m line: 722 -727
if( y == iterations - 1 && remainder ) {
    float dify = destTile.size.height;
    destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale;
    dify -= destTile.size.height;
    destTile.origin.y = MIN(0, destTile.origin.y + dify);
}
```

But in the above code snippet,``` destTile.size. height ``` is not added with kDestSeemOverlap. so It may lead to one-pixel content loss.

so I reference the code line 717, and add an overlay height to destTile.
```destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale + kDestSeemOverlap; ```

## Add test case

Since the test size ```CGSizeMake(1029, 1029)``` contains the edge case of  ```CGSizeMake(3024, 4032)```.

as the PR [#3321 ](https://github.com/SDWebImage/SDWebImage/pull/3321) described: **This code is handling the rendering of the last tile if the height of the tile is not equally distributed to the height of the image.**

I change the data and add a new assert for this PR.
