### PR TITLE
Update the TargetConditional check for visionOS for Xcode 15.1

### DIFF
--- a/SDWebImage/Core/SDWebImageCompat.h
+++ b/SDWebImage/Core/SDWebImageCompat.h
@@ -21,14 +21,6 @@
     #define SD_MAC 0
 #endif
 
-// iOS and tvOS are very similar, UIKit exists on both platforms
-// Note: watchOS also has UIKit, but it's very limited
-#if TARGET_OS_IOS || TARGET_OS_TV
-    #define SD_UIKIT 1
-#else
-    #define SD_UIKIT 0
-#endif
-
 #if TARGET_OS_IOS
     #define SD_IOS 1
 #else
@@ -52,6 +44,14 @@
 #if TARGET_OS_VISION
     #define SD_VISION 1
 #endif
+#endif
+
+// iOS/tvOS/visionOS are very similar, UIKit exists on both platforms
+// Note: watchOS also has UIKit, but it's very limited
+#if SD_IOS || SD_TV || SD_VISION
+    #define SD_UIKIT 1
+#else
+    #define SD_UIKIT 0
 #endif
 
 #if SD_MAC

--- a/SDWebImage/Core/SDWebImageIndicator.h
+++ b/SDWebImage/Core/SDWebImageIndicator.h
@@ -109,8 +109,10 @@
 
 /// default-style progress indicator
 @property (nonatomic, class, nonnull, readonly) SDWebImageProgressIndicator *defaultIndicator;
+#if SD_UIKIT
 /// bar-style progress indicator
-@property (nonatomic, class, nonnull, readonly) SDWebImageProgressIndicator *barIndicator API_UNAVAILABLE(macos, tvos);
+@property (nonatomic, class, nonnull, readonly) SDWebImageProgressIndicator *barIndicator API_UNAVAILABLE(tvos);
+#endif
 
 @end
 

--- a/SDWebImage/Core/SDWebImageIndicator.m
+++ b/SDWebImage/Core/SDWebImageIndicator.m
@@ -278,8 +278,8 @@
     return indicator;
 }
 
-#if SD_IOS
-+ (SDWebImageProgressIndicator *)barIndicator {
+#if SD_UIKIT
++ (SDWebImageProgressIndicator *)barIndicator API_UNAVAILABLE(tvos) {
     SDWebImageProgressIndicator *indicator = [SDWebImageProgressIndicator new];
     indicator.indicatorView.progressViewStyle = UIProgressViewStyleBar;
     return indicator;

--- a/SDWebImage/Private/SDDisplayLink.m
+++ b/SDWebImage/Private/SDDisplayLink.m
@@ -10,7 +10,7 @@
 #import "SDWeakProxy.h"
 #if SD_MAC
 #import <CoreVideo/CoreVideo.h>
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
 #import <QuartzCore/QuartzCore.h>
 #endif
 #include <mach/mach_time.h>
@@ -30,7 +30,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 @property (nonatomic, assign) CVDisplayLinkRef displayLink;
 @property (nonatomic, assign) CVTimeStamp outputTime;
 @property (nonatomic, copy) NSRunLoopMode runloopMode;
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
 @property (nonatomic, strong) CADisplayLink *displayLink;
 #else
 @property (nonatomic, strong) NSTimer *displayLink;
@@ -49,7 +49,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
         CVDisplayLinkRelease(_displayLink);
         _displayLink = NULL;
     }
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     [_displayLink invalidate];
     _displayLink = nil;
 #else
@@ -69,7 +69,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
         CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
         // Simulate retain for target, the target is weak proxy to self
         CVDisplayLinkSetOutputCallback(_displayLink, DisplayLinkCallback, (__bridge_retained void *)weakProxy);
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
         _displayLink = [CADisplayLink displayLinkWithTarget:weakProxy selector:@selector(displayLinkDidRefresh:)];
 #else
         _displayLink = [NSTimer timerWithTimeInterval:kSDDisplayLinkInterval target:weakProxy selector:@selector(displayLinkDidRefresh:) userInfo:nil repeats:YES];
@@ -123,7 +123,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
         } else {
             duration = kSDDisplayLinkInterval;
         }
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
         // Fallback
         duration = self.displayLink.duration;
 #else
@@ -137,7 +137,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 - (BOOL)isRunning {
 #if SD_MAC
     return CVDisplayLinkIsRunning(self.displayLink);
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     return !self.displayLink.isPaused;
 #else
     return self.displayLink.isValid;
@@ -150,7 +150,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     }
 #if SD_MAC
     self.runloopMode = mode;
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     [self.displayLink addToRunLoop:runloop forMode:mode];
 #else
     self.runloop = runloop;
@@ -173,7 +173,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     }
 #if SD_MAC
     self.runloopMode = nil;
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     [self.displayLink removeFromRunLoop:runloop forMode:mode];
 #else
     self.runloop = nil;
@@ -193,7 +193,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 - (void)start {
 #if SD_MAC
     CVDisplayLinkStart(self.displayLink);
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     self.displayLink.paused = NO;
 #else
     if (self.displayLink.isValid) {
@@ -209,7 +209,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 - (void)stop {
 #if SD_MAC
     CVDisplayLinkStop(self.displayLink);
-#elif SD_IOS || SD_TV
+#elif SD_UIKIT
     self.displayLink.paused = YES;
 #else
     [self.displayLink invalidate];
@@ -219,7 +219,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 }
 
 - (void)displayLinkDidRefresh:(id)displayLink {
-#if SD_IOS || SD_TV
+#if SD_UIKIT
     if (@available(iOS 10.0, tvOS 10.0, *)) {
         self.nextFireTime = self.displayLink.targetTimestamp;
     } else {


### PR DESCRIPTION
### Pull Request Description

+ VisionOS should be in the UIKit variant

This close #3618

This is because Apple's SDK break changes that `TARGET_OS_IOS` does not resolve to `1` on visionOS. But on Xcode 15.0 it is :)