### PR TITLE
add missing break keyword while converting NSData to SDImageFormat

### DIFF
--- a/SDWebImage/Core/NSData+ImageContentType.m
+++ b/SDWebImage/Core/NSData+ImageContentType.m
@@ -74,12 +74,14 @@
                     return SDImageFormatPDF;
                 }
             }
+            break;
         }
         case 0x3C: {
             // Check end with SVG tag
             if ([data rangeOfData:[kSVGTagEnd dataUsingEncoding:NSUTF8StringEncoding] options:NSDataSearchBackwards range: NSMakeRange(data.length - MIN(100, data.length), MIN(100, data.length))].location != NSNotFound) {
                 return SDImageFormatSVG;
             }
+            break;
         }
     }
     return SDImageFormatUndefined;


### PR DESCRIPTION
…e converting NSData to SDImageFormat

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
The function `+ (SDImageFormat)sd_imageFormatForImageData:(nullable NSData *)data` misses two break keyword in case  `PDF` and `SVG`

...

