### PR TITLE
WIP: Added `.scaleMode` decode options and context option to allows aspect fill thumbnail

### DIFF
--- a/SDWebImage/Core/SDImageCacheDefine.m
+++ b/SDWebImage/Core/SDImageCacheDefine.m
@@ -15,11 +15,14 @@
 
 #import <CoreServices/CoreServices.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext * _Nullable context, SDWebImageOptions options, NSString * _Nonnull cacheKey) {
     BOOL decodeFirstFrame = SD_OPTIONS_CONTAINS(options, SDWebImageDecodeFirstFrameOnly);
     NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
     CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey); // Use cache key to detect scale
     NSNumber *preserveAspectRatioValue = context[SDWebImageContextImagePreserveAspectRatio];
+    NSNumber *scaleModeValue = context[SDWebImageContextImageScaleMode];
     NSValue *thumbnailSizeValue;
     BOOL shouldScaleDown = SD_OPTIONS_CONTAINS(options, SDWebImageScaleDownLargeImages);
     NSNumber *scaleDownLimitBytesValue = context[SDWebImageContextImageScaleDownLimitBytes];
@@ -53,6 +56,7 @@ SDImageCoderOptions * _Nonnull SDGetDecodeOptionsFromContext(SDWebImageContext *
     mutableCoderOptions[SDImageCoderDecodeFirstFrameOnly] = @(decodeFirstFrame);
     mutableCoderOptions[SDImageCoderDecodeScaleFactor] = @(scale);
     mutableCoderOptions[SDImageCoderDecodePreserveAspectRatio] = preserveAspectRatioValue;
+    mutableCoderOptions[SDImageCoderDecodeScaleMode] = scaleModeValue;
     mutableCoderOptions[SDImageCoderDecodeThumbnailPixelSize] = thumbnailSizeValue;
     mutableCoderOptions[SDImageCoderDecodeTypeIdentifierHint] = typeIdentifierHint;
     mutableCoderOptions[SDImageCoderDecodeFileExtensionHint] = fileExtensionHint;
@@ -70,6 +74,7 @@ void SDSetDecodeOptionsToContext(SDWebImageMutableContext * _Nonnull mutableCont
     
     mutableContext[SDWebImageContextImageScaleFactor] = decodeOptions[SDImageCoderDecodeScaleFactor];
     mutableContext[SDWebImageContextImagePreserveAspectRatio] = decodeOptions[SDImageCoderDecodePreserveAspectRatio];
+    mutableContext[SDWebImageContextImageScaleMode] = decodeOptions[SDImageCoderDecodeScaleMode];
     mutableContext[SDWebImageContextImageThumbnailPixelSize] = decodeOptions[SDImageCoderDecodeThumbnailPixelSize];
     mutableContext[SDWebImageContextImageScaleDownLimitBytes] = decodeOptions[SDImageCoderDecodeScaleDownLimitBytes];
     
@@ -86,6 +91,7 @@ void SDSetDecodeOptionsToContext(SDWebImageMutableContext * _Nonnull mutableCont
     }
     mutableContext[SDWebImageContextImageTypeIdentifierHint] = typeIdentifierHint;
 }
+#pragma clang diagnostic pop
 
 UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
     NSCParameterAssert(imageData);

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -32,15 +32,23 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeScaleFacto
 /**
  A Boolean value indicating whether to keep the original aspect ratio when generating thumbnail images (or bitmap images from vector format).
  Defaults to YES.
+ @deprecated This was deprecated after 5.19.0 and translate into `SDImageCoderDecodeScaleMode`. `YES` translate to `.aspectFit` and `NO` translate to `.fill`. If you need the `.aspectFill` use the new options instead.
  @note works for `SDImageCoder`, `SDProgressiveImageCoder`, `SDAnimatedImageCoder`.
  */
-FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodePreserveAspectRatio;
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodePreserveAspectRatio API_DEPRECATED("Use SDImageCoderDecodeScaleMode instead", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0));
 
 /**
- A CGSize value indicating whether or not to generate the thumbnail images (or bitmap images from vector format). When this value is provided, the decoder will generate a thumbnail image which pixel size is smaller than or equal to (depends the `.preserveAspectRatio`) the value size.
+ A `SDImageScale` value (NSNumber) indicating the scale mode during thumbnail decoding. The scaled size will use the `
+ Defaults to `.aspectFit`.
+ @note works for `SDImageCoder`, `SDProgressiveImageCoder`, `SDAnimatedImageCoder`.
+ */
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeScaleMode;
+
+/**
+ A CGSize value indicating whether or not to generate the thumbnail images (or bitmap images from vector format). When this value is provided, the decoder will generate a thumbnail image which pixel size is smaller than or equal to (depends the `.scaleMode`) the value size.
  Defaults to CGSizeZero, which means no thumbnail generation at all.
  @note Supports for animated image as well.
- @note When you pass `.preserveAspectRatio == NO`, the thumbnail image is stretched to match each dimension. When `.preserveAspectRatio == YES`, the thumbnail image's width is limited to pixel size's width, the thumbnail image's height is limited to pixel size's height. For common cases, you can just pass a square size to limit both.
+ @note When you pass `.aspectFit` or `.aspectFill`, the thumbnail image is stretched to match each dimension. When `.fill`, the thumbnail image's width is limited to pixel size's width, the thumbnail image's height is limited to pixel size's height. Note in `.aspectFill` the image size may be larger than pixel size.
  @note works for `SDImageCoder`, `SDProgressiveImageCoder`, `SDAnimatedImageCoder`.
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeThumbnailPixelSize;

--- a/SDWebImage/Core/SDImageCoder.m
+++ b/SDWebImage/Core/SDImageCoder.m
@@ -11,6 +11,7 @@
 SDImageCoderOption const SDImageCoderDecodeFirstFrameOnly = @"decodeFirstFrameOnly";
 SDImageCoderOption const SDImageCoderDecodeScaleFactor = @"decodeScaleFactor";
 SDImageCoderOption const SDImageCoderDecodePreserveAspectRatio = @"decodePreserveAspectRatio";
+SDImageCoderOption const SDImageCoderDecodeScaleMode = @"decodeScaleMode";
 SDImageCoderOption const SDImageCoderDecodeThumbnailPixelSize = @"decodeThumbnailPixelSize";
 SDImageCoderOption const SDImageCoderDecodeFileExtensionHint = @"decodeFileExtensionHint";
 SDImageCoderOption const SDImageCoderDecodeTypeIdentifierHint = @"decodeTypeIdentifierHint";

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -10,6 +10,16 @@
 #import "SDWebImageCompat.h"
 #import "SDImageFrame.h"
 
+/// The scale mode to apply when image drawing on a container with different sizes.
+typedef NS_ENUM(NSUInteger, SDImageScaleMode) {
+    /// The option to scale the content to fit the size of itself by changing the aspect ratio of the content if necessary.
+    SDImageScaleModeFill = 0,
+    /// The option to scale the content to fit the size of the view by maintaining the aspect ratio. Any remaining area of the view’s bounds is transparent.
+    SDImageScaleModeAspectFit = 1,
+    /// The option to scale the content to fill the size of the view. Some portion of the content may be clipped to fill the view’s bounds.
+    SDImageScaleModeAspectFill = 2
+};
+
 /// The options controls how we force pre-draw the image (to avoid lazy-decoding). Which need OS's framework compatibility
 typedef NS_ENUM(NSUInteger, SDImageCoderDecodeSolution) {
     /// automatically choose the solution based on image format, hardware, OS version. This keep balance for compatibility and performance. Default after SDWebImage 5.13.0
@@ -154,7 +164,13 @@ typedef struct SDImagePixelFormat {
  @param preserveAspectRatio Whether or not to preserve aspect ratio
  @param shouldScaleUp Whether or not to scale up (or scale down only)
  */
-+ (CGSize)scaledSizeWithImageSize:(CGSize)imageSize scaleSize:(CGSize)scaleSize preserveAspectRatio:(BOOL)preserveAspectRatio shouldScaleUp:(BOOL)shouldScaleUp;
++ (CGSize)scaledSizeWithImageSize:(CGSize)imageSize scaleSize:(CGSize)scaleSize preserveAspectRatio:(BOOL)preserveAspectRatio shouldScaleUp:(BOOL)shouldScaleUp API_DEPRECATED_WITH_REPLACEMENT("scaledSizeWithImageSize:scaleSize:scaleMode:", macos(10.10, API_TO_BE_DEPRECATED), ios(8.0, API_TO_BE_DEPRECATED), tvos(9.0, API_TO_BE_DEPRECATED), watchos(2.0, API_TO_BE_DEPRECATED));
+
+/// Scale the image size based on provided scale size and scale mode.
+/// @param imageSize The image size (in pixel or point defined by caller)
+/// @param scaleSize The scale size (in pixel or point defined by caller)
+/// @param scaleMode The image scale mode to use. If `.aspectFill` the returned size will be larger than the image size
++ (CGSize)scaledSizeWithImageSize:(CGSize)imageSize scaleSize:(CGSize)scaleSize scaleMode:(SDImageScaleMode)scaleMode;
 
 /// Calculate the limited image size with the bytes, when using `SDImageCoderDecodeScaleDownLimitBytes`. This preserve aspect ratio and never scale up
 /// @param imageSize The image size (in pixel or point defined by caller)

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -623,6 +623,49 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     return CGSizeMake(resultWidth, resultHeight);
 }
 
++ (CGSize)scaledSizeWithImageSize:(CGSize)imageSize scaleSize:(CGSize)scaleSize scaleMode:(SDImageScaleMode)scaleMode {
+    CGFloat width = imageSize.width;
+    CGFloat height = imageSize.height;
+    CGFloat resultWidth;
+    CGFloat resultHeight;
+    
+    if (width <= 0 || height <= 0 || scaleSize.width <= 0 || scaleSize.height <= 0) {
+        // Protect
+        resultWidth = width;
+        resultHeight = height;
+    } else {
+        // Scale to fit, choose the smallest edge
+        if (scaleMode == SDImageScaleModeAspectFit) {
+            CGFloat pixelRatio = width / height;
+            CGFloat scaleRatio = scaleSize.width / scaleSize.height;
+            if (pixelRatio > scaleRatio) {
+                resultWidth = scaleSize.width;
+                resultHeight = ceil(scaleSize.width / pixelRatio);
+            } else {
+                resultHeight = scaleSize.height;
+                resultWidth = ceil(scaleSize.height * pixelRatio);
+            }
+        } else if (scaleMode == SDImageScaleModeAspectFill) {
+            // Scale to fill, choose the longest edge
+            CGFloat pixelRatio = width / height;
+            CGFloat scaleRatio = scaleSize.width / scaleSize.height;
+            if (pixelRatio > scaleRatio) {
+                resultHeight = scaleSize.height;
+                resultWidth = ceil(scaleSize.height * pixelRatio);
+            } else {
+                resultWidth = scaleSize.width;
+                resultHeight = ceil(scaleSize.width / pixelRatio);
+            }
+        } else{
+            // Stretch
+            resultWidth = scaleSize.width;
+            resultHeight = scaleSize.height;
+        }
+    }
+    
+    return CGSizeMake(resultWidth, resultHeight);
+}
+
 + (CGSize)scaledSizeWithImageSize:(CGSize)imageSize limitBytes:(NSUInteger)limitBytes bytesPerPixel:(NSUInteger)bytesPerPixel frameCount:(NSUInteger)frameCount {
     if (CGSizeEqualToSize(imageSize, CGSizeZero)) return CGSizeMake(1, 1);
     NSUInteger totalFramePixelSize = limitBytes / bytesPerPixel / (frameCount ?: 1);

--- a/SDWebImage/Core/SDImageTransformer.h
+++ b/SDWebImage/Core/SDImageTransformer.h
@@ -22,11 +22,12 @@ FOUNDATION_EXPORT NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullab
  Return the thumbnailed cache key which applied with specify thumbnailSize and preserveAspectRatio control.
  @param key The original cache key
  @param thumbnailPixelSize The thumbnail pixel size
- @param preserveAspectRatio The preserve aspect ratio option
+ @param scaleMode The image scale mode to use. History this arg use `preserveAspectRatio`
  @return The thumbnailed cache key
  @note If you have both transformer and thumbnail applied for image, call `SDThumbnailedKeyForKey` firstly and then with `SDTransformedKeyForKey`.`
+ @note Before 5.19.0, we construct key with `preserveAspectRatio` arg and `YES` for 1, `NO` for 0. After 5.19.0 it still use `.aspectFit` for 1, `.fill` for 0, match the exits cache key.
  */
-FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, BOOL preserveAspectRatio);
+FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, SDImageScaleMode scaleMode);
 
 /**
  A transformer protocol to transform the image load from cache or from download.

--- a/SDWebImage/Core/SDImageTransformer.m
+++ b/SDWebImage/Core/SDImageTransformer.m
@@ -38,8 +38,8 @@ NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullable key, NSString *
     }
 }
 
-NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, BOOL preserveAspectRatio) {
-    NSString *thumbnailKey = [NSString stringWithFormat:@"Thumbnail({%f,%f},%d)", thumbnailPixelSize.width, thumbnailPixelSize.height, preserveAspectRatio];
+NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thumbnailPixelSize, SDImageScaleMode scaleMode) {
+    NSString *thumbnailKey = [NSString stringWithFormat:@"Thumbnail({%f,%f},%d)", thumbnailPixelSize.width, thumbnailPixelSize.height, (unsigned int)scaleMode];
     return SDTransformedKeyForKey(key, thumbnailKey);
 }
 

--- a/SDWebImage/Core/SDWebImageDefine.h
+++ b/SDWebImage/Core/SDWebImageDefine.h
@@ -304,12 +304,20 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageS
 /**
  A Boolean value indicating whether to keep the original aspect ratio when generating thumbnail images (or bitmap images from vector format).
  Defaults to YES. (NSNumber)
+ @deprecated This was deprecated after 5.19.0 and translate into `SDWebImageContextImageScaleMode`. `YES` translate to `.aspectFit` and `NO` translate to `.fill`. If you need the `.aspectFill` use the new options instead.
  */
-FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImagePreserveAspectRatio;
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImagePreserveAspectRatio  API_DEPRECATED("Use SDWebImageContextImageScaleMode instead", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0));
 
 /**
- A CGSize raw value indicating whether or not to generate the thumbnail images (or bitmap images from vector format). When this value is provided, the decoder will generate a thumbnail image which pixel size is smaller than or equal to (depends the `.imagePreserveAspectRatio`) the value size.
- @note When you pass `.preserveAspectRatio == NO`, the thumbnail image is stretched to match each dimension. When `.preserveAspectRatio == YES`, the thumbnail image's width is limited to pixel size's width, the thumbnail image's height is limited to pixel size's height. For common cases, you can just pass a square size to limit both.
+ A `SDImageScale` value (NSNumber) indicating the scale mode during thumbnail decoding. The scaled size will use the `
+ Defaults to `.aspectFit`.
+ @note works for `SDImageCoder`, `SDProgressiveImageCoder`, `SDAnimatedImageCoder`.
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageScaleMode;
+
+/**
+ A CGSize raw value indicating whether or not to generate the thumbnail images (or bitmap images from vector format). When this value is provided, the decoder will generate a thumbnail image which pixel size is smaller than or equal to (depends the `.imageScaleMode`) the value size.
+ @note When you pass `.aspectFit` or `.aspectFill`, the thumbnail image is stretched to match each dimension. When `.fill`, the thumbnail image's width is limited to pixel size's width, the thumbnail image's height is limited to pixel size's height. Note in `.aspectFill` the image size may be larger than pixel size.
  Defaults to CGSizeZero, which means no thumbnail generation at all. (NSValue)
  @note When this value is used, we will trigger thumbnail decoding for url, and the callback's data **will be nil** (because this time the data saved to disk does not match the image return to you. If you need full size data, query the cache with full size url key)
  */

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -145,6 +145,7 @@ SDWebImageContextOption const SDWebImageContextImageForceDecodePolicy = @"imageF
 SDWebImageContextOption const SDWebImageContextImageDecodeOptions = @"imageDecodeOptions";
 SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextImagePreserveAspectRatio = @"imagePreserveAspectRatio";
+SDWebImageContextOption const SDWebImageContextImageScaleMode = @"imageScaleMode";
 SDWebImageContextOption const SDWebImageContextImageThumbnailPixelSize = @"imageThumbnailPixelSize";
 SDWebImageContextOption const SDWebImageContextImageTypeIdentifierHint = @"imageTypeIdentifierHint";
 SDWebImageContextOption const SDWebImageContextImageScaleDownLimitBytes = @"imageScaleDownLimitBytes";

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -159,12 +159,20 @@ static id<SDImageLoader> _defaultImageLoader;
 #else
         thumbnailSize = thumbnailSizeValue.CGSizeValue;
 #endif
-        BOOL preserveAspectRatio = YES;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDImageScaleMode scaleMode = SDImageScaleModeAspectFit;
         NSNumber *preserveAspectRatioValue = context[SDWebImageContextImagePreserveAspectRatio];
         if (preserveAspectRatioValue != nil) {
-            preserveAspectRatio = preserveAspectRatioValue.boolValue;
+            BOOL preserveAspectRatio = preserveAspectRatioValue.boolValue;
+            scaleMode = preserveAspectRatio ? SDImageScaleModeAspectFit : SDImageScaleModeFill;
         }
-        key = SDThumbnailedKeyForKey(key, thumbnailSize, preserveAspectRatio);
+        NSNumber *scaleModeValue = context[SDWebImageContextImageScaleMode];
+        if (scaleModeValue != nil) {
+            scaleMode = scaleModeValue.unsignedIntegerValue;
+        }
+#pragma clang diagnostic pop
+        key = SDThumbnailedKeyForKey(key, thumbnailSize, scaleMode);
     }
     
     // Transformer Key Appending

--- a/SDWebImage/Core/UIImage+Transform.h
+++ b/SDWebImage/Core/UIImage+Transform.h
@@ -7,16 +7,7 @@
  */
 
 #import "SDWebImageCompat.h"
-
-/// The scale mode to apply when image drawing on a container with different sizes.
-typedef NS_ENUM(NSUInteger, SDImageScaleMode) {
-    /// The option to scale the content to fit the size of itself by changing the aspect ratio of the content if necessary.
-    SDImageScaleModeFill = 0,
-    /// The option to scale the content to fit the size of the view by maintaining the aspect ratio. Any remaining area of the view’s bounds is transparent.
-    SDImageScaleModeAspectFit = 1,
-    /// The option to scale the content to fill the size of the view. Some portion of the content may be clipped to fill the view’s bounds.
-    SDImageScaleModeAspectFill = 2
-};
+#import "SDImageCoderHelper.h"
 
 #if SD_UIKIT || SD_WATCH
 typedef UIRectCorner SDRectCorner;

--- a/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
+++ b/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <ImageIO/ImageIO.h>
 #import "SDImageIOAnimatedCoder.h"
+#import "SDImageCoderHelper.h"
 
 // AVFileTypeHEIC/AVFileTypeHEIF is defined in AVFoundation via iOS 11, we use this without import AVFoundation
 #define kSDUTTypeHEIC  ((__bridge CFStringRef)@"public.heic")
@@ -32,7 +33,7 @@
 
 + (NSTimeInterval)frameDurationAtIndex:(NSUInteger)index source:(nonnull CGImageSourceRef)source;
 + (NSUInteger)imageLoopCountWithSource:(nonnull CGImageSourceRef)source;
-+ (nullable UIImage *)createFrameAtIndex:(NSUInteger)index source:(nonnull CGImageSourceRef)source scale:(CGFloat)scale preserveAspectRatio:(BOOL)preserveAspectRatio thumbnailSize:(CGSize)thumbnailSize lazyDecode:(BOOL)lazyDecode animatedImage:(BOOL)animatedImage;
++ (nullable UIImage *)createFrameAtIndex:(NSUInteger)index source:(nonnull CGImageSourceRef)source scale:(CGFloat)scale thumbnailSize:(CGSize)thumbnailSize scaleMode:(SDImageScaleMode)scaleMode lazyDecode:(BOOL)lazyDecode animatedImage:(BOOL)animatedImage;
 + (BOOL)canEncodeToFormat:(SDImageFormat)format;
 + (BOOL)canDecodeFromFormat:(SDImageFormat)format;
 


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This is useful for user who want to use the aspect fill content mode on image view level to make image more sharp

This close #3622 

### Behavior Changes

1. If the coder does not response to the `.scaleMode` options, it should always use the aspect fit instead.
2. The coder must response to the old version `.preserveAspectRatio` option for history compatible, until we reached v6.0.0
3. The `SDThumbnailedKeyForKey` change arg from BOOL to `NSUInteger`, but this is binary compatible changes, and the thumbnail cache is still valid (because `.aspectFit` == `YES` == 1, and `.fill` == `NO` == 0)

