### PR TITLE
Update the convenient API for case when user encode the format the same as image format, provide better quick return

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -372,15 +372,23 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 }
 
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality firstFrameOnly:(BOOL)firstFrameOnly {
-    if (firstFrameOnly) {
-        // First frame, use super implementation
-        return [super sd_imageDataAsFormat:imageFormat compressionQuality:compressionQuality firstFrameOnly:firstFrameOnly];
+    // Protect when user input the imageFormat == self.animatedImageFormat && compressionQuality == 1
+    // This should be treated as grabbing `self.animatedImageData` as well :)
+    NSData *imageData;
+    if (imageFormat == self.animatedImageFormat && compressionQuality == 1) {
+        imageData = self.animatedImageData;
     }
+    if (imageData) return imageData;
+    
+    SDImageCoderOptions *options = @{SDImageCoderEncodeCompressionQuality : @(compressionQuality), SDImageCoderEncodeFirstFrameOnly : @(firstFrameOnly)};
     NSUInteger frameCount = self.animatedImageFrameCount;
     if (frameCount <= 1) {
-        // Static image, use super implementation
-        return [super sd_imageDataAsFormat:imageFormat compressionQuality:compressionQuality firstFrameOnly:firstFrameOnly];
+        // Static image
+        imageData = [SDImageCodersManager.sharedManager encodedDataWithImage:self format:imageFormat options:options];
     }
+    if (imageData) return imageData;
+    
+    NSUInteger loopCount = self.animatedImageLoopCount;
     // Keep animated image encoding, loop each frame.
     NSMutableArray<SDImageFrame *> *frames = [NSMutableArray arrayWithCapacity:frameCount];
     for (size_t i = 0; i < frameCount; i++) {
@@ -389,8 +397,7 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
         SDImageFrame *frame = [SDImageFrame frameWithImage:image duration:duration];
         [frames addObject:frame];
     }
-    UIImage *animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
-    NSData *imageData = [animatedImage sd_imageDataAsFormat:imageFormat compressionQuality:compressionQuality firstFrameOnly:firstFrameOnly];
+    imageData = [SDImageCodersManager.sharedManager encodedDataWithFrames:frames loopCount:loopCount format:imageFormat options:options];
     return imageData;
 }
 

--- a/SDWebImage/Core/UIImage+MultiFormat.m
+++ b/SDWebImage/Core/UIImage+MultiFormat.m
@@ -9,6 +9,7 @@
 #import "UIImage+MultiFormat.h"
 #import "SDImageCodersManager.h"
 #import "SDAnimatedImageRep.h"
+#import "UIImage+Metadata.h"
 
 @implementation UIImage (MultiFormat)
 
@@ -41,7 +42,7 @@
         }
     }
 #endif
-    return [self sd_imageDataAsFormat:SDImageFormatUndefined];
+    return [self sd_imageDataAsFormat:self.sd_imageFormat];
 }
 
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat {


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3616

Though I don't think this is good solution. Actually for user who understand what this API do, can manually check and use `SDImageCodersManager` to call the proper code instead...

