### PR TITLE
Fix the iOS 17 UIKit issue that UIImageView entering the background will reset CALayer's contents, which cause SDAnimatedImageView render issue (out-of-sync)

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -501,6 +501,17 @@
     }
 }
 
+#if SD_UIKIT
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    // See: #3635
+    // From iOS 17, when UIImageView entering the background, it will receive the trait collection changes, and modify the CALayer.contents by `self.image.CGImage`
+    // However, For animated image, `self.image.CGImge != self.currentFrame.CGImage`, right ?
+    // So this cause the render issue, we need to reset the CALayer.contents again
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self.imageViewLayer setNeedsDisplay];
+}
+#endif
+
 #if SD_MAC
 // NSImageView use a subview. We need this subview's layer for actual rendering.
 // Why using this design may because of properties like `imageAlignment` and `imageScaling`, which it's not available for UIImageView.contentMode (it's impossible to align left and keep aspect ratio at the same time)


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

See more information in #3635 and details debugging steps

This close #3635

### Solution

Should use traitCollectionDidChange to refresh the CALayer's contents status to match current frame index

