### PR TITLE
mark `SDWebImageCacheKeyFilter` default initializer unavailable &  add missing default case of `SDCallbackQueue` sync/async function

### DIFF
--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -94,6 +94,9 @@ static void SDSafeExecute(SDCallbackQueue *callbackQueue, dispatch_block_t _Nonn
         case SDCallbackPolicyInvoke:
             block();
             break;
+        default:
+            SDSafeExecute(self, block, NO);
+            break;
     }
 }
 
@@ -107,6 +110,9 @@ static void SDSafeExecute(SDCallbackQueue *callbackQueue, dispatch_block_t _Nonn
             break;
         case SDCallbackPolicyInvoke:
             block();
+            break;
+        default:
+            SDSafeExecute(self, block, YES);
             break;
     }
 }

--- a/SDWebImage/Core/SDDiskCache.h
+++ b/SDWebImage/Core/SDDiskCache.h
@@ -129,6 +129,7 @@
 @property (nonatomic, strong, readonly, nonnull) SDImageCacheConfig *config;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
 
 /**
  Move the cache directory from old location to new location, the old location will be removed after finish.

--- a/SDWebImage/Core/SDImageTransformer.h
+++ b/SDWebImage/Core/SDImageTransformer.h
@@ -69,6 +69,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, copy, readonly, nonnull) NSArray<id<SDImageTransformer>> *transformers;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithTransformers:(nonnull NSArray<id<SDImageTransformer>> *)transformers;
 
 @end
@@ -109,6 +111,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, strong, readonly, nullable) UIColor *borderColor;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithRadius:(CGFloat)cornerRadius corners:(SDRectCorner)corners borderWidth:(CGFloat)borderWidth borderColor:(nullable UIColor *)borderColor;
 
 @end
@@ -129,6 +133,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, assign, readonly) SDImageScaleMode scaleMode;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithSize:(CGSize)size scaleMode:(SDImageScaleMode)scaleMode;
 
 @end
@@ -144,6 +150,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, assign, readonly) CGRect rect;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithRect:(CGRect)rect;
 
 @end
@@ -164,6 +172,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, assign, readonly) BOOL vertical;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithHorizontal:(BOOL)horizontal vertical:(BOOL)vertical;
 
 @end
@@ -185,6 +195,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, assign, readonly) BOOL fitSize;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithAngle:(CGFloat)angle fitSize:(BOOL)fitSize;
 
 @end
@@ -202,6 +214,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, strong, readonly, nonnull) UIColor *tintColor;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithColor:(nonnull UIColor *)tintColor;
 
 @end
@@ -219,6 +233,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, assign, readonly) CGFloat blurRadius;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithRadius:(CGFloat)blurRadius;
 
 @end
@@ -235,6 +251,8 @@ FOUNDATION_EXPORT NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullab
 @property (nonatomic, strong, readonly, nonnull) CIFilter *filter;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 + (nonnull instancetype)transformerWithFilter:(nonnull CIFilter *)filter;
 
 @end

--- a/SDWebImage/Core/SDWebImageCacheKeyFilter.h
+++ b/SDWebImage/Core/SDWebImageCacheKeyFilter.h
@@ -26,6 +26,9 @@ typedef NSString * _Nullable(^SDWebImageCacheKeyFilterBlock)(NSURL * _Nonnull ur
  */
 @interface SDWebImageCacheKeyFilter : NSObject <SDWebImageCacheKeyFilter>
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageCacheKeyFilterBlock)block;
 + (nonnull instancetype)cacheKeyFilterWithBlock:(nonnull SDWebImageCacheKeyFilterBlock)block;
 

--- a/SDWebImage/Core/SDWebImageCacheSerializer.h
+++ b/SDWebImage/Core/SDWebImageCacheSerializer.h
@@ -33,4 +33,7 @@ typedef NSData * _Nullable(^SDWebImageCacheSerializerBlock)(UIImage * _Nonnull i
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageCacheSerializerBlock)block;
 + (nonnull instancetype)cacheSerializerWithBlock:(nonnull SDWebImageCacheSerializerBlock)block;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 @end

--- a/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
+++ b/SDWebImage/Core/SDWebImageDownloaderDecryptor.h
@@ -38,6 +38,9 @@ A downloader response modifier class with block.
 /// @param block A block to control decrypt logic
 + (nonnull instancetype)decryptorWithBlock:(nonnull SDWebImageDownloaderDecryptorBlock)block;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 @end
 
 /// Convenience way to create decryptor for common data encryption.

--- a/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderRequestModifier.h
@@ -37,6 +37,9 @@ typedef NSURLRequest * _Nullable (^SDWebImageDownloaderRequestModifierBlock)(NSU
 /// @param block A block to control modifier logic
 + (nonnull instancetype)requestModifierWithBlock:(nonnull SDWebImageDownloaderRequestModifierBlock)block;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 @end
 
 /**

--- a/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
+++ b/SDWebImage/Core/SDWebImageDownloaderResponseModifier.h
@@ -37,6 +37,9 @@ typedef NSURLResponse * _Nullable (^SDWebImageDownloaderResponseModifierBlock)(N
 /// @param block A block to control modifier logic
 + (nonnull instancetype)responseModifierWithBlock:(nonnull SDWebImageDownloaderResponseModifierBlock)block;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 @end
 
 /**

--- a/SDWebImage/Core/SDWebImageOptionsProcessor.h
+++ b/SDWebImage/Core/SDWebImageOptionsProcessor.h
@@ -38,6 +38,9 @@ typedef SDWebImageOptionsResult * _Nullable(^SDWebImageOptionsProcessorBlock)(NS
  */
 - (nonnull instancetype)initWithOptions:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+
 @end
 
 /**
@@ -68,5 +71,8 @@ typedef SDWebImageOptionsResult * _Nullable(^SDWebImageOptionsProcessorBlock)(NS
 
 - (nonnull instancetype)initWithBlock:(nonnull SDWebImageOptionsProcessorBlock)block;
 + (nonnull instancetype)optionsProcessorWithBlock:(nonnull SDWebImageOptionsProcessorBlock)block;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
1. Mark `SDWebImageCacheKeyFilter` default `init` and `new` initializer as `unavailable` to prevent unexpected behavior
2. add missing default case of `SDCallbackQueue`  `sync` and `async` function to avoid future unexpected behavior

