### PR TITLE
Fix issue causing disk cache eviction LRU to not function as expected.

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -71,13 +71,16 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     }
     NSData *data = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
+        [[NSURL fileURLWithPath:filePath] setResourceValue:[NSDate date] forKey:NSURLContentAccessDateKey error:nil];
         return data;
     }
     
     // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
     // checking the key with and without the extension
-    data = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
+    filePath = filePath.stringByDeletingPathExtension;
+    data = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
+        [[NSURL fileURLWithPath:filePath] setResourceValue:[NSDate date] forKey:NSURLContentAccessDateKey error:nil];
         return data;
     }
     

--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -152,11 +152,8 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
     NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
     
     // Compute content date key to be used for tests
-    NSURLResourceKey cacheContentDateKey = NSURLContentModificationDateKey;
+    NSURLResourceKey cacheContentDateKey;
     switch (self.config.diskCacheExpireType) {
-        case SDImageCacheConfigExpireTypeAccessDate:
-            cacheContentDateKey = NSURLContentAccessDateKey;
-            break;
         case SDImageCacheConfigExpireTypeModificationDate:
             cacheContentDateKey = NSURLContentModificationDateKey;
             break;
@@ -166,7 +163,9 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
         case SDImageCacheConfigExpireTypeChangeDate:
             cacheContentDateKey = NSURLAttributeModificationDateKey;
             break;
+        case SDImageCacheConfigExpireTypeAccessDate:
         default:
+            cacheContentDateKey = NSURLContentAccessDateKey;
             break;
     }
     

--- a/SDWebImage/Core/SDImageCacheConfig.h
+++ b/SDWebImage/Core/SDImageCacheConfig.h
@@ -115,7 +115,7 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 
 /*
  * The attribute which the clear cache will be checked against when clearing the disk cache
- * Default is Modified Date
+ * Default is Access Date
  */
 @property (assign, nonatomic) SDImageCacheConfigExpireType diskCacheExpireType;
 

--- a/SDWebImage/Core/SDImageCacheConfig.m
+++ b/SDWebImage/Core/SDImageCacheConfig.m
@@ -34,7 +34,7 @@ static const NSInteger kDefaultCacheMaxDiskAge = 60 * 60 * 24 * 7; // 1 week
         _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxDiskAge = kDefaultCacheMaxDiskAge;
         _maxDiskSize = 0;
-        _diskCacheExpireType = SDImageCacheConfigExpireTypeModificationDate;
+        _diskCacheExpireType = SDImageCacheConfigExpireTypeAccessDate;
         _fileManager = nil;
         if (@available(iOS 10.0, tvOS 10.0, macOS 10.12, watchOS 3.0, *)) {
             _ioQueueAttributes = DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL; // DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -108,7 +108,7 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
             }
             
             // Remove files that are older than the expiration date;
-            NSDate *accessDate = resourceValues[NSURLAttributeContentAccessDateKey];
+            NSDate *accessDate = resourceValues[NSURLContentAccessDateKey];
             if (expirationDate && [[accessDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
                 [self.fileManager removeItemAtURL:fileURL error:nil];
             }

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -91,7 +91,7 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
 - (void)removeExpiredData {
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.config.maxDiskAge];
     NSURL *diskCacheURL = [NSURL fileURLWithPath:self.cachePath isDirectory:YES];
-    NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLAttributeModificationDateKey];
+    NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLAttributeContentAccessDateKey];
     NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
                                                    includingPropertiesForKeys:resourceKeys
                                                                       options:NSDirectoryEnumerationSkipsHiddenFiles
@@ -108,8 +108,8 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
             }
             
             // Remove files that are older than the expiration date;
-            NSDate *modifiedDate = resourceValues[NSURLAttributeModificationDateKey];
-            if (expirationDate && [[modifiedDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
+            NSDate *accessDate = resourceValues[NSURLAttributeContentAccessDateKey];
+            if (expirationDate && [[accessDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
                 [self.fileManager removeItemAtURL:fileURL error:nil];
             }
         }

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -91,7 +91,7 @@ static NSString * const SDWebImageTestDiskCacheExtendedAttributeName = @"com.hac
 - (void)removeExpiredData {
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.config.maxDiskAge];
     NSURL *diskCacheURL = [NSURL fileURLWithPath:self.cachePath isDirectory:YES];
-    NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLAttributeContentAccessDateKey];
+    NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLContentAccessDateKey];
     NSDirectoryEnumerator<NSURL *> *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
                                                    includingPropertiesForKeys:resourceKeys
                                                                       options:NSDirectoryEnumerationSkipsHiddenFiles


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

`NSFileManager` does not automatically increment access date when reading files off disk, which means that use of `SDImageCacheConfigExpireTypeAccessDate` is effectively identical to using `SDImageCacheConfigExpireTypeCreationDate`. This doesn't seem like the correct behavior on SDWebImage's part, and it isn't what's documented [here](https://github.com/SDWebImage/SDWebImage/blob/d68b92db8557f1aed608106e5d6ae8826ce3afac/SDWebImage/Core/SDImageCacheConfig.h#L15). This PR makes it so that SDWebImage adjusts the file content access date when files are read off disk to address the issue.

I've also added a commit that updates the default cache behavior to `SDImageCacheConfigExpireTypeAccessDate` since I believe that's what's commonly expected. People generally want cache purging by time-of-use in my experience instead of using the time the file was downloaded at. If you strongly disagree I can omit that change!