### PR TITLE
Fix the crash when some special urls cause the cache path return nil and crash

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -64,6 +64,11 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
 - (NSData *)dataForKey:(NSString *)key {
     NSParameterAssert(key);
     NSString *filePath = [self cachePathForKey:key];
+    // if filePath is nil or (null)，framework will crash with this：
+    // Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[_NSPlaceholderData initWithContentsOfFile:options:maxLength:error:]: nil file argument'
+    if (filePath == nil || [@"(null)" isEqualToString: filePath]) {
+        return nil;
+    }
     NSData *data = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
         return data;


### PR DESCRIPTION
  if filePath is nil or (null)，framework will crash with this：
 Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[_NSPlaceholderData initWithContentsOfFile:options:maxLength:error:]: nil file argument'
 at - (NSData *)dataForKey:(NSString *)key in the file Core/SDDiskCache.m


