### PR TITLE
build: download visionOS SDK before CI/CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macos-15
     env:
       CODESIGN_KEY_BASE64: "${{ secrets.CODESIGN_KEY_BASE64 }}"
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   Release:
     name: Release XCFramework
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       CODESIGN_KEY_BASE64: "${{ secrets.CODESIGN_KEY_BASE64 }}"
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -23,14 +23,6 @@ jobs:
           - linkage: static
             MACH_O_TYPE: staticlib
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-            
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -23,6 +23,14 @@ jobs:
           - linkage: static
             MACH_O_TYPE: staticlib
     steps:
+      # https://github.com/actions/runner-images/issues/10559
+      - name: Download visionOS SDK
+        run: |
+            sudo xcodebuild -runFirstLaunch
+            sudo xcrun simctl list
+            sudo xcodebuild -downloadPlatform visionOS
+            sudo xcodebuild -runFirstLaunch
+            
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,14 +18,6 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.2.app
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -60,14 +52,6 @@ jobs:
       watchOSDestination: platform=watchOS Simulator,name=Apple Watch Ultra (49mm)
       visionOSDestination: platform=visionOS Simulator,name=Apple Vision Pro
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -138,14 +122,6 @@ jobs:
             scheme: Vision
             flag: visionos
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -190,14 +166,6 @@ jobs:
       PROJECT_NAME: SDWebImage.xcodeproj
       SCHEME_NAME: SDWebImage
     steps:
-      # https://github.com/actions/runner-images/issues/10559
-      - name: Download visionOS SDK
-        run: |
-            sudo xcodebuild -runFirstLaunch
-            sudo xcrun simctl list
-            sudo xcodebuild -downloadPlatform visionOS
-            sudo xcodebuild -runFirstLaunch
-            
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   Lint:
     name: Cocoapods Lint
-    runs-on: macos-14
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,16 +38,15 @@ jobs:
           
   Demo:
     name: Cocoapods Demo
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app
       WORKSPACE_NAME: SDWebImage.xcworkspace
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      iosDestination: platform=iOS Simulator,name=iPhone 15 Pro
+      iosDestination: platform=iOS Simulator,name=iPhone 16 Pro
       macOSDestination: platform=macOS,arch=x86_64
       macCatalystDestination: platform=macOS,arch=x86_64,variant=Mac Catalyst
       tvOSDestination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
-      watchOSDestination: platform=watchOS Simulator,name=Apple Watch Ultra (49mm)
+      watchOSDestination: platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)
       visionOSDestination: platform=visionOS Simulator,name=Apple Vision Pro
     steps:
       - name: Checkout
@@ -94,9 +91,8 @@ jobs:
 
   Test:
     name: Unit Test
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app
       WORKSPACE_NAME: SDWebImage.xcworkspace
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # use matrix to generate jobs for each platform
@@ -106,7 +102,7 @@ jobs:
         platform: [iOS, macOS, tvOS, visionOS]
         include:
           - platform: iOS
-            destination: platform=iOS Simulator,name=iPhone 15 Pro
+            destination: platform=iOS Simulator,name=iPhone 16 Pro
             scheme: iOS
             flag: ios
           - platform: macOS
@@ -160,9 +156,8 @@ jobs:
           
   Build:
     name: Build Library
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app
       PROJECT_NAME: SDWebImage.xcodeproj
       SCHEME_NAME: SDWebImage
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,8 @@ jobs:
   Lint:
     name: Cocoapods Lint
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,6 +42,7 @@ jobs:
     name: Cocoapods Demo
     runs-on: macos-15
     env:
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app
       WORKSPACE_NAME: SDWebImage.xcworkspace
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       iosDestination: platform=iOS Simulator,name=iPhone 16 Pro
@@ -93,6 +96,7 @@ jobs:
     name: Unit Test
     runs-on: macos-15
     env:
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app
       WORKSPACE_NAME: SDWebImage.xcworkspace
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # use matrix to generate jobs for each platform
@@ -158,6 +162,7 @@ jobs:
     name: Build Library
     runs-on: macos-15
     env:
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app
       PROJECT_NAME: SDWebImage.xcodeproj
       SCHEME_NAME: SDWebImage
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,14 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.2.app
     steps:
+      # https://github.com/actions/runner-images/issues/10559
+      - name: Download visionOS SDK
+        run: |
+            sudo xcodebuild -runFirstLaunch
+            sudo xcrun simctl list
+            sudo xcodebuild -downloadPlatform visionOS
+            sudo xcodebuild -runFirstLaunch
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -52,6 +60,14 @@ jobs:
       watchOSDestination: platform=watchOS Simulator,name=Apple Watch Ultra (49mm)
       visionOSDestination: platform=visionOS Simulator,name=Apple Vision Pro
     steps:
+      # https://github.com/actions/runner-images/issues/10559
+      - name: Download visionOS SDK
+        run: |
+            sudo xcodebuild -runFirstLaunch
+            sudo xcrun simctl list
+            sudo xcodebuild -downloadPlatform visionOS
+            sudo xcodebuild -runFirstLaunch
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -122,6 +138,14 @@ jobs:
             scheme: Vision
             flag: visionos
     steps:
+      # https://github.com/actions/runner-images/issues/10559
+      - name: Download visionOS SDK
+        run: |
+            sudo xcodebuild -runFirstLaunch
+            sudo xcrun simctl list
+            sudo xcodebuild -downloadPlatform visionOS
+            sudo xcodebuild -runFirstLaunch
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -166,6 +190,14 @@ jobs:
       PROJECT_NAME: SDWebImage.xcodeproj
       SCHEME_NAME: SDWebImage
     steps:
+      # https://github.com/actions/runner-images/issues/10559
+      - name: Download visionOS SDK
+        run: |
+            sudo xcodebuild -runFirstLaunch
+            sudo xcrun simctl list
+            sudo xcodebuild -downloadPlatform visionOS
+            sudo xcodebuild -runFirstLaunch
+            
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Due to https://github.com/actions/runner-images/issues/10559 , should download visionOS SDK before running workflow.

