### PR TITLE
Fix the issue when using the `sd_cancelCurrentImageLoad` on non-stateful view (like UIImageView.image)

### DIFF
--- a/SDWebImage/Core/UIView+WebCacheOperation.h
+++ b/SDWebImage/Core/UIView+WebCacheOperation.h
@@ -20,14 +20,16 @@
  *
  *  @param key key for identifying the operations
  *  @return the image load operation
+ *  @note If key is nil, means using the NSStringFromClass(self.class) instead, match the behavior of `operation key`
  */
 - (nullable id<SDWebImageOperation>)sd_imageLoadOperationForKey:(nullable NSString *)key;
 
 /**
  *  Set the image load operation (storage in a UIView based weak map table)
  *
- *  @param operation the operation
+ *  @param operation the operation, should not be nil or no-op will perform
  *  @param key       key for storing the operation
+ *  @note If key is nil, means using the NSStringFromClass(self.class) instead, match the behavior of `operation key`
  */
 - (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key;
 
@@ -35,13 +37,15 @@
  *  Cancel the operation for the current UIView and key
  *
  *  @param key key for identifying the operations
+ *  @note If key is nil, means using the NSStringFromClass(self.class) instead, match the behavior of `operation key`
  */
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key;
 
 /**
  *  Just remove the operation corresponding to the current UIView and key without cancelling them
  *
- *  @param key key for identifying the operations
+ *  @param key key for identifying the operations.
+ *  @note If key is nil, means using the NSStringFromClass(self.class) instead, match the behavior of `operation key`
  */
 - (void)sd_removeImageLoadOperationWithKey:(nullable NSString *)key;
 

--- a/SDWebImage/Core/UIView+WebCacheOperation.m
+++ b/SDWebImage/Core/UIView+WebCacheOperation.m
@@ -29,52 +29,56 @@ typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
 
 - (nullable id<SDWebImageOperation>)sd_imageLoadOperationForKey:(nullable NSString *)key  {
     id<SDWebImageOperation> operation;
-    if (key) {
-        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-        @synchronized (self) {
-            operation = [operationDictionary objectForKey:key];
-        }
+    if (!key) {
+        key = NSStringFromClass(self.class);
+    }
+    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+    @synchronized (self) {
+        operation = [operationDictionary objectForKey:key];
     }
     return operation;
 }
 
 - (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key {
-    if (key) {
-        if (operation) {
-            SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-            @synchronized (self) {
-                [operationDictionary setObject:operation forKey:key];
-            }
+    if (!key) {
+        key = NSStringFromClass(self.class);
+    }
+    if (operation) {
+        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+        @synchronized (self) {
+            [operationDictionary setObject:operation forKey:key];
         }
     }
 }
 
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key {
-    if (key) {
-        // Cancel in progress downloader from queue
-        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-        id<SDWebImageOperation> operation;
-        
-        @synchronized (self) {
-            operation = [operationDictionary objectForKey:key];
+    if (!key) {
+        key = NSStringFromClass(self.class);
+    }
+    // Cancel in progress downloader from queue
+    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+    id<SDWebImageOperation> operation;
+    
+    @synchronized (self) {
+        operation = [operationDictionary objectForKey:key];
+    }
+    if (operation) {
+        if ([operation respondsToSelector:@selector(cancel)]) {
+            [operation cancel];
         }
-        if (operation) {
-            if ([operation respondsToSelector:@selector(cancel)]) {
-                [operation cancel];
-            }
-            @synchronized (self) {
-                [operationDictionary removeObjectForKey:key];
-            }
+        @synchronized (self) {
+            [operationDictionary removeObjectForKey:key];
         }
     }
 }
 
 - (void)sd_removeImageLoadOperationWithKey:(nullable NSString *)key {
-    if (key) {
-        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-        @synchronized (self) {
-            [operationDictionary removeObjectForKey:key];
-        }
+    if (!key) {
+        key = NSStringFromClass(self.class);
+    }
+    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+    @synchronized (self) {
+        [operationDictionary removeObjectForKey:key];
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3647 
This close #3646

### Changes

When `nil` operation key provided, it should always translated into `NSClassFromString(self.class)` for history compatible behavior.