### PR TITLE
Fix the CGImageCreateScaled to support 16/32 bit depth CGImage (RGB161616) and always preserve pixel format info

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -131,6 +131,7 @@ typedef struct SDImagePixelFormat {
  Create a scaled CGImage by the provided CGImage and size. This follows The Create Rule and you are response to call release after usage.
  It will detect whether the image size matching the scale size, if not, stretch the image to the target size.
  @note If you need to keep aspect ratio, you can calculate the scale size by using `scaledSizeWithImageSize` first.
+ @note This scale does not change pixel format (which means RGB888 in, RGB888 out), supports 8/16/32 bit depth. But the method in UIImage+Transform does not gurantee this.
  
  @param cgImage The CGImage
  @param size The scale size in pixel.

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -131,7 +131,8 @@ typedef struct SDImagePixelFormat {
  Create a scaled CGImage by the provided CGImage and size. This follows The Create Rule and you are response to call release after usage.
  It will detect whether the image size matching the scale size, if not, stretch the image to the target size.
  @note If you need to keep aspect ratio, you can calculate the scale size by using `scaledSizeWithImageSize` first.
- @note This scale does not change pixel format (which means RGB888 in, RGB888 out), supports 8/16/32 bit depth. But the method in UIImage+Transform does not gurantee this.
+ @note This scale does not change bits per components (which means RGB888 in, RGB888 out), supports 8/16/32(float) bpc. But the method in UIImage+Transform does not gurantee this.
+ @note All supported CGImage pixel format: https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB
  
  @param cgImage The CGImage
  @param size The scale size in pixel.


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This fix the issue I found in https://github.com/SDWebImage/SDWebImageAVIFCoder
The created 16-bit depth CGImage will fail on this. vImage need to handle the `pixel format` one by one, let's add the dummy code.....


Test Result :

```
<CGImage 0x100645080> (DP)
	<<CGColorSpace 0x600002603900> (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; Rec. ITU-R BT.2100 PQ)>
		width = 4500, height = 3000, bpc = 16, bpp = 48, row bytes = 27000 
		kCGImageAlphaNone | kCGImageByteOrder16Little  | kCGImagePixelFormatPacked 
		is mask? No, has masking color? No, has soft mask? No, has matte? No, should interpolate? No
Printing description of imageRef:
<CGImage 0x100c0c460> (IP)
	<<CGColorSpace 0x600002603900> (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; Rec. ITU-R BT.2100 PQ)>
		width = 128, height = 86, bpc = 16, bpp = 48, row bytes = 768 
		kCGImageAlphaNone | kCGImageByteOrder16Little  | kCGImagePixelFormatPacked 
		is mask? No, has masking color? No, has soft mask? No, has matte? No, should interpolate? Yes
```