### PR TITLE
Fix the unit test `test31ThatMultipleRequestForSameURLFailedCallback`

### DIFF
--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -541,6 +541,8 @@
 #if SD_UIKIT
     UIImageOrientation orientation = image.imageOrientation;
     expect(orientation).equal(UIImageOrientationUp);
+#else
+    expect(image.sd_imageFormat).equal(SDImageFormatJPEG);
 #endif
     
     // Manual test again for Apple's API

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -825,14 +825,17 @@
     [self waitForExpectations:expectations timeout:kAsyncTestTimeout * 2];
 }
 
-
 - (void)test31ThatMultipleRequestForSameURLFailedCallback {
     // See #3493, silly bug
-    NSURL *url = [NSURL fileURLWithPath:@"/dev/null"]; // Always fail url
-    NSMutableArray<XCTestExpectation *> *expectations = [NSMutableArray arrayWithCapacity:100];
+    // Create tmp file with empty contents
+    NSURL *dir = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:NSStringFromSelector(_cmd) isDirectory: true];
+    [NSFileManager.defaultManager createDirectoryAtURL:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    NSURL *url = [dir URLByAppendingPathComponent:@"file" isDirectory:NO];
+    [[NSData data] writeToURL:url atomically:YES]; // Always fail url (but valid)
+    NSMutableArray<XCTestExpectation *> *expectations = [NSMutableArray arrayWithCapacity:10];
     __block void (^recursiveBlock)(int);
     void (^mainBlock)(int) = ^(int i) {
-        if (i > 200) return;
+        if (i > 10) return;
         NSString *desc = [NSString stringWithFormat:@"Failed url with index %d should callback error", i];
         XCTestExpectation *expectation = [self expectationWithDescription:desc];
         [expectations addObject:expectation];
@@ -852,7 +855,6 @@
     
     [self waitForExpectations:expectations timeout:kAsyncTestTimeout * 2];
 }
-
 
 #pragma mark - SDWebImageLoader
 - (void)testCustomImageLoaderWorks {


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Seems using `/dev/null` is not safe to always get invalid image data 

