### PR TITLE
Fix `sd_imageFormat` sometimes returns `undefined` 

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -376,11 +376,6 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
     }
 }
 
-- (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {
-    // Sets the image format for static images
-    super.sd_imageFormat = sd_imageFormat;
-}
-
 - (BOOL)sd_isVector {
     return NO;
 }

--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -182,6 +182,8 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 #else
         self = [super initWithCGImage:image.CGImage scale:MAX(scale, 1) orientation:image.imageOrientation];
 #endif
+        // Defines the associated object that holds the format for static images
+        super.sd_imageFormat = format;
         return self;
     }
 }
@@ -375,7 +377,8 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 }
 
 - (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {
-    return;
+    // Sets the image format for static images
+    super.sd_imageFormat = sd_imageFormat;
 }
 
 - (BOOL)sd_isVector {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes: 
`sd_imageFormat` returns nil when used on `SDAnimatedImage` to which static image were loaded.

### Pull Request Description

When a static image is loaded into `SDAnimatedImage`, the `sd_imageFormat` remains unset. As a result, the associated object on the underlying `UIImage` is not present. This value is typically assigned by decoders; for instance, `SDImageIOCoder` does so [here](https://github.com/SDWebImage/SDWebImage/blob/0b10fcb54484b618a53386670bff38176a203290/SDWebImage/Core/SDImageIOCoder.m#L217). However, with `SDAnimatedImage`, the correct format is returned only if the `animatedImageData` is included. 

I’m uncertain if my solution is accurate (I’ve tested it, but I’m unsure if it’s the right approach). I’ve opened this PR to initiate a discussion on how to properly address that issue.