### PR TITLE
Use the new macro from Swift compiler and SDK to mark the UIImage/UIImageView subclass matching what they designed to be

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.h
+++ b/SDWebImage/Core/SDAnimatedImage.h
@@ -68,6 +68,7 @@
 /**
  The image class which supports animating on `SDAnimatedImageView`. You can also use it on normal UIImageView/NSImageView.
  */
+NS_SWIFT_NONISOLATED
 @interface SDAnimatedImage : UIImage <SDAnimatedImage>
 
 // This class override these methods from UIImage(NSImage), and it supports NSSecureCoding.

--- a/SDWebImage/Core/SDAnimatedImageView.h
+++ b/SDWebImage/Core/SDAnimatedImageView.h
@@ -19,6 +19,7 @@
  For UIKit: use `-startAnimating`, `-stopAnimating` to control animating. `isAnimating` to check animation state.
  For AppKit: use `-setAnimates:` to control animating, `animates` to check animation state. This view is layer-backed.
  */
+NS_SWIFT_UI_ACTOR
 @interface SDAnimatedImageView : UIImageView
 /**
  The internal animation player.


### PR DESCRIPTION
### Pull Request Description
This close #3729 

UIImage subclass should be thread-safe
UIImageView subclass should be on MainActor only

CC @LeoTheCatMeow