### PR TITLE
Temp remove the assert when thumbnail cache key used with thumbnail context , this may be changed later

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -323,6 +323,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancelled
+ * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
@@ -335,6 +336,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancellederation, will callback immediately when cancelled
+ * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
@@ -348,6 +350,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancelled
+ * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context cacheType:(SDImageCacheType)queryCacheType done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -533,8 +533,7 @@ static NSString * _defaultDiskCacheDirectory;
     // The disk -> memory sync logic, which should only store thumbnail image with thumbnail key
     // However, caller (like SDWebImageManager) will query full key, with thumbnail size, and get thubmnail image
     // We should add a check here, currently it's a hack
-    if (diskImage.sd_isThumbnail) {
-        NSAssert(!SDIsThumbnailKey(key), @"The input cache key %@ should not be thumbnail key", key);
+    if (diskImage.sd_isThumbnail && !SDIsThumbnailKey(key)) {
         SDImageCoderOptions *options = diskImage.sd_decodeOptions;
         CGSize thumbnailSize = CGSizeZero;
         NSValue *thumbnailSizeValue = options[SDImageCoderDecodeThumbnailPixelSize];


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

In #3657 I added an assert here.

But I think this may cause some behavior changes. Currently remove this to keep old patch version compatible
