### PR TITLE
Change the default callback queue policy to SafeAsyncMainThread, don't need main queue check at all

### DIFF
--- a/SDWebImage/Core/SDCallbackQueue.h
+++ b/SDWebImage/Core/SDCallbackQueue.h
@@ -17,10 +17,8 @@ typedef NS_ENUM(NSUInteger, SDCallbackPolicy) {
     SDCallbackPolicyDispatch = 1,
     /// Ignore any async/sync and just directly invoke `block` in current queue (without `dispatch_async`/`dispatch_sync`)
     SDCallbackPolicyInvoke = 2,
-    /// Ensure callback in main queue (no gurantee on main thread). Do `dispatch_async` if the current queue is not main queue; else do invoke `block`. Never use `dispatch_sync`, suitable for general UI-related code
-    SDCallbackPolicySafeAsyncMainQueue = 3,
     /// Ensure callback in main thread. Do `dispatch_async` if the `NSThread.isMainTrhead == true` ; else do invoke `block`. Never use `dispatch_sync`, suitable for special UI-related code
-    SDCallbackPolicySafeAsyncMainThread = 4,
+    SDCallbackPolicySafeAsyncMainThread = 3,
 };
 
 /// SDCallbackQueue is a wrapper used to control how the completionBlock should perform on queues, used by our `Cache`/`Manager`/`Loader`.
@@ -28,7 +26,7 @@ typedef NS_ENUM(NSUInteger, SDCallbackPolicy) {
 @interface SDCallbackQueue : NSObject
 
 /// The main queue. This is the default value, has the same effect when passing `nil` to `SDWebImageContextCallbackQueue`
-/// The policy defaults to `SDCallbackPolicySafeAsyncMainQueue`
+/// The policy defaults to `SDCallbackPolicySafeAsyncMainThread`
 @property (nonnull, class, readonly) SDCallbackQueue *mainQueue;
 
 /// The caller current queue. Using `dispatch_get_current_queue`. This is not a dynamic value and only keep the first call time queue.
@@ -52,7 +50,7 @@ typedef NS_ENUM(NSUInteger, SDCallbackPolicy) {
 
 /// Submits a block for execution and returns after that block finishes executing.
 /// - Parameter block: The block that contains the work to perform.
-- (void)sync:(nonnull dispatch_block_t)block;
+- (void)sync:(nonnull dispatch_block_t)block API_DEPRECATED("No longer use, may cause deadlock when misused", macos(10.10, 10.10), ios(8.0, 8.0), tvos(9.0, 9.0), watchos(2.0, 2.0));;
 
 /// Schedules a block asynchronously for execution.
 /// - Parameter block: The block that contains the work to perform.

--- a/SDWebImage/Core/SDCallbackQueue.m
+++ b/SDWebImage/Core/SDCallbackQueue.m
@@ -15,20 +15,7 @@
 
 @end
 
-static inline void SDSafeMainQueueAsync(dispatch_block_t _Nonnull block) {
-    if (NSThread.isMainThread) {
-        // Match exists `dispatch_main_async_safe` behavior
-        const char *currentLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
-        const char *mainLabel = dispatch_queue_get_label(dispatch_get_main_queue());
-        if (mainLabel == currentLabel) {
-            block();
-            return;
-        }
-    }
-    dispatch_async(dispatch_get_main_queue(), block);
-}
-
-static inline void SDSafeMainThreadAsync(dispatch_block_t _Nonnull block) {
+static inline void SDSafeAsyncMainThread(dispatch_block_t _Nonnull block) {
     if (NSThread.isMainThread) {
         block();
     } else {
@@ -71,7 +58,7 @@ static void SDSafeExecute(dispatch_queue_t queue, dispatch_block_t _Nonnull bloc
 
 + (SDCallbackQueue *)mainQueue {
     SDCallbackQueue *queue = [[SDCallbackQueue alloc] initWithDispatchQueue:dispatch_get_main_queue()];
-    queue->_policy = SDCallbackPolicySafeAsyncMainQueue;
+    queue->_policy = SDCallbackPolicySafeAsyncMainThread;
     return queue;
 }
 
@@ -99,11 +86,8 @@ static void SDSafeExecute(dispatch_queue_t queue, dispatch_block_t _Nonnull bloc
         case SDCallbackPolicyInvoke:
             block();
             break;
-        case SDCallbackPolicySafeAsyncMainQueue:
-            SDSafeMainQueueAsync(block);
-            break;
         case SDCallbackPolicySafeAsyncMainThread:
-            SDSafeMainThreadAsync(block);
+            SDSafeAsyncMainThread(block);
             break;
         default:
             NSCAssert(NO, @"unexpected policy %tu", self.policy);
@@ -122,11 +106,8 @@ static void SDSafeExecute(dispatch_queue_t queue, dispatch_block_t _Nonnull bloc
         case SDCallbackPolicyInvoke:
             block();
             break;
-        case SDCallbackPolicySafeAsyncMainQueue:
-            SDSafeMainQueueAsync(block);
-            break;
         case SDCallbackPolicySafeAsyncMainThread:
-            SDSafeMainThreadAsync(block);
+            SDSafeAsyncMainThread(block);
             break;
         default:
             NSCAssert(NO, @"unexpected policy %tu", self.policy);

--- a/Tests/Tests/SDUtilsTests.m
+++ b/Tests/Tests/SDUtilsTests.m
@@ -171,9 +171,12 @@
     dispatch_queue_t queue = dispatch_queue_create("testSDCallbackQueue", NULL);
     SDCallbackQueue *callbackQueue = [[SDCallbackQueue alloc] initWithDispatchQueue:queue];
     __block BOOL called = NO;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [callbackQueue sync:^{
         called = YES;
     }];
+#pragma clang diagnostic pop
     expect(called).beTruthy();
     
     __block BOOL called1 = NO;


### PR DESCRIPTION
This is the best practice for UI related code

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

After discussion in #3766 

Actually this `SafeAsyncMainQueue` does not do anything useful. UIKit always check `MainThread` , but not `MainQueue`. So, we should remove this policy and always use `SafeAsyncMainThread` instead

This is also what Kingfisher or ReactNative do in their latest release, to support UICollectionViewDiffableDataSource

