### PR TITLE
Fix our HEIC coder to encode `timed image sequences` instead of `non-timed image gallery` for HEIC encoding

### DIFF
--- a/SDWebImage/Core/SDImageHEICCoder.m
+++ b/SDWebImage/Core/SDImageHEICCoder.m
@@ -75,7 +75,11 @@ static NSString * kSDCGImagePropertyHEICSUnclampedDelayTime = @"UnclampedDelayTi
 }
 
 + (NSString *)imageUTType {
-    return (__bridge NSString *)kSDUTTypeHEIC;
+    // See: https://nokiatech.github.io/heif/technical.html
+    // Actually HEIC has another concept called `non-timed Image Sequence`, which can be encoded using `public.heic`
+    // But current SDWebImage does not has this design, I don't know whether there are use case for this
+    // So we just replace and always use `timed Image Sequence`, means, animated image for encoding
+    return (__bridge NSString *)kSDUTTypeHEICS;
 }
 
 + (NSString *)dictionaryProperty {

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -832,11 +832,11 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     }
     
     NSMutableData *imageData = [NSMutableData data];
-    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:format];
+    NSString *imageUTType = self.class.imageUTType;
     
     // Create an image destination. Animated Image does not support EXIF image orientation TODO
     // The `CGImageDestinationCreateWithData` will log a warning when count is 0, use 1 instead.
-    CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frames.count ?: 1, NULL);
+    CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, (__bridge CFStringRef)imageUTType, frames.count ?: 1, NULL);
     if (!imageDestination) {
         // Handle failure.
         return nil;
@@ -921,6 +921,11 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     }
     
     CFRelease(imageDestination);
+    
+    // In some beta version, ImageIO `CGImageDestinationFinalize` returns success, but the data buffer is 0 bytes length.
+    if (imageData.length == 0) {
+        return nil;
+    }
     
     return [imageData copy];
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Also, some little behavior changes, the `format` arg in animated coder does not help for anything.

This close #3726 

