### PR TITLE
Using os_log for our all log to replace the NSLog

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -7,6 +7,7 @@
  */
 
 #import "SDImageCache.h"
+#import "SDInternalMacros.h"
 #import "NSImage+Compatibility.h"
 #import "SDImageCodersManager.h"
 #import "SDImageCoderHelper.h"
@@ -307,7 +308,7 @@ static NSString * _defaultDiskCacheDirectory;
         NSError *error;
         extendedData = [NSKeyedArchiver archivedDataWithRootObject:extendedObject requiringSecureCoding:NO error:&error];
         if (error) {
-            NSLog(@"NSKeyedArchiver archive failed with error: %@", error);
+            SD_LOG("NSKeyedArchiver archive failed with error: %@", error);
         }
     } else {
         @try {
@@ -316,7 +317,7 @@ static NSString * _defaultDiskCacheDirectory;
             extendedData = [NSKeyedArchiver archivedDataWithRootObject:extendedObject];
 #pragma clang diagnostic pop
         } @catch (NSException *exception) {
-            NSLog(@"NSKeyedArchiver archive failed with exception: %@", exception);
+            SD_LOG("NSKeyedArchiver archive failed with exception: %@", exception);
         }
     }
     if (extendedData) {
@@ -542,7 +543,7 @@ static NSString * _defaultDiskCacheDirectory;
         unarchiver.requiresSecureCoding = NO;
         extendedObject = [unarchiver decodeTopLevelObjectForKey:NSKeyedArchiveRootObjectKey error:&error];
         if (error) {
-            NSLog(@"NSKeyedUnarchiver unarchive failed with error: %@", error);
+            SD_LOG("NSKeyedUnarchiver unarchive failed with error: %@", error);
         }
     } else {
         @try {
@@ -551,7 +552,7 @@ static NSString * _defaultDiskCacheDirectory;
             extendedObject = [NSKeyedUnarchiver unarchiveObjectWithData:extendedData];
 #pragma clang diagnostic pop
         } @catch (NSException *exception) {
-            NSLog(@"NSKeyedUnarchiver unarchive failed with exception: %@", exception);
+            SD_LOG("NSKeyedUnarchiver unarchive failed with exception: %@", exception);
         }
     }
     image.sd_extendedObject = extendedObject;

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -238,7 +238,7 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
                 // Correct value
                 isBuggy = NO;
             } else {
-                NSLog(@"Detected the current OS's ImageIO PNG Decoder is buggy on indexed color PNG. Perform workaround solution...");
+                SD_LOG("Detected the current OS's ImageIO PNG Decoder is buggy on indexed color PNG. Perform workaround solution...");
                 isBuggy = YES;
             }
         }

--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -11,6 +11,7 @@
 #import "SDImageGraphics.h"
 #import "SDGraphicsImageRenderer.h"
 #import "NSBezierPath+SDRoundedCorners.h"
+#import "SDInternalMacros.h"
 #import <Accelerate/Accelerate.h>
 #if SD_UIKIT || SD_MAC
 #import <CoreImage/CoreImage.h>
@@ -648,7 +649,7 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
         // Convert to color
         return SDGetColorFromRGBA(pixel, bitmapInfo, colorSpace);
     } else {
-        NSLog(@"Unsupported components: %zu", components);
+        SD_LOG("Unsupported components: %zu", components);
         CFRelease(data);
         CGImageRelease(imageRef);
         return nil;
@@ -732,7 +733,7 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
                 Pixel_8888 pixel = {pixels[index], pixels[index+1], pixels[index+2], pixels[index+3]};
                 color = SDGetColorFromRGBA(pixel, bitmapInfo, colorSpace);
             } else {
-                NSLog(@"Unsupported components: %zu", components);
+                SD_LOG("Unsupported components: %zu", components);
             }
         }
         if (color) {
@@ -796,12 +797,12 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
     vImage_Error err;
     err = vImageBuffer_InitWithCGImage(&effect, &format, NULL, imageRef, kvImageNoFlags); // vImage will convert to format we requests, no need `vImageConvert`
     if (err != kvImageNoError) {
-        NSLog(@"UIImage+Transform error: vImageBuffer_InitWithCGImage returned error code %zi for inputImage: %@", err, self);
+        SD_LOG("UIImage+Transform error: vImageBuffer_InitWithCGImage returned error code %zi for inputImage: %@", err, self);
         return nil;
     }
     err = vImageBuffer_Init(&scratch, effect.height, effect.width, format.bitsPerPixel, kvImageNoFlags);
     if (err != kvImageNoError) {
-        NSLog(@"UIImage+Transform error: vImageBuffer_Init returned error code %zi for inputImage: %@", err, self);
+        SD_LOG("UIImage+Transform error: vImageBuffer_Init returned error code %zi for inputImage: %@", err, self);
         return nil;
     }
     

--- a/SDWebImage/Private/SDInternalMacros.h
+++ b/SDWebImage/Private/SDInternalMacros.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <os/lock.h>
 #import <libkern/OSAtomic.h>
+#import <os/log.h>
 #import "SDmetamacros.h"
 
 #define SD_USE_OS_UNFAIR_LOCK TARGET_OS_MACCATALYST ||\
@@ -76,6 +77,13 @@ else OSSpinLockUnlock(&lock##_deprecated);
 
 #ifndef SD_SEL_SPI
 #define SD_SEL_SPI(name) NSSelectorFromString([NSString stringWithFormat:@"_%@", SD_NSSTRING(name)])
+#endif
+
+extern os_log_t sd_getDefaultLog(void);
+
+#ifndef SD_LOG
+#define SD_LOG(_log, ...) if (@available(iOS 10.0, tvOS 10.0, macOS 10.12, watchOS 3.0, *)) os_log(sd_getDefaultLog(), _log, ##__VA_ARGS__); \
+else NSLog(@(_log), ##__VA_ARGS__);
 #endif
 
 #ifndef weakify

--- a/SDWebImage/Private/SDInternalMacros.m
+++ b/SDWebImage/Private/SDInternalMacros.m
@@ -8,6 +8,15 @@
 
 #import "SDInternalMacros.h"
 
+os_log_t sd_getDefaultLog(void) {
+    static dispatch_once_t onceToken;
+    static os_log_t log;
+    dispatch_once(&onceToken, ^{
+        log = os_log_create("com.hackemist.SDWebImage", "Default");
+    });
+    return log;
+}
+
 void sd_executeCleanupBlock (__strong sd_cleanupBlock_t *block) {
     (*block)();
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Using the subsystem (`com.hackemist.SDWebImage` for better filter
Need the runtime version check for now (will remove in 6.x)