### PR TITLE
Expose the data and format when SDAnimatedImageRep created with APNG/GIF/WebP/HEICS

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.h
+++ b/SDWebImage/Core/SDAnimatedImage.h
@@ -88,6 +88,7 @@
 
 /**
  Current animated image format.
+ @note This format is only valid when `animatedImageData` not nil
  */
 @property (nonatomic, assign, readonly) SDImageFormat animatedImageFormat;
 

--- a/SDWebImage/Core/SDAnimatedImageRep.h
+++ b/SDWebImage/Core/SDAnimatedImageRep.h
@@ -10,6 +10,8 @@
 
 #if SD_MAC
 
+#import "NSData+ImageContentType.h"
+
 /**
  A subclass of `NSBitmapImageRep` to fix that GIF duration issue because `NSBitmapImageRep` will reset `NSImageCurrentFrameDuration` by using `kCGImagePropertyGIFDelayTime` but not `kCGImagePropertyGIFUnclampedDelayTime`.
  This also fix the GIF loop count issue, which will use the Netscape standard (See http://www6.uniovi.es/gifanim/gifabout.htm)  to only place once when the `kCGImagePropertyGIFLoopCount` is nil. This is what modern browser's behavior.
@@ -17,6 +19,14 @@
  This also support APNG format using `SDImageAPNGCoder`. Which provide full alpha-channel support and the correct duration match the `kCGImagePropertyAPNGUnclampedDelayTime`.
  */
 @interface SDAnimatedImageRep : NSBitmapImageRep
+
+/// Current animated image format.
+/// @note This format is only valid when `animatedImageData` not nil
+@property (nonatomic, assign, readonly) SDImageFormat animatedImageFormat;
+
+/// This allows to retrive the compressed data like GIF using `sd_imageData` on parent `NSImage`, without re-encoding (waste CPU and RAM)
+/// @note This is typically nonnull when you create with `initWithData:`, even it's marked as weak, because ImageIO retain it
+@property (nonatomic, readonly, nullable, weak) NSData *animatedImageData;
 
 @end
 

--- a/SDWebImage/Core/UIImage+MultiFormat.h
+++ b/SDWebImage/Core/UIImage+MultiFormat.h
@@ -46,6 +46,7 @@
  Encode the current image to the data, the image format is unspecified
 
  @note If the receiver is `SDAnimatedImage`, this will return the animated image data if available. No more extra encoding process.
+ @note For macOS, if the receiver contains only `SDAnimatedImageRep`, this will return the animated image data if available. No more extra encoding process.
  @return The encoded data. If can't encode, return nil
  */
 - (nullable NSData *)sd_imageData;

--- a/SDWebImage/Core/UIImage+MultiFormat.m
+++ b/SDWebImage/Core/UIImage+MultiFormat.m
@@ -32,7 +32,7 @@
 #if SD_MAC
     NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
     NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
-    // Check weak assigned frames firstly
+    // Check weak animated data firstly
     if ([imageRep isKindOfClass:[SDAnimatedImageRep class]]) {
         SDAnimatedImageRep *animatedImageRep = (SDAnimatedImageRep *)imageRep;
         NSData *imageData = [animatedImageRep animatedImageData];

--- a/SDWebImage/Core/UIImage+MultiFormat.m
+++ b/SDWebImage/Core/UIImage+MultiFormat.m
@@ -8,6 +8,7 @@
 
 #import "UIImage+MultiFormat.h"
 #import "SDImageCodersManager.h"
+#import "SDAnimatedImageRep.h"
 
 @implementation UIImage (MultiFormat)
 
@@ -28,6 +29,18 @@
 }
 
 - (nullable NSData *)sd_imageData {
+#if SD_MAC
+    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
+    // Check weak assigned frames firstly
+    if ([imageRep isKindOfClass:[SDAnimatedImageRep class]]) {
+        SDAnimatedImageRep *animatedImageRep = (SDAnimatedImageRep *)imageRep;
+        NSData *imageData = [animatedImageRep animatedImageData];
+        if (imageData) {
+            return imageData;
+        }
+    }
+#endif
     return [self sd_imageDataAsFormat:SDImageFormatUndefined];
 }
 

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -446,6 +446,14 @@
     UIImage *animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
     NSData *data = [SDImageGIFCoder.sharedCoder encodedDataWithImage:animatedImage format:SDImageFormatGIF options:nil];
     expect(data).notTo.beNil();
+
+#if SD_MAC
+    // Test implementation use SDAnimatedImageRep
+    SDAnimatedImageRep *rep = (SDAnimatedImageRep *)animatedImage.representations.firstObject;
+    expect([rep isKindOfClass:SDAnimatedImageRep.class]);
+    expect(rep.animatedImageData).equal(data);
+    expect(rep.animatedImageFormat).equal(SDImageFormatGIF);
+#endif
     
     // Test new API
     NSData *data2 = [SDImageGIFCoder.sharedCoder encodedDataWithFrames:frames loopCount:0 format:SDImageFormatGIF options:nil];


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This can avoid extra re-encoding (slow) for some cases if you need compressed image data, on macOS AppKit

Used in AVIFQuickLook or some other cases