### PR TITLE
Fix the behavior that query thumbnail from full size data does not sync back the thumbnail image into memory cache

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -17,6 +17,14 @@
 #import "SDCallbackQueue.h"
 #import "SDImageTransformer.h" // TODO, remove this
 
+// TODO, remove this
+static BOOL SDIsThumbnailKey(NSString *key) {
+    if ([key rangeOfString:@"-Thumbnail("].location != NSNotFound) {
+        return YES;
+    }
+    return NO;
+}
+
 @interface SDImageCacheToken ()
 
 @property (nonatomic, strong, nullable, readwrite) NSString *key;
@@ -526,6 +534,7 @@ static NSString * _defaultDiskCacheDirectory;
     // However, caller (like SDWebImageManager) will query full key, with thumbnail size, and get thubmnail image
     // We should add a check here, currently it's a hack
     if (diskImage.sd_isThumbnail) {
+        NSAssert(!SDIsThumbnailKey(key), @"The input cache key %@ should not be thumbnail key", key);
         SDImageCoderOptions *options = diskImage.sd_decodeOptions;
         CGSize thumbnailSize = CGSizeZero;
         NSValue *thumbnailSizeValue = options[SDImageCoderDecodeThumbnailPixelSize];

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -304,12 +304,7 @@ static id<SDImageLoader> _defaultImageLoader;
         NSString *key = [self cacheKeyForURL:url context:context];
         // to avoid the SDImageCache's sync logic use the mismatched cache key
         // we should strip the `thumbnail` related context
-        SDWebImageMutableContext *mutableContext;
-        if (context) {
-            mutableContext = [context mutableCopy];
-        } else {
-            mutableContext = [NSMutableDictionary dictionary];
-        }
+        SDWebImageMutableContext *mutableContext = [context mutableCopy];
         mutableContext[SDWebImageContextImageThumbnailPixelSize] = nil;
         mutableContext[SDWebImageContextImagePreserveAspectRatio] = nil;
         @weakify(operation);

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -302,8 +302,18 @@ static id<SDImageLoader> _defaultImageLoader;
     if (shouldQueryCache) {
         // transformed cache key
         NSString *key = [self cacheKeyForURL:url context:context];
+        // to avoid the SDImageCache's sync logic use the mismatched cache key
+        // we should strip the `thumbnail` related context
+        SDWebImageMutableContext *mutableContext;
+        if (context) {
+            mutableContext = [context mutableCopy];
+        } else {
+            mutableContext = [NSMutableDictionary dictionary];
+        }
+        mutableContext[SDWebImageContextImageThumbnailPixelSize] = nil;
+        mutableContext[SDWebImageContextImagePreserveAspectRatio] = nil;
         @weakify(operation);
-        operation.cacheOperation = [imageCache queryImageForKey:key options:options context:context cacheType:queryCacheType completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
+        operation.cacheOperation = [imageCache queryImageForKey:key options:options context:mutableContext cacheType:queryCacheType completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
             @strongify(operation);
             if (!operation || operation.isCancelled) {
                 // Image combined operation cancelled by user

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -482,11 +482,15 @@
     [SDImageCache.sharedImageCache queryCacheOperationForKey:fullSizeKey options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(thumbnailSize)} done:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image.size).equal(thumbnailSize);
         expect(cacheType).equal(SDImageCacheTypeDisk);
-        // Currently, thumbnail decoding does not write back to the original key's memory cache
-        // But this may change in the future once I change the API for `SDImageCacheProtocol`
-        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:fullSizeKey]).beNil();
-        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey]).beNil();
+        // Check the full image should not be in memory cache (because we have only full data + thumbnail image)
+        // Check the thumbnail image should be in memory cache (because we have only full data + thumbnail image)
+        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:fullSizeKey].size).equal(CGSizeZero);
+        expect([SDImageCache.sharedImageCache imageFromDiskCacheForKey:fullSizeKey]).notTo.beNil();
+        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey].size).equal(thumbnailSize);
+        expect([SDImageCache.sharedImageCache imageFromDiskCacheForKey:thumbnailKey]).beNil();
         
+        [SDImageCache.sharedImageCache removeImageFromDiskForKey:fullSizeKey];
+        [SDImageCache.sharedImageCache removeImageFromMemoryForKey:thumbnailKey];
         [expectation fulfill];
     }];
     


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3656 

### Changes

In history commits I do a hack which breaks's disk -> memory cache sync behavior for thumbnail. https://github.com/SDWebImage/SDWebImage/commit/e7e9268a7e9c2f1157f1cea1b88465bc1589b4f9

It's not correct. We should use another more better way for workaround.

The caller should not passes the `thumbnail` related context when querying the actual thumbnail key (calculate twice)

