### PR TITLE
Modify the definition of SDImageFormat to extern to avoid creating multiple global variables

### DIFF
--- a/SDWebImage/Core/NSData+ImageContentType.h
+++ b/SDWebImage/Core/NSData+ImageContentType.h
@@ -15,18 +15,18 @@
  For custom coder plugin, it can also extern the enum for supported format. See `SDImageCoder` for more detailed information.
  */
 typedef NSInteger SDImageFormat NS_TYPED_EXTENSIBLE_ENUM;
-static const SDImageFormat SDImageFormatUndefined = -1;
-static const SDImageFormat SDImageFormatJPEG      = 0;
-static const SDImageFormat SDImageFormatPNG       = 1;
-static const SDImageFormat SDImageFormatGIF       = 2;
-static const SDImageFormat SDImageFormatTIFF      = 3;
-static const SDImageFormat SDImageFormatWebP      = 4;
-static const SDImageFormat SDImageFormatHEIC      = 5;
-static const SDImageFormat SDImageFormatHEIF      = 6;
-static const SDImageFormat SDImageFormatPDF       = 7;
-static const SDImageFormat SDImageFormatSVG       = 8;
-static const SDImageFormat SDImageFormatBMP       = 9;
-static const SDImageFormat SDImageFormatRAW       = 10;
+extern const SDImageFormat SDImageFormatUndefined;
+extern const SDImageFormat SDImageFormatJPEG;
+extern const SDImageFormat SDImageFormatPNG;
+extern const SDImageFormat SDImageFormatGIF;
+extern const SDImageFormat SDImageFormatTIFF;
+extern const SDImageFormat SDImageFormatWebP;
+extern const SDImageFormat SDImageFormatHEIC;
+extern const SDImageFormat SDImageFormatHEIF;
+extern const SDImageFormat SDImageFormatPDF;
+extern const SDImageFormat SDImageFormatSVG;
+extern const SDImageFormat SDImageFormatBMP;
+extern const SDImageFormat SDImageFormatRAW;
 
 /**
  NSData category about the image content type and UTI.

--- a/SDWebImage/Core/NSData+ImageContentType.m
+++ b/SDWebImage/Core/NSData+ImageContentType.m
@@ -17,6 +17,19 @@
 
 #define kSVGTagEnd @"</svg>"
 
+const SDImageFormat SDImageFormatUndefined = -1;
+const SDImageFormat SDImageFormatJPEG      = 0;
+const SDImageFormat SDImageFormatPNG       = 1;
+const SDImageFormat SDImageFormatGIF       = 2;
+const SDImageFormat SDImageFormatTIFF      = 3;
+const SDImageFormat SDImageFormatWebP      = 4;
+const SDImageFormat SDImageFormatHEIC      = 5;
+const SDImageFormat SDImageFormatHEIF      = 6;
+const SDImageFormat SDImageFormatPDF       = 7;
+const SDImageFormat SDImageFormatSVG       = 8;
+const SDImageFormat SDImageFormatBMP       = 9;
+const SDImageFormat SDImageFormatRAW       = 10;
+
 @implementation NSData (ImageContentType)
 
 + (SDImageFormat)sd_imageFormatForImageData:(nullable NSData *)data {

--- a/SDWebImage/Core/SDImageAWebPCoder.m
+++ b/SDWebImage/Core/SDImageAWebPCoder.m
@@ -42,12 +42,11 @@ static NSString * kSDCGImagePropertyWebPUnclampedDelayTime = @"UnclampedDelayTim
 #pragma mark - SDImageCoder
 
 - (BOOL)canDecodeFromData:(nullable NSData *)data {
-    switch ([NSData sd_imageFormatForImageData:data]) {
-        case SDImageFormatWebP:
-            // Check WebP decoding compatibility
-            return [self.class canDecodeFromFormat:SDImageFormatWebP];
-        default:
-            return NO;
+    if ([NSData sd_imageFormatForImageData:data] == SDImageFormatWebP) {
+        // Check WebP decoding compatibility
+        return [self.class canDecodeFromFormat:SDImageFormatWebP];
+    } else {
+        return NO;
     }
 }
 
@@ -56,12 +55,11 @@ static NSString * kSDCGImagePropertyWebPUnclampedDelayTime = @"UnclampedDelayTim
 }
 
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
-    switch (format) {
-        case SDImageFormatWebP:
-            // Check WebP encoding compatibility
-            return [self.class canEncodeToFormat:SDImageFormatWebP];
-        default:
-            return NO;
+    if (format == SDImageFormatWebP) {
+        // Check WebP encoding compatibility
+        return [self.class canEncodeToFormat:SDImageFormatWebP];
+    } else {
+        return NO;
     }
 }
 

--- a/SDWebImage/Core/SDImageHEICCoder.m
+++ b/SDWebImage/Core/SDImageHEICCoder.m
@@ -39,15 +39,15 @@ static NSString * kSDCGImagePropertyHEICSUnclampedDelayTime = @"UnclampedDelayTi
 #pragma mark - SDImageCoder
 
 - (BOOL)canDecodeFromData:(nullable NSData *)data {
-    switch ([NSData sd_imageFormatForImageData:data]) {
-        case SDImageFormatHEIC:
-            // Check HEIC decoding compatibility
-            return [self.class canDecodeFromFormat:SDImageFormatHEIC];
-        case SDImageFormatHEIF:
-            // Check HEIF decoding compatibility
-            return [self.class canDecodeFromFormat:SDImageFormatHEIF];
-        default:
-            return NO;
+    SDImageFormat format = [NSData sd_imageFormatForImageData:data];
+    if (format == SDImageFormatHEIC) {
+        // Check HEIC decoding compatibility
+        return [self.class canDecodeFromFormat:SDImageFormatHEIC];
+    } else if (format == SDImageFormatHEIF) {
+        // Check HEIF decoding compatibility
+        return [self.class canDecodeFromFormat:SDImageFormatHEIF];
+    } else {
+        return NO;
     }
 }
 
@@ -56,15 +56,14 @@ static NSString * kSDCGImagePropertyHEICSUnclampedDelayTime = @"UnclampedDelayTi
 }
 
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
-    switch (format) {
-        case SDImageFormatHEIC:
-            // Check HEIC encoding compatibility
-            return [self.class canEncodeToFormat:SDImageFormatHEIC];
-        case SDImageFormatHEIF:
-            // Check HEIF encoding compatibility
-            return [self.class canEncodeToFormat:SDImageFormatHEIF];
-        default:
-            return NO;
+    if (format == SDImageFormatHEIC) {
+        // Check HEIC encoding compatibility
+        return [self.class canEncodeToFormat:SDImageFormatHEIC];
+    } else if (format == SDImageFormatHEIF) {
+        // Check HEIF encoding compatibility
+        return [self.class canEncodeToFormat:SDImageFormatHEIF];
+    } else {
+        return NO;
     }
 }
 


### PR DESCRIPTION
I found that several formats about SDImageFormat are static variables defined in a header file. When the program is compiled and linked, any .m file that imports or indirectly imports this header will create a static variable inside the file. This results in an increase in useless binary size. In fact, only need to declare these variables as extern and assign values ​​inside a certain .m file, so that there will only be one copy of these variables in the entire binary.