### PR TITLE
Replace NSFileManager.enumeratorAtPath with enumeratorAtURL for performance and RAM saving

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -268,8 +268,11 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
 
 - (NSUInteger)totalCount {
     NSUInteger count = 0;
-    NSDirectoryEnumerator<NSString *> *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
-    count = fileEnumerator.allObjects.count;
+    @autoreleasepool {
+        NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
+        NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL includingPropertiesForKeys:@[] options:(NSDirectoryEnumerationOptions)0 errorHandler:nil];
+        count = fileEnumerator.allObjects.count;
+    }
     return count;
 }
 

--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -165,7 +165,7 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, cacheContentDateKey, NSURLTotalFileAllocatedSizeKey];
     
     // This enumerator prefetches useful properties for our cache files.
-    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
+    NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
                                                includingPropertiesForKeys:resourceKeys
                                                                   options:NSDirectoryEnumerationSkipsHiddenFiles
                                                              errorHandler:NULL];
@@ -180,25 +180,27 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     //  2. Storing file attributes for the size-based cleanup pass.
     NSMutableArray<NSURL *> *urlsToDelete = [[NSMutableArray alloc] init];
     for (NSURL *fileURL in fileEnumerator) {
-        NSError *error;
-        NSDictionary<NSString *, id> *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
-        
-        // Skip directories and errors.
-        if (error || !resourceValues || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
-            continue;
+        @autoreleasepool {
+            NSError *error;
+            NSDictionary<NSString *, id> *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
+            
+            // Skip directories and errors.
+            if (error || !resourceValues || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
+                continue;
+            }
+            
+            // Remove files that are older than the expiration date;
+            NSDate *modifiedDate = resourceValues[cacheContentDateKey];
+            if (expirationDate && [[modifiedDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
+                [urlsToDelete addObject:fileURL];
+                continue;
+            }
+            
+            // Store a reference to this file and account for its total size.
+            NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+            currentCacheSize += totalAllocatedSize.unsignedIntegerValue;
+            cacheFiles[fileURL] = resourceValues;
         }
-        
-        // Remove files that are older than the expiration date;
-        NSDate *modifiedDate = resourceValues[cacheContentDateKey];
-        if (expirationDate && [[modifiedDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
-            [urlsToDelete addObject:fileURL];
-            continue;
-        }
-        
-        // Store a reference to this file and account for its total size.
-        NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
-        currentCacheSize += totalAllocatedSize.unsignedIntegerValue;
-        cacheFiles[fileURL] = resourceValues;
     }
     
     for (NSURL *fileURL in urlsToDelete) {
@@ -240,18 +242,41 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
 
 - (NSUInteger)totalSize {
     NSUInteger size = 0;
-    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
-    for (NSString *fileName in fileEnumerator) {
-        NSString *filePath = [self.diskCachePath stringByAppendingPathComponent:fileName];
-        NSDictionary<NSString *, id> *attrs = [self.fileManager attributesOfItemAtPath:filePath error:nil];
-        size += [attrs fileSize];
+
+    // Use URL-based enumerator instead of Path(NSString *)-based enumerator to reduce
+    // those objects(ex. NSPathStore2/_NSCFString/NSConcreteData) created during traversal.
+    // Even worse, those objects are added into AutoreleasePool, in background threads, 
+    // the time to release those objects is undifined(according to the usage of CPU)
+    // It will truely consumes a lot of VM, up to cause OOMs. 
+    NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
+    if (@available (iOS 13, *)) {
+        // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator 
+        // to always produce file path URLs relative to the directoryURL. This can reduce 
+        // the size of each URL object returned during enumeration.
+        options |= NSDirectoryEnumerationProducesRelativePathURLs;
+    }
+    
+    @autoreleasepool {
+        NSURL *pathURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
+        NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:pathURL
+                                                  includingPropertiesForKeys:@[NSURLFileSizeKey]
+                                                                     options:options
+                                                                errorHandler:NULL];
+        
+        for (NSURL *fileURL in fileEnumerator) {
+            @autoreleasepool {
+                NSNumber *fileSize;
+                [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:NULL];
+                size += fileSize.unsignedIntegerValue;
+            }
+        }
     }
     return size;
 }
 
 - (NSUInteger)totalCount {
     NSUInteger count = 0;
-    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
+    NSDirectoryEnumerator<NSString *> *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
     count = fileEnumerator.allObjects.count;
     return count;
 }
@@ -295,13 +320,29 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
         }
     } else {
         // New directory exist, merge the files
-        NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
-        NSString *file;
-        while ((file = [dirEnumerator nextObject])) {
-            [self.fileManager moveItemAtPath:[srcPath stringByAppendingPathComponent:file] toPath:[dstPath stringByAppendingPathComponent:file] error:nil];
+        NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
+        if (@available (iOS 13, *)) {
+            // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator
+            // to always produce file path URLs relative to the directoryURL. This can reduce
+            // the size of each URL object returned during enumeration.
+            options |= NSDirectoryEnumerationProducesRelativePathURLs;
         }
+        
+        NSURL *srcURL = [NSURL fileURLWithPath:srcPath isDirectory:YES];
+        NSDirectoryEnumerator<NSURL *> *srcDirEnumerator = [self.fileManager enumeratorAtURL:srcURL
+                                                               includingPropertiesForKeys:@[]
+                                                                                  options:options
+                                                                             errorHandler:NULL];
+        for (NSURL *url in srcDirEnumerator) {
+            @autoreleasepool {
+                NSString *dstFilePath = [dstPath stringByAppendingPathComponent:url.lastPathComponent];
+                NSURL *dstFileURL = [NSURL fileURLWithPath:dstFilePath isDirectory:NO];
+                [self.fileManager moveItemAtURL:url toURL:dstFileURL error:nil];
+            }
+        }
+        
         // Remove the old path
-        [self.fileManager removeItemAtPath:srcPath error:nil];
+        [self.fileManager removeItemAtURL:srcURL error:nil];
     }
 }
 

--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -247,20 +247,12 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     // those objects(ex. NSPathStore2/_NSCFString/NSConcreteData) created during traversal.
     // Even worse, those objects are added into AutoreleasePool, in background threads, 
     // the time to release those objects is undifined(according to the usage of CPU)
-    // It will truely consumes a lot of VM, up to cause OOMs. 
-    NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
-    if (@available (iOS 13, *)) {
-        // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator 
-        // to always produce file path URLs relative to the directoryURL. This can reduce 
-        // the size of each URL object returned during enumeration.
-        options |= NSDirectoryEnumerationProducesRelativePathURLs;
-    }
-    
+    // It will truely consumes a lot of VM, up to cause OOMs.
     @autoreleasepool {
         NSURL *pathURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
         NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:pathURL
                                                   includingPropertiesForKeys:@[NSURLFileSizeKey]
-                                                                     options:options
+                                                                     options:(NSDirectoryEnumerationOptions)0
                                                                 errorHandler:NULL];
         
         for (NSURL *fileURL in fileEnumerator) {
@@ -320,18 +312,10 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
         }
     } else {
         // New directory exist, merge the files
-        NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
-        if (@available (iOS 13, *)) {
-            // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator
-            // to always produce file path URLs relative to the directoryURL. This can reduce
-            // the size of each URL object returned during enumeration.
-            options |= NSDirectoryEnumerationProducesRelativePathURLs;
-        }
-        
         NSURL *srcURL = [NSURL fileURLWithPath:srcPath isDirectory:YES];
         NSDirectoryEnumerator<NSURL *> *srcDirEnumerator = [self.fileManager enumeratorAtURL:srcURL
                                                                includingPropertiesForKeys:@[]
-                                                                                  options:options
+                                                                                  options:(NSDirectoryEnumerationOptions)0
                                                                              errorHandler:NULL];
         for (NSURL *url in srcDirEnumerator) {
             @autoreleasepool {

--- a/SDWebImage/Core/SDImageCacheConfig.h
+++ b/SDWebImage/Core/SDImageCacheConfig.h
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 
 /**
  * The dispatch queue attr for ioQueue. You can config the QoS and concurrent/serial to internal IO queue. The ioQueue is used by SDImageCache to access read/write for disk data.
- * Defaults we use `DISPATCH_QUEUE_SERIAL`(NULL), to use serial dispatch queue to ensure single access for disk data. It's safe but may be slow.
+ * Defaults we use `DISPATCH_QUEUE_SERIAL`(NULL) under iOS 10, `DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL` above and equal iOS 10, using serial dispatch queue is to ensure single access for disk data. It's safe but may be slow.
  * @note You can override this to use `DISPATCH_QUEUE_CONCURRENT`, use concurrent queue.
  * @warning **MAKE SURE** to keep `diskCacheWritingOptions` to use `NSDataWritingAtomic`, or concurrent queue may cause corrupted disk data (because multiple threads read/write same file without atomic is not IO-safe).
  * @note This value does not support dynamic changes. Which means further modification on this value after cache initialized has no effect.

--- a/SDWebImage/Core/SDImageCacheConfig.m
+++ b/SDWebImage/Core/SDImageCacheConfig.m
@@ -36,7 +36,11 @@ static const NSInteger kDefaultCacheMaxDiskAge = 60 * 60 * 24 * 7; // 1 week
         _maxDiskSize = 0;
         _diskCacheExpireType = SDImageCacheConfigExpireTypeModificationDate;
         _fileManager = nil;
-        _ioQueueAttributes = DISPATCH_QUEUE_SERIAL; // NULL
+        if (@available(iOS 10.0, *)) {
+            _ioQueueAttributes = DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL; // DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM
+        } else {
+            _ioQueueAttributes = DISPATCH_QUEUE_SERIAL; // NULL
+        }
         _memoryCacheClass = [SDMemoryCache class];
         _diskCacheClass = [SDDiskCache class];
     }

--- a/SDWebImage/Core/SDImageCacheConfig.m
+++ b/SDWebImage/Core/SDImageCacheConfig.m
@@ -36,7 +36,7 @@ static const NSInteger kDefaultCacheMaxDiskAge = 60 * 60 * 24 * 7; // 1 week
         _maxDiskSize = 0;
         _diskCacheExpireType = SDImageCacheConfigExpireTypeModificationDate;
         _fileManager = nil;
-        if (@available(iOS 10.0, *)) {
+        if (@available(iOS 10.0, tvOS 10.0, macOS 10.12, watchOS 3.0, *)) {
             _ioQueueAttributes = DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL; // DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM
         } else {
             _ioQueueAttributes = DISPATCH_QUEUE_SERIAL; // NULL

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -563,7 +563,13 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     NSString *newDefaultPath = [[[self userCacheDirectory] stringByAppendingPathComponent:@"com.hackemist.SDImageCache"] stringByAppendingPathComponent:@"default"];
     NSString *oldDefaultPath = [[[self userCacheDirectory] stringByAppendingPathComponent:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDWebImageCache.default"];
     [fileManager createDirectoryAtPath:oldDefaultPath withIntermediateDirectories:YES attributes:nil error:nil];
-    [fileManager createFileAtPath:[oldDefaultPath stringByAppendingPathComponent:@"a.png"] contents:[NSData dataWithContentsOfFile:[self testPNGPath]] attributes:nil];
+    
+    // Create 100 files to Migrate
+    for (NSUInteger i = 0; i < 100; i++) {
+        NSString *fileName = [NSString stringWithFormat:@"a%@.png", @(i)];
+        [fileManager createFileAtPath:[oldDefaultPath stringByAppendingPathComponent:fileName] contents:[NSData dataWithContentsOfFile:[self testPNGPath]] attributes:nil];
+    }
+    
     // Call migration
     SDDiskCache *diskCache = [[SDDiskCache alloc] initWithCachePath:newDefaultPath config:config];
     [diskCache moveCacheDirectoryFromPath:oldDefaultPath toPath:newDefaultPath];

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -559,7 +559,7 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     NSFileManager *fileManager = [[NSFileManager alloc] init];
     config.fileManager = fileManager;
     
-    // Fake to store a.png into old path
+    // Fake to store a%@.png into old path
     NSString *newDefaultPath = [[[self userCacheDirectory] stringByAppendingPathComponent:@"com.hackemist.SDImageCache"] stringByAppendingPathComponent:@"default"];
     NSString *oldDefaultPath = [[[self userCacheDirectory] stringByAppendingPathComponent:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDWebImageCache.default"];
     [fileManager createDirectoryAtPath:oldDefaultPath withIntermediateDirectories:YES attributes:nil error:nil];
@@ -574,12 +574,15 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     SDDiskCache *diskCache = [[SDDiskCache alloc] initWithCachePath:newDefaultPath config:config];
     [diskCache moveCacheDirectoryFromPath:oldDefaultPath toPath:newDefaultPath];
     
-    // Expect a.png into new path and oldDefaultPath is deleted
+    // Expect a%@.png into new path and oldDefaultPath is deleted
     BOOL isDirectory = NO;
-    BOOL newFileExist = [fileManager fileExistsAtPath:[newDefaultPath stringByAppendingPathComponent:@"a.png"] isDirectory:&isDirectory];
+    for (NSUInteger i = 0; i < 100; i++) {
+        NSString *fileName = [NSString stringWithFormat:@"a%@.png", @(i)];
+        BOOL newFileExist = [fileManager fileExistsAtPath:[newDefaultPath stringByAppendingPathComponent:fileName] isDirectory:&isDirectory];
+        expect(newFileExist).beTruthy();
+        expect(isDirectory).beFalsy();
+    }
     BOOL oldDefaultPathExist = [fileManager fileExistsAtPath:oldDefaultPath];
-    expect(newFileExist).beTruthy();
-    expect(isDirectory).beFalsy();
     expect(oldDefaultPathExist).beFalsy();
 }
 

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -568,9 +568,13 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     SDDiskCache *diskCache = [[SDDiskCache alloc] initWithCachePath:newDefaultPath config:config];
     [diskCache moveCacheDirectoryFromPath:oldDefaultPath toPath:newDefaultPath];
     
-    // Expect a.png into new path
-    BOOL exist = [fileManager fileExistsAtPath:[newDefaultPath stringByAppendingPathComponent:@"a.png"]];
-    expect(exist).beTruthy();
+    // Expect a.png into new path and oldDefaultPath is deleted
+    BOOL isDirectory = NO;
+    BOOL newFileExist = [fileManager fileExistsAtPath:[newDefaultPath stringByAppendingPathComponent:@"a.png"] isDirectory:&isDirectory];
+    BOOL oldDefaultPathExist = [fileManager fileExistsAtPath:oldDefaultPath];
+    expect(newFileExist).beTruthy();
+    expect(isDirectory).beFalsy();
+    expect(oldDefaultPathExist).beFalsy();
 }
 
 - (void)test45DiskCacheRemoveExpiredData {

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -73,16 +73,9 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
 
 - (void)removeAllData {
     NSURL *srcURL = [NSURL fileURLWithPath:self.cachePath isDirectory:YES];
-    NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
-    if (@available (iOS 13, *)) {
-        // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator
-        // to always produce file path URLs relative to the directoryURL. This can reduce
-        // the size of each URL object returned during enumeration.
-        options |= NSDirectoryEnumerationProducesRelativePathURLs;
-    }
     NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:srcURL
                                                   includingPropertiesForKeys:@[]
-                                                                     options:options
+                                                                     options:(NSDirectoryEnumerationOptions)0
                                                                 errorHandler:NULL];
     for (NSURL *url in fileEnumerator) {
         @autoreleasepool {
@@ -137,19 +130,11 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
 
 - (NSUInteger)totalSize {
     NSUInteger size = 0;
-    NSDirectoryEnumerationOptions options = (NSDirectoryEnumerationOptions)0;
-    if (@available (iOS 13, *)) {
-        // NSDirectoryEnumerationProducesRelativePathURLs causes the NSDirectoryEnumerator 
-        // to always produce file path URLs relative to the directoryURL. This can reduce 
-        // the size of each URL object returned during enumeration.
-        options |= NSDirectoryEnumerationProducesRelativePathURLs;
-    }
-    
     @autoreleasepool {
         NSURL *pathURL = [NSURL fileURLWithPath:self.cachePath isDirectory:YES];
         NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:pathURL
                                                   includingPropertiesForKeys:@[NSURLFileSizeKey]
-                                                                     options:options
+                                                                     options:(NSDirectoryEnumerationOptions)0
                                                                 errorHandler:NULL];
         
         for (NSURL *fileURL in fileEnumerator) {


### PR DESCRIPTION
1. repalce ``@selector(enumeratorAtURL:)`` with ``@selector(enumeratorAtURL:)``
2. replace ``SDImageCacheConfig.ioQueueAttributes`` from ``DISPATCH_QUEUE_SERIAL`` to ``DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL`` >= ``iOS 10``

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

