### PR TITLE
Fix alpha not applying to tinted image

### DIFF
--- a/SDWebImage/Core/UIImage+Transform.m
+++ b/SDWebImage/Core/UIImage+Transform.m
@@ -566,7 +566,7 @@ static inline CGImageRef _Nullable SDCreateCGImageFromCIImage(CIImage * _Nonnull
     CGFloat scale = self.scale;
     
     // blend mode, see https://en.wikipedia.org/wiki/Alpha_compositing
-    CGBlendMode blendMode = kCGBlendModeSourceAtop;
+    CGBlendMode blendMode = kCGBlendModeSourceIn;
     
     SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] init];
     format.scale = scale;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Fix the issue where alpha values do not apply to the image.

While using SDWebImage, I discovered that the alpha value for the image color was not being applied. The issue was caused by the CGBlendMode setting. When using kCGBlendModeSourceATop as before, the A color was being overwritten. To resolve this, I switched to using kCGBlendModeSourceIn, which effectively replaced the color. This change ensures that the alpha value is applied to the tintColor of UIImage, similar to how it behaves natively. I discovered this issue while testing with SVG images.

## Reference
documentation - https://developer.apple.com/documentation/coregraphics/cgblendmode/

