### PR TITLE
url is kind of NSString and shouldUseWeakMemoryCache is YES, APP will crash.

### DIFF
--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -61,6 +61,10 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                                                  setImageBlock:(nullable SDSetImageBlock)setImageBlock
                                                       progress:(nullable SDImageLoaderProgressBlock)progressBlock
                                                      completed:(nullable SDInternalCompletionBlock)completedBlock {
+    // if url is NSString and shouldUseWeakMemoryCache is true, [cacheKeyForURL:context] will crash.
+    if ([url isKindOfClass:NSString.class]) {
+        url = [NSURL URLWithString:(NSString *)url];
+    }
     if (context) {
         // copy to avoid mutable object
         context = [context copy];

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -61,10 +61,18 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                                                  setImageBlock:(nullable SDSetImageBlock)setImageBlock
                                                       progress:(nullable SDImageLoaderProgressBlock)progressBlock
                                                      completed:(nullable SDInternalCompletionBlock)completedBlock {
-    // if url is NSString and shouldUseWeakMemoryCache is true, [cacheKeyForURL:context] will crash.
+    
+    // Very common mistake is to send the URL using NSString object instead of NSURL. For some strange reason, Xcode won't
+    // throw any warning for this type mismatch. Here we failsafe this error by allowing URLs to be passed as NSString.
+    //  if url is NSString and shouldUseWeakMemoryCache is true, [cacheKeyForURL:context] will crash. just for a  global protect.
     if ([url isKindOfClass:NSString.class]) {
         url = [NSURL URLWithString:(NSString *)url];
     }
+    // Prevents app crashing on argument type error like sending NSNull instead of NSURL
+    if (![url isKindOfClass:NSURL.class]) {
+        url = nil;
+    }
+    
     if (context) {
         // copy to avoid mutable object
         context = [context copy];

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -63,35 +63,6 @@
     expect(image.sd_imageFrameCount).equal(5);
 }
 
-- (void)test04UIViewWebCacheCategory {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is nil"];
-    UIImageView *imageView = [[UIImageView alloc] init];
-    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
-    cache.config.shouldUseWeakMemoryCache = YES;
-    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
-    [imageView sd_setImageWithURL:[NSURL URLWithString:kTestJPEGURL] placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-        expect(image).notTo.beNil();
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithCommonTimeout];
-    
-}
-
-- (void)test05UIViewWebCacheCategory {
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is NSString"];
-    
-    UIImageView *imageView = [[UIImageView alloc] init];
-    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
-    cache.config.shouldUseWeakMemoryCache = YES;
-    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
-    [imageView sd_setImageWithURL:kTestJPEGURL placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-        expect(image).notTo.beNil();
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithCommonTimeout];
-}
-
 
 #pragma mark - Helper
 

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -63,6 +63,36 @@
     expect(image.sd_imageFrameCount).equal(5);
 }
 
+- (void)test04UIViewWebCacheCategory {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is nil"];
+    UIImageView *imageView = [[UIImageView alloc] init];
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
+    cache.config.shouldUseWeakMemoryCache = YES;
+    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
+    [imageView sd_setImageWithURL:[NSURL URLWithString:kTestJPEGURL] placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+    
+}
+
+- (void)test05UIViewWebCacheCategory {
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is NSString"];
+    
+    UIImageView *imageView = [[UIImageView alloc] init];
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
+    cache.config.shouldUseWeakMemoryCache = YES;
+    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
+    [imageView sd_setImageWithURL:kTestJPEGURL placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+
 #pragma mark - Helper
 
 - (NSString *)testJPEGPath {

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -63,7 +63,6 @@
     expect(image.sd_imageFrameCount).equal(5);
 }
 
-
 #pragma mark - Helper
 
 - (NSString *)testJPEGPath {

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -620,6 +620,52 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+// test url is nil
+- (void)testUIViewImageUrlForNilWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is nil"];
+    UIImageView *imageView = [[UIImageView alloc] init];
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
+    cache.config.shouldUseWeakMemoryCache = YES;
+    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
+    [imageView sd_setImageWithURL:nil placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        expect(image).to.beNil();
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+    
+}
+
+// test url is NSString
+- (void)testUIViewImageUrlForStringWorks {
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is NSString"];
+    
+    UIImageView *imageView = [[UIImageView alloc] init];
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
+    cache.config.shouldUseWeakMemoryCache = YES;
+    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
+    [imageView sd_setImageWithURL:kTestJPEGURL placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+// test url is NSURL
+- (void)testUIViewImageUrlForNSURLWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is NSURL"];
+    UIImageView *imageView = [[UIImageView alloc] init];
+    SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
+    cache.config.shouldUseWeakMemoryCache = YES;
+    SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
+    [imageView sd_setImageWithURL:[NSURL URLWithString:kTestJPEGURL] placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+        expect(image).notTo.beNil();
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+    
+}
+
 #pragma mark - Helper
 
 - (NSString *)testJPEGPath {

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -635,7 +635,7 @@
     
 }
 
-// test url is NSString
+// test url is NSString.
 - (void)testUIViewImageUrlForStringWorks {
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion is called with url is NSString"];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [] I have added the required tests to prove the fix/feature I am adding
* [] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

if url is NSString and shouldUseWeakMemoryCache is true, method [cacheKeyForURL:context] will crash.

...

