### PR TITLE
Deprecate dispatch_main_async_safe, UIView+WebCache API now supports SDCallbackQueue and may callback in non-main queue

### DIFF
--- a/SDWebImage/Core/SDWebImageCompat.h
+++ b/SDWebImage/Core/SDWebImageCompat.h
@@ -98,4 +98,5 @@
     } else {\
         dispatch_async(dispatch_get_main_queue(), block);\
     }
+#pragma clang deprecated(dispatch_main_async_safe, "Use SDCallbackQueue instead")
 #endif

--- a/SDWebImage/Core/UIView+WebCache.m
+++ b/SDWebImage/Core/UIView+WebCache.m
@@ -13,6 +13,7 @@
 #import "SDInternalMacros.h"
 #import "SDWebImageTransitionInternal.h"
 #import "SDImageCache.h"
+#import "SDCallbackQueue.h"
 
 const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 
@@ -108,7 +109,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
         mutableContext[SDWebImageContextCustomManager] = nil;
         context = [mutableContext copy];
     }
-    
+    SDCallbackQueue *queue = context[SDWebImageContextCallbackQueue];
     BOOL shouldUseWeakCache = NO;
     if ([manager.imageCache isKindOfClass:SDImageCache.class]) {
         shouldUseWeakCache = ((SDImageCache *)manager.imageCache).config.shouldUseWeakMemoryCache;
@@ -121,9 +122,9 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             // in the future the weak cache feature may be re-design or removed
             [((SDImageCache *)manager.imageCache) imageFromMemoryCacheForKey:key];
         }
-        dispatch_main_async_safe(^{
+        [(queue ?: SDCallbackQueue.mainQueue) async:^{
             [self sd_setImage:placeholder imageData:nil basedOnClassOrViaCustomSetImageBlock:setImageBlock cacheType:SDImageCacheTypeNone imageURL:url];
-        });
+        }];
     }
     
     id <SDWebImageOperation> operation = nil;
@@ -138,7 +139,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
         
 #if SD_UIKIT || SD_MAC
         // check and start image indicator
-        [self sd_startImageIndicator];
+        [self sd_startImageIndicatorWithQueue:queue];
         id<SDWebImageIndicator> imageIndicator = self.sd_imageIndicator;
 #endif
         
@@ -176,7 +177,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 #if SD_UIKIT || SD_MAC
             // check and stop image indicator
             if (finished) {
-                [self sd_stopImageIndicator];
+                [self sd_stopImageIndicatorWithQueue:queue];
             }
 #endif
             
@@ -197,7 +198,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             // OR
             // case 1b: we got no image and the SDWebImageDelayPlaceholder is not set
             if (shouldNotSetImage) {
-                dispatch_main_async_safe(callCompletedBlockClosure);
+                [(queue ?: SDCallbackQueue.mainQueue) async:callCompletedBlockClosure];
                 return;
             }
             
@@ -242,25 +243,25 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                 transition = self.sd_imageTransition;
             }
 #endif
-            dispatch_main_async_safe(^{
+            [(queue ?: SDCallbackQueue.mainQueue) async:^{
 #if SD_UIKIT || SD_MAC
                 [self sd_setImage:targetImage imageData:targetData options:options basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL callback:callCompletedBlockClosure];
 #else
                 [self sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock cacheType:cacheType imageURL:imageURL];
                 callCompletedBlockClosure();
 #endif
-            });
+            }];
         }];
         [self sd_setImageLoadOperation:operation forKey:validOperationKey];
     } else {
 #if SD_UIKIT || SD_MAC
-        [self sd_stopImageIndicator];
+        [self sd_stopImageIndicatorWithQueue:queue];
 #endif
         if (completedBlock) {
-            dispatch_main_async_safe(^{
+            [(queue ?: SDCallbackQueue.mainQueue) async:^{
                 NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}];
                 completedBlock(nil, nil, error, SDImageCacheTypeNone, YES, url);
-            });
+            }];
         }
     }
     
@@ -482,24 +483,24 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
     [self addSubview:view];
 }
 
-- (void)sd_startImageIndicator {
+- (void)sd_startImageIndicatorWithQueue:(SDCallbackQueue *)queue {
     id<SDWebImageIndicator> imageIndicator = self.sd_imageIndicator;
     if (!imageIndicator) {
         return;
     }
-    dispatch_main_async_safe(^{
+    [(queue ?: SDCallbackQueue.mainQueue) async:^{
         [imageIndicator startAnimatingIndicator];
-    });
+    }];
 }
 
-- (void)sd_stopImageIndicator {
+- (void)sd_stopImageIndicatorWithQueue:(SDCallbackQueue *)queue {
     id<SDWebImageIndicator> imageIndicator = self.sd_imageIndicator;
     if (!imageIndicator) {
         return;
     }
-    dispatch_main_async_safe(^{
+    [(queue ?: SDCallbackQueue.mainQueue) async:^{
         [imageIndicator stopAnimatingIndicator];
-    });
+    }];
 }
 
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3765 

