### PR TITLE
Fix that `colorSpaceGetDeviceRGB` cache the color space even when active display changed

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -290,22 +290,23 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 }
 
 + (CGColorSpaceRef)colorSpaceGetDeviceRGB {
+#if SD_MAC
+    NSScreen *mainScreen = nil;
+    if (@available(macOS 10.12, *)) {
+        mainScreen = [NSScreen mainScreen];
+    } else {
+        mainScreen = [NSScreen screens].firstObject;
+    }
+    CGColorSpaceRef colorSpace = mainScreen.colorSpace.CGColorSpace;
+    return colorSpace;
+#else
     static CGColorSpaceRef colorSpace;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#if SD_MAC
-        NSScreen *mainScreen = nil;
-        if (@available(macOS 10.12, *)) {
-            mainScreen = [NSScreen mainScreen];
-        } else {
-            mainScreen = [NSScreen screens].firstObject;
-        }
-        colorSpace = mainScreen.colorSpace.CGColorSpace;
-#else
         colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
-#endif
     });
     return colorSpace;
+#endif
 }
 
 + (SDImagePixelFormat)preferredPixelFormat:(BOOL)containsAlpha {

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -217,7 +217,7 @@
 - (void)test14ThatHEIFWorks {
     if (@available(iOS 11, tvOS 11, macOS 10.13, *)) {
         NSURL *heifURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestImage" withExtension:@"heif"];
-        BOOL supportsEncoding = !SDTestCase.isCI; // GitHub Action Mac env currently does not support HEIC encoding
+        BOOL supportsEncoding = NO; // public.heif UTI alwsays return false, use public.heic
         [self verifyCoder:[SDImageIOCoder sharedCoder]
         withLocalImageURL:heifURL
          supportsEncoding:supportsEncoding


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This was found during the test case `testSDGraphicsImageRenderer`

```
Draw Color ColorSpace: <CGColor 0x6000027c5620> [<CGColorSpace 0x6000027c48a0> (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1)] ( 1 0 0 1 )

Test Color ColorSpace: <CGColor 0x6000027c5980> [<CGColorSpace 0x6000027c48a0> (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1)] ( 0.978015 0.00459104 0.00225032 1 )
```

Also, fix the unit test on macOS.

