### PR TITLE
Fix the thumbnail decoding on JPEG which contains EXIF orientation, use the new way to workaround JFIF bug

### DIFF
--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -547,15 +547,23 @@
 }
 
 - (void)test29ThatJFIFDecodeOrientationShouldNotApplyTwice {
+    // I don't think this is SDWebImage's issue, it's Apple's ImgeIO Bug, but user complain about this: #3594
+    // In W3C standard, JFIF should always be orientation up, and should not contains EXIF orientation
+    // But some bad image editing tool will generate this kind of image :(
     NSURL *url = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestJFIF" withExtension:@"jpg"];
     NSData *data = [NSData dataWithContentsOfURL:url];
     
     UIImage *image = [SDImageIOCoder.sharedCoder decodedImageWithData:data options:nil];
+    expect(image.sd_imageFormat).equal(SDImageFormatJPEG);
 #if SD_UIKIT
     UIImageOrientation orientation = image.imageOrientation;
-    expect(orientation).equal(UIImageOrientationUp);
-#else
-    expect(image.sd_imageFormat).equal(SDImageFormatJPEG);
+    expect(orientation).equal(UIImageOrientationDown);
+#endif
+    
+    UIImage *systemImage = [[UIImage alloc] initWithData:data];
+#if SD_UIKIT
+    orientation = image.imageOrientation;
+    expect(orientation).equal(UIImageOrientationDown);
 #endif
     
     // Manual test again for Apple's API


### PR DESCRIPTION


### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This can close #3742 

and also workaround that strange JFIF image bug in #3594
