### PR TITLE
Fix some regression when SDAnimatedImage created with static format like JPEG

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -335,7 +335,7 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 @implementation SDAnimatedImage (Metadata)
 
 - (BOOL)sd_isAnimated {
-    return YES;
+    return self.animatedImageFrameCount > 1;
 }
 
 - (NSUInteger)sd_imageLoopCount {
@@ -347,11 +347,21 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 }
 
 - (NSUInteger)sd_imageFrameCount {
-    return self.animatedImageFrameCount;
+    NSUInteger frameCount = self.animatedImageFrameCount;
+    if (frameCount > 1) {
+        return frameCount;
+    } else {
+        return 1;
+    }
 }
 
 - (SDImageFormat)sd_imageFormat {
-    return self.animatedImageFormat;
+    NSData *animatedImageData = self.animatedImageData;
+    if (animatedImageData) {
+        return [NSData sd_imageFormatForImageData:animatedImageData];
+    } else {
+        return [super sd_imageFormat];
+    }
 }
 
 - (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {

--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -129,12 +129,12 @@
     
     // We need call super method to keep function. This will impliedly call `setNeedsDisplay`. But we have no way to avoid this when using animated image. So we call `setNeedsDisplay` again at the end.
     super.image = image;
-    if ([image.class conformsToProtocol:@protocol(SDAnimatedImage)]) {
+    if ([image.class conformsToProtocol:@protocol(SDAnimatedImage)] && [(id<SDAnimatedImage>)image animatedImageFrameCount] > 1) {
         if (!self.player) {
             id<SDAnimatedImageProvider> provider;
             // Check progressive loading
             if (self.isProgressive) {
-                provider = [self progressiveAnimatedCoderForImage:image];
+                provider = [(id<SDAnimatedImage>)image animatedCoder];
             } else {
                 provider = (id<SDAnimatedImage>)image;
             }

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -84,7 +84,11 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
             }
         }
     }
-    if (!scaledImage && image.sd_isAnimated) {
+    if (scaledImage) {
+        SDImageCopyAssociatedObject(image, scaledImage);
+        return scaledImage;
+    }
+    if (image.sd_isAnimated) {
         UIImage *animatedImage;
 #if SD_UIKIT || SD_WATCH
         // `UIAnimatedImage` images share the same size and scale.
@@ -120,9 +124,12 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
         scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
     }
-    SDImageCopyAssociatedObject(image, scaledImage);
+    if (scaledImage) {
+        SDImageCopyAssociatedObject(image, scaledImage);
+        return scaledImage;
+    }
     
-    return scaledImage;
+    return nil;
 }
 
 #pragma mark - Context option

--- a/SDWebImage/Core/SDWebImageDefine.m
+++ b/SDWebImage/Core/SDWebImageDefine.m
@@ -83,11 +83,8 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
                 scaledImage = [[image.class alloc] initWithData:data scale:scale];
             }
         }
-        if (scaledImage) {
-            return scaledImage;
-        }
     }
-    if (image.sd_isAnimated) {
+    if (!scaledImage && image.sd_isAnimated) {
         UIImage *animatedImage;
 #if SD_UIKIT || SD_WATCH
         // `UIAnimatedImage` images share the same size and scale.
@@ -100,7 +97,6 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
         }
         
         animatedImage = [UIImage animatedImageWithImages:scaledImages duration:image.duration];
-        animatedImage.sd_imageLoopCount = image.sd_imageLoopCount;
 #else
         // Animated GIF for `NSImage` need to grab `NSBitmapImageRep`;
         NSRect imageRect = NSMakeRect(0, 0, image.size.width, image.size.height);

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -38,7 +38,7 @@
  * Returns the underlaying `NSBitmapImageRep` or `SDAnimatedImageRep` frame count.
  * Returns 1 for static image.
  * SDAnimatedImage:
- * Returns `animatedImageFrameCount`
+ * Returns `animatedImageFrameCount` for animated image, 1 for static image.
  */
 @property (nonatomic, assign, readonly) NSUInteger sd_imageFrameCount;
 

--- a/SDWebImage/Core/UIImage+Metadata.h
+++ b/SDWebImage/Core/UIImage+Metadata.h
@@ -24,6 +24,8 @@
  * NSImage currently only support animated via `NSBitmapImageRep`(GIF) or `SDAnimatedImageRep`(APNG/GIF/WebP) unlike UIImage.
  * The getter of this property will get the loop count from animated imageRep
  * The setter of this property will set the loop count from animated imageRep
+ * SDAnimatedImage:
+ * Returns `animatedImageLoopCount`
  */
 @property (nonatomic, assign) NSUInteger sd_imageLoopCount;
 
@@ -35,6 +37,8 @@
  * AppKit:
  * Returns the underlaying `NSBitmapImageRep` or `SDAnimatedImageRep` frame count.
  * Returns 1 for static image.
+ * SDAnimatedImage:
+ * Returns `animatedImageFrameCount`
  */
 @property (nonatomic, assign, readonly) NSUInteger sd_imageFrameCount;
 
@@ -42,7 +46,9 @@
  * UIKit:
  * Check the `images` array property.
  * AppKit:
- * NSImage currently only support animated via GIF imageRep unlike UIImage. It will check the imageRep's frame count.
+ * NSImage currently only support animated via GIF imageRep unlike UIImage. It will check the imageRep's frame count > 1.
+ * SDAnimatedImage:
+ * Check `animatedImageFrameCount` > 1
  */
 @property (nonatomic, assign, readonly) BOOL sd_isAnimated;
 
@@ -51,6 +57,8 @@
  * Check the `isSymbolImage` property. Also check the system PDF(iOS 11+) && SVG(iOS 13+) support.
  * AppKit:
  * NSImage supports PDF && SVG && EPS imageRep, check the imageRep class.
+ * SDAnimatedImage:
+ * Returns `NO`
  */
 @property (nonatomic, assign, readonly) BOOL sd_isVector;
 
@@ -58,6 +66,7 @@
  * The image format represent the original compressed image data format.
  * If you don't manually specify a format, this information is retrieve from CGImage using `CGImageGetUTType`, which may return nil for non-CG based image. At this time it will return `SDImageFormatUndefined` as default value.
  * @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
+ * @note For `SDAnimatedImage`, returns `animatedImageFormat` when animated, or fallback when static.
  */
 @property (nonatomic, assign) SDImageFormat sd_imageFormat;
 

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -786,6 +786,22 @@ static BOOL _isCalled;
 }
 #endif
 
+- (void)test37AnimatedImageWithStaticDataBehavior {
+    UIImage *image = [[SDAnimatedImage alloc] initWithData:[self testJPEGData]];
+    // UIImage+Metadata.h
+    expect(image).notTo.beNil();
+    expect(image.sd_isAnimated).beFalsy();
+    expect(image.sd_imageFormat).equal(SDImageFormatJPEG);
+    expect(image.sd_imageFrameCount).equal(1);
+    expect(image.sd_imageLoopCount).equal(0);
+    // SDImageCoderHelper.h
+    UIImage *decodedImage = [SDImageCoderHelper decodedImageWithImage:image policy:SDImageForceDecodePolicyAutomatic];
+    expect(decodedImage).notTo.equal(image);
+    // SDWebImageDefine.h
+    UIImage *scaledImage = SDScaledImageForScaleFactor(2.0, image);
+    expect(scaledImage).notTo.equal(image);
+}
+
 #pragma mark - Helper
 
 - (NSString *)testGIFPath {

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -644,7 +644,7 @@
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"Test"];
     cache.config.shouldUseWeakMemoryCache = YES;
     SDWebImageManager *imageManager = [[SDWebImageManager alloc] initWithCache:cache loader:[SDWebImageDownloader sharedDownloader]];
-    [imageView sd_setImageWithURL:kTestJPEGURL placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+    [imageView sd_setImageWithURL:(NSURL *)kTestJPEGURL placeholderImage:nil options:0 context:@{SDWebImageContextCustomManager:imageManager} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         expect(image).notTo.beNil();
         [expectation fulfill];
     }];


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: close #3706 

### Pull Request Description

For now, I still prefer to keep the idea that `SDAnimatedImage` can be created with non-static format like JPEG.

Why ?  Because even without the changes in #3626, you can still do hack using `NSCoder` to create a JPEG `SDAnimatedImage` object, before 5.19.0 version...😂 (See the line of code)

![image](https://github.com/SDWebImage/SDWebImage/assets/6919743/25e03372-3f06-42df-b403-46c204da6188)


And this, match the behavior like `subclassing` (For the same input param, the parent class `UIImage` can init successfully, but why a subclass return nil ?)

And this matches the YYImage's behavior, it's more easy to keep sync of that https://github.com/SDWebImage/SDWebImageYYPlugin

CC @LeoTheCatMeow

