### PR TITLE
Added the visionOS support for "Build XCFramework" script target

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Note: `SD` is the prefix for **Simple Design** (which is the team name in Daily 
 
 From 5.18.0, SDWebImage can be compiled for visionOS platform. However, it's still in beta and may contains issues unlike the stable iOS UIKit support. Welcome to have a try and [report issue](https://github.com/SDWebImage/SDWebImage/issues).
 
-To build on visionOS, currently we only support the standard Xcode integration. Which means, open that `SDWebImage.xcodeproj` (Xcode 15+), then choose the target to build as library, framework or XCFramework (supports static and dynamic), and integrate to your visionOS App.
+To build on visionOS, currently we only support the standard Xcode integration.
 
-Once the visionOS toolchain is stable, we will add the package manager support later (include CocoaPods and SwiftPM).
+See `Installation with Swift Package Manager` and `Manual Installation Guide` below.
+
+Once the visionOS toolchain is stable, we will add the other package manager support later (include CocoaPods).
 
 ## Supported Image Formats
 
@@ -287,7 +289,31 @@ let package = Package(
 
 ### Manual Installation Guide
 
-See more on [Manual install Guide](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#manual-installation-guide)
++ Check your command line Xcode version
+
+```
+sudo xcode-select -s /path/to/Xcode.app
+```
+
+or
+
+```
+export DEVELOPER_DIR=/path/to/Xcode.app/Contents/Developer
+```
+
++ Run the script to build frameworks
+
+```
+./Scripts/build-frameworks.sh
+```
+
++ Run the script to merge XCFramework
+
+```
+./Scripts/create-xcframework.sh
+```
+
+See more on wiki: [Manual install Guide](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#manual-installation-guide)
 
 ### Import headers in your source files
 

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -1140,10 +1140,12 @@
 				"$(SRCROOT)/build/watchos/SDWebImage.framework",
 				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
 				"$(SRCROOT)/build/maccatalyst/SDWebImage.framework",
+				"$(SRCROOT)/build/xros/SDWebImage.framework",
+				"$(SRCROOT)/build/xrsimulator/SDWebImage.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')\nXCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')\n\nmkdir -p $(SRCROOT)/build\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\" \"maccatalyst\")\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\n    if [[ $CURRENT_PLATFORM == *\"simulator\" ]]; then\n        xcodebuild build -project \"SDWebImage.xcodeproj\" -sdk \"${CURRENT_PLATFORM}\" -scheme \"SDWebImage\" -configuration \"Debug\" -derivedDataPath \"${SRCROOT}/build/DerivedData\" CONFIGURATION_BUILD_DIR=\"${SRCROOT}/build/${CURRENT_PLATFORM}/\"\n    else\n    # macOS Catalyst\n    if [[ $CURRENT_PLATFORM == \"maccatalyst\" ]]; then\n        if [[ $XCODE_VERSION_MAJOR -lt 11 ]]; then\n            # Xcode 10 does not support macOS Catalyst\n            continue\n        else\n            xcodebuild archive -project \"SDWebImage.xcodeproj\" -scheme \"SDWebImage\" -configuration \"Release\" -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -archivePath \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive\" -derivedDataPath \"${SRCROOT}/build/DerivedData\" SKIP_INSTALL=NO\n        fi\n    else\n        xcodebuild archive -project \"SDWebImage.xcodeproj\" -sdk \"${CURRENT_PLATFORM}\" -scheme \"SDWebImage\" -configuration \"Release\" -archivePath \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive\" SKIP_INSTALL=NO\n    fi\n    mv \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/Products/Library/Frameworks/SDWebImage.framework\" \"${SRCROOT}/build/${CURRENT_PLATFORM}/\"\n    mv \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/dSYMs/SDWebImage.framework.dSYM\" \"${SRCROOT}/build/${CURRENT_PLATFORM}/\"\n    rm -rf \"${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/\"\n    fi\ndone\n";
+			shellScript = "sh ${SRCROOT}/Scripts/build-frameworks.sh\n";
 		};
 		326CA51422BA25F70033A92F /* Create XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1161,6 +1163,8 @@
 				"$(SRCROOT)/build/watchos/SDWebImage.framework",
 				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
 				"$(SRCROOT)/build/maccatalyst/SDWebImage.framework",
+				"$(SRCROOT)/build/xros/SDWebImage.framework",
+				"$(SRCROOT)/build/xrsimulator/SDWebImage.framework",
 			);
 			name = "Create XCFramework";
 			outputFileListPaths = (
@@ -1170,7 +1174,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')\nXCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')\n\nif [ $XCODE_VERSION_MAJOR -lt 11 ]\nthen\n    echo \"Xcode 10 does not support xcframework. You can still use the individual framework for each platform.\"\n    open -a Finder \"${SRCROOT}/build/\"\n    exit 0\nfi\n\ndeclare -a PLATFORMS=(\"iphoneos\" \"iphonesimulator\" \"macosx\" \"appletvos\" \"appletvsimulator\" \"watchos\" \"watchsimulator\" \"maccatalyst\")\nCOMMAND_ARGS=\"\"\nfor CURRENT_PLATFORM in \"${PLATFORMS[@]}\"\ndo\n    COMMAND_ARGS=\"${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.framework\"\ndone\n\n# Combine XCFramework\nxcodebuild -create-xcframework $COMMAND_ARGS -output \"${SRCROOT}/build/SDWebImage.xcframework\"\nopen -a Finder \"${SRCROOT}/build/SDWebImage.xcframework\"\n";
+			shellScript = "sh ${SRCROOT}/Scripts/create-xcframework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -1132,16 +1132,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/build/iphoneos/SDWebImage.framework",
-				"$(SRCROOT)/build/iphonesimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/macosx/SDWebImage.framework",
-				"$(SRCROOT)/build/appletvos/SDWebImage.framework",
-				"$(SRCROOT)/build/appletvsimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/watchos/SDWebImage.framework",
-				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/maccatalyst/SDWebImage.framework",
-				"$(SRCROOT)/build/xros/SDWebImage.framework",
-				"$(SRCROOT)/build/xrsimulator/SDWebImage.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1155,22 +1145,11 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/build/iphoneos/SDWebImage.framework",
-				"$(SRCROOT)/build/iphonesimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/macosx/SDWebImage.framework",
-				"$(SRCROOT)/build/appletvos/SDWebImage.framework",
-				"$(SRCROOT)/build/appletvsimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/watchos/SDWebImage.framework",
-				"$(SRCROOT)/build/watchsimulator/SDWebImage.framework",
-				"$(SRCROOT)/build/maccatalyst/SDWebImage.framework",
-				"$(SRCROOT)/build/xros/SDWebImage.framework",
-				"$(SRCROOT)/build/xrsimulator/SDWebImage.framework",
 			);
 			name = "Create XCFramework";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/build/SDWebImage.xcframework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Scripts/build-frameworks.sh
+++ b/Scripts/build-frameworks.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')
+XCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')
+if [ -z "$SRCROOT" ]
+then
+    SRCROOT=$(pwd)
+fi
+
+mkdir -p "${SRCROOT}/build"
+declare -a PLATFORMS=("iphoneos" "iphonesimulator" "macosx" "appletvos" "appletvsimulator" "watchos" "watchsimulator" "maccatalyst")
+
+if [ $XCODE_VERSION_MAJOR -ge 15 ]
+then
+    PLATFORMS+=("xros")
+    PLATFORMS+=("xrsimulator")
+fi
+
+for CURRENT_PLATFORM in "${PLATFORMS[@]}"
+do
+    if [[ $CURRENT_PLATFORM == *"simulator" ]]; then
+        xcodebuild build -project "SDWebImage.xcodeproj" -sdk "${CURRENT_PLATFORM}" -scheme "SDWebImage" -configuration "Debug" -derivedDataPath "${SRCROOT}/build/DerivedData" CONFIGURATION_BUILD_DIR="${SRCROOT}/build/${CURRENT_PLATFORM}/"
+    else
+    # macOS Catalyst
+    if [[ $CURRENT_PLATFORM == "maccatalyst" ]]; then
+        if [[ $XCODE_VERSION_MAJOR -lt 11 ]]; then
+            # Xcode 10 does not support macOS Catalyst
+            continue
+        else
+            xcodebuild archive -project "SDWebImage.xcodeproj" -scheme "SDWebImage" -configuration "Release" -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' -archivePath "${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive" -derivedDataPath "${SRCROOT}/build/DerivedData" SKIP_INSTALL=NO
+        fi
+    else
+        xcodebuild archive -project "SDWebImage.xcodeproj" -sdk "${CURRENT_PLATFORM}" -scheme "SDWebImage" -configuration "Release" -archivePath "${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive" SKIP_INSTALL=NO
+    fi
+    mv "${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/Products/Library/Frameworks/SDWebImage.framework" "${SRCROOT}/build/${CURRENT_PLATFORM}/"
+    mv "${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/dSYMs/SDWebImage.framework.dSYM" "${SRCROOT}/build/${CURRENT_PLATFORM}/"
+    rm -rf "${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.xcarchive/"
+    fi
+done

--- a/Scripts/create-xcframework.sh
+++ b/Scripts/create-xcframework.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')
 XCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')
 if [ -z "$SRCROOT" ]
@@ -14,12 +17,18 @@ then
     exit 0
 fi
 
-declare -a PLATFORMS=("iphoneos" "iphonesimulator" "macosx" "appletvos" "appletvsimulator" "watchos" "watchsimulator")
+mkdir -p "${SRCROOT}/build"
+PLATFORMS=("iOS" "iOSSimulator" "macOS" "tvOS" "tvOSSimulator" "watchOS" "watchOSSimulator")
+
+if [ $XCODE_VERSION_MAJOR -ge 11 ]
+then
+    PLATFORMS+=("macCatalyst")
+fi
 
 if [ $XCODE_VERSION_MAJOR -ge 15 ]
 then
-    PLATFORMS+=("xros")
-    PLATFORMS+=("xrsimulator")
+    PLATFORMS+=("visionOS")
+    PLATFORMS+=("visionOSSimulator")
 fi
 
 COMMAND_ARGS=""

--- a/Scripts/create-xcframework.sh
+++ b/Scripts/create-xcframework.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+XCODE_VERSION=$(xcodebuild -version | head -n 1| awk -F ' ' '{print $2}')
+XCODE_VERSION_MAJOR=$(echo $XCODE_VERSION | awk -F '.' '{print $1}')
+if [ -z "$SRCROOT" ]
+then
+    SRCROOT=$(pwd)
+fi
+
+if [ $XCODE_VERSION_MAJOR -lt 11 ]
+then
+    echo "Xcode 10 does not support xcframework. You can still use the individual framework for each platform."
+    open -a Finder "${SRCROOT}/build/"
+    exit 0
+fi
+
+declare -a PLATFORMS=("iphoneos" "iphonesimulator" "macosx" "appletvos" "appletvsimulator" "watchos" "watchsimulator")
+
+if [ $XCODE_VERSION_MAJOR -ge 15 ]
+then
+    PLATFORMS+=("xros")
+    PLATFORMS+=("xrsimulator")
+fi
+
+COMMAND_ARGS=""
+for CURRENT_PLATFORM in "${PLATFORMS[@]}"
+do
+    COMMAND_ARGS="${COMMAND_ARGS} -framework ${SRCROOT}/build/${CURRENT_PLATFORM}/SDWebImage.framework"
+done
+
+# Combine XCFramework
+xcodebuild -create-xcframework $COMMAND_ARGS -output "${SRCROOT}/build/SDWebImage.xcframework"
+open -a Finder "${SRCROOT}/build/SDWebImage.xcframework"


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Also, move the scripts from xcproj into the actual Scripts folder

