### PR TITLE
Fix the SDDisplayLink on watchOS does not behave like other platform

### DIFF
--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -197,7 +197,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     self.displayLink.paused = NO;
 #else
     if (self.displayLink.isValid) {
-        [self.displayLink fire];
+        // Do nothing
     } else {
         SDWeakProxy *weakProxy = [SDWeakProxy proxyWithTarget:self];
         self.displayLink = [NSTimer timerWithTimeInterval:kSDDisplayLinkInterval target:weakProxy selector:@selector(displayLinkDidRefresh:) userInfo:nil repeats:YES];


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The first callback should be trigger in next runloop when calling `start`, but not callback in sync.

This match iOS/tvOS/macOS/visionOS behavior, only watchOS who use `NSTimer` contains issues...
