### PR TITLE
Fix redundant requests for the same url during decoding time

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloader.m
+++ b/SDWebImage/Core/SDWebImageDownloader.m
@@ -21,22 +21,6 @@ NSNotificationName const SDWebImageDownloadStopNotification = @"SDWebImageDownlo
 NSNotificationName const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinishNotification";
 
 static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
-static void * SDWebImageDownloaderOperationKey = &SDWebImageDownloaderOperationKey;
-
-BOOL SDWebImageDownloaderOperationGetCompleted(id<SDWebImageDownloaderOperation> operation) {
-    NSCParameterAssert(operation);
-    NSNumber *value = objc_getAssociatedObject(operation, SDWebImageDownloaderOperationKey);
-    if (value != nil) {
-        return value.boolValue;
-    } else {
-        return NO;
-    }
-}
-
-void SDWebImageDownloaderOperationSetCompleted(id<SDWebImageDownloaderOperation> operation, BOOL isCompleted) {
-    NSCParameterAssert(operation);
-    objc_setAssociatedObject(operation, SDWebImageDownloaderOperationKey, @(isCompleted), OBJC_ASSOCIATION_RETAIN);
-}
 
 @interface SDWebImageDownloadToken ()
 
@@ -239,7 +223,7 @@ void SDWebImageDownloaderOperationSetCompleted(id<SDWebImageDownloaderOperation>
     BOOL shouldNotReuseOperation;
     if (operation) {
         @synchronized (operation) {
-            shouldNotReuseOperation = operation.isFinished || operation.isCancelled || SDWebImageDownloaderOperationGetCompleted(operation);
+            shouldNotReuseOperation = operation.isFinished || operation.isCancelled;
         }
     } else {
         shouldNotReuseOperation = YES;
@@ -518,12 +502,6 @@ didReceiveResponse:(NSURLResponse *)response
     
     // Identify the operation that runs this task and pass it the delegate method
     NSOperation<SDWebImageDownloaderOperation> *dataOperation = [self operationWithTask:task];
-    if (dataOperation) {
-        @synchronized (dataOperation) {
-            // Mark the downloader operation `isCompleted = YES`, no longer re-use this operation when new request comes in
-            SDWebImageDownloaderOperationSetCompleted(dataOperation, YES);
-        }
-    }
     if ([dataOperation respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {
         [dataOperation URLSession:session task:task didCompleteWithError:error];
     }

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -342,19 +342,19 @@
 // Check for unprocessed tokens.
 // if all tokens have been processed call [self done].
 - (void)checkDoneWithImageData:(NSData *)imageData
-                  finisdTokens:(NSArray<SDWebImageDownloaderOperationToken *> *)finisdTokens {
+                finishedTokens:(NSArray<SDWebImageDownloaderOperationToken *> *)finishedTokens {
     NSMutableArray<SDWebImageDownloaderOperationToken *> *tokens;
     @synchronized (self) {
         tokens = [self.callbackTokens mutableCopy];
     }
-    [finisdTokens enumerateObjectsUsingBlock:^(SDWebImageDownloaderOperationToken * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [finishedTokens enumerateObjectsUsingBlock:^(SDWebImageDownloaderOperationToken * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         [tokens removeObjectIdenticalTo:obj];
     }];
     if (tokens.count == 0) {
         [self done];
     } else {
         // If there are new tokens added during the decoding operation, the decoding operation is supplemented with these new tokens.
-        [self startCoderOperationWithImageData:imageData pendingTokens:tokens finishedTokens:finisdTokens];
+        [self startCoderOperationWithImageData:imageData pendingTokens:tokens finishedTokens:finishedTokens];
     }
 }
 
@@ -412,7 +412,7 @@
         }
         // Check for new tokens added during the decode operation.
         [self checkDoneWithImageData:imageData
-                        finisdTokens:[finishedTokens arrayByAddingObjectsFromArray:pendingTokens]];
+                      finishedTokens:[finishedTokens arrayByAddingObjectsFromArray:pendingTokens]];
     };
     if (@available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)) {
         // seems faster than `addOperationWithBlock`

--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -343,18 +343,17 @@
 // if all tokens have been processed call [self done].
 - (void)checkDoneWithImageData:(NSData *)imageData
                 finishedTokens:(NSArray<SDWebImageDownloaderOperationToken *> *)finishedTokens {
-    NSMutableArray<SDWebImageDownloaderOperationToken *> *tokens;
     @synchronized (self) {
-        tokens = [self.callbackTokens mutableCopy];
-    }
-    [finishedTokens enumerateObjectsUsingBlock:^(SDWebImageDownloaderOperationToken * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        [tokens removeObjectIdenticalTo:obj];
-    }];
-    if (tokens.count == 0) {
-        [self done];
-    } else {
-        // If there are new tokens added during the decoding operation, the decoding operation is supplemented with these new tokens.
-        [self startCoderOperationWithImageData:imageData pendingTokens:tokens finishedTokens:finishedTokens];
+        NSMutableArray<SDWebImageDownloaderOperationToken *> *tokens = [self.callbackTokens mutableCopy];
+        [finishedTokens enumerateObjectsUsingBlock:^(SDWebImageDownloaderOperationToken * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            [tokens removeObjectIdenticalTo:obj];
+        }];
+        if (tokens.count == 0) {
+            [self done];
+        } else {
+            // If there are new tokens added during the decoding operation, the decoding operation is supplemented with these new tokens.
+            [self startCoderOperationWithImageData:imageData pendingTokens:tokens finishedTokens:finishedTokens];
+        }
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

fix redundant url requests #3571 

After SDWebImageDownloaderOperation finishes downloading and processing all the current tokens, check if there are any new tokens added during the previous processing. If there are, continue to perform decoding tasks for the newly added tokens until all tasks are completed, then execute [self done].

