### PR TITLE
Supports HDR encoding on Apple ImageIO coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can use those directly, or create similar components of your own, by using t
 - watchOS 2.0 or later
 - macOS 10.11 or later (10.15 for Catalyst)
 - visionOS 1.0 or later
-- Xcode 14.0 or later (visionOS requires Xcode 15.0)
+- Xcode 15.0 or later
 
 #### Backwards compatibility
 

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -15,7 +15,7 @@ typedef NSString * SDImageCoderOption NS_STRING_ENUM;
 typedef NSDictionary<SDImageCoderOption, id> SDImageCoderOptions;
 typedef NSMutableDictionary<SDImageCoderOption, id> SDImageCoderMutableOptions;
 
-#pragma mark - Coder Options
+#pragma mark - Image Decoding Options
 // These options are for image decoding
 /**
  A Boolean value indicating whether to decode the first frame only for animated image during decoding. (NSNumber). If not provide, decode animated image if need.
@@ -96,7 +96,18 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeScaleDownL
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeToHDR;
 
-// These options are for image encoding
+#pragma mark - Image Encoding Options
+/**
+ A NSUInteger value (NSNumber) to provide converting to HDR during encoding. Read the below carefully to choose the value.
+ @note 0 means SDR; 1 means ISO HDR (at least using 10 bits per components or above, supported by AVIF/HEIF/JPEG-XL); 2 means ISO Gain Map Image (may use 8 bits per components, supported AVIF/HEIF/JPEG-XL, as well as traditional JPEG)
+ @note Gain Map like a mask image with metadata, which contains the depth/bright information for each pixel (or smaller, 1/4 resolution), which used to convert between HDR and SDR.
+ @note If you use CIImage as HDR pipeline, you can export as CGImage for encoding. (But it's also recommanded to use CIImage's `JPEGRepresentationOfImage` or `HEIFRepresentationOfImage`)
+ @note Supported by iOS 18 and above when using ImageIO coder (third-party coder can support lower firmware)
+ Defaults to @(0), encoder will automatically convert SDR.
+ @note works for `SDImageCoder`
+ */
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeToHDR;
+
 /**
  A Boolean value indicating whether to encode the first frame only for animated image during encoding. (NSNumber). If not provide, encode animated image if need.
  @note works for `SDImageCoder`.

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -89,7 +89,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeUseLazyDec
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeScaleDownLimitBytes;
 
 /**
- A Boolean value (NSNumber) to provide converting to HDR during decoding. Currently if number is 0, use SDR, else use HDR. But we may extend this option to use `NSUInteger` in the future (means, think this options as int number, but not actual boolean)
+ A Boolean (`SDImageHDRType.rawValue`) value (stored inside NSNumber) to provide converting to HDR during decoding. Currently if number is 0 (`SDImageHDRTypeSDR`), use SDR, else use HDR. But we may extend this option to represent `SDImageHDRType` all cases in the future (means, think this options as uint number, but not actual boolean)
  @note Supported by iOS 17 and above when using ImageIO coder (third-party coder can support lower firmware)
  Defaults to @(NO), decoder will automatically convert SDR.
  @note works for `SDImageCoder`
@@ -98,9 +98,9 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeToHDR;
 
 #pragma mark - Image Encoding Options
 /**
- A NSUInteger value (NSNumber) to provide converting to HDR during encoding. Read the below carefully to choose the value.
- @note 0 means SDR; 1 means ISO HDR (at least using 10 bits per components or above, supported by AVIF/HEIF/JPEG-XL); 2 means ISO Gain Map HDR (may use 8 bits per components, supported by AVIF/HEIF/JPEG-XL, as well as traditional JPEG)
- @note Gain Map like a mask image with metadata, which contains the depth/bright information for each pixel (or smaller, 1/4 resolution), which used to convert between HDR and SDR.
+ A NSUInteger (`SDImageHDRType.rawValue`) value (stored inside NSNumber) to provide converting to HDR during encoding. Read the below carefully to choose the value.
+ @note 0(`SDImageHDRTypeSDR`) means SDR; 1(`SDImageHDRTypeISOHDR`) means ISO HDR (at least using 10 bits per components or above, supported by AVIF/HEIF/JPEG-XL); 2(`SDImageHDRTypeISOGainMap`) means ISO Gain Map HDR (may use 8 bits per components, supported by AVIF/HEIF/JPEG-XL, as well as traditional JPEG)
+ @note Gain Map like a mask image with metadata, which contains the depth/bright information for pixels (1/4 resolution), which used to convert between HDR and SDR.
  @note If you use CIImage as HDR pipeline, you can export as CGImage for encoding. (But it's also recommanded to use CIImage's `JPEGRepresentationOfImage` or `HEIFRepresentationOfImage`)
  @note Supported by iOS 18 and above when using ImageIO coder (third-party coder can support lower firmware)
  Defaults to @(0), encoder will automatically convert SDR.

--- a/SDWebImage/Core/SDImageCoder.h
+++ b/SDWebImage/Core/SDImageCoder.h
@@ -99,7 +99,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderDecodeToHDR;
 #pragma mark - Image Encoding Options
 /**
  A NSUInteger value (NSNumber) to provide converting to HDR during encoding. Read the below carefully to choose the value.
- @note 0 means SDR; 1 means ISO HDR (at least using 10 bits per components or above, supported by AVIF/HEIF/JPEG-XL); 2 means ISO Gain Map Image (may use 8 bits per components, supported AVIF/HEIF/JPEG-XL, as well as traditional JPEG)
+ @note 0 means SDR; 1 means ISO HDR (at least using 10 bits per components or above, supported by AVIF/HEIF/JPEG-XL); 2 means ISO Gain Map HDR (may use 8 bits per components, supported by AVIF/HEIF/JPEG-XL, as well as traditional JPEG)
  @note Gain Map like a mask image with metadata, which contains the depth/bright information for each pixel (or smaller, 1/4 resolution), which used to convert between HDR and SDR.
  @note If you use CIImage as HDR pipeline, you can export as CGImage for encoding. (But it's also recommanded to use CIImage's `JPEGRepresentationOfImage` or `HEIFRepresentationOfImage`)
  @note Supported by iOS 18 and above when using ImageIO coder (third-party coder can support lower firmware)

--- a/SDWebImage/Core/SDImageCoder.m
+++ b/SDWebImage/Core/SDImageCoder.m
@@ -18,6 +18,7 @@ SDImageCoderOption const SDImageCoderDecodeUseLazyDecoding = @"decodeUseLazyDeco
 SDImageCoderOption const SDImageCoderDecodeScaleDownLimitBytes = @"decodeScaleDownLimitBytes";
 SDImageCoderOption const SDImageCoderDecodeToHDR = @"decodeToHDR";
 
+SDImageCoderOption const SDImageCoderEncodeToHDR = @"encodeToHDR";
 SDImageCoderOption const SDImageCoderEncodeFirstFrameOnly = @"encodeFirstFrameOnly";
 SDImageCoderOption const SDImageCoderEncodeCompressionQuality = @"encodeCompressionQuality";
 SDImageCoderOption const SDImageCoderEncodeBackgroundColor = @"encodeBackgroundColor";

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -33,6 +33,17 @@ typedef NS_ENUM(NSUInteger, SDImageForceDecodePolicy) {
     SDImageForceDecodePolicyAlways
 };
 
+/// These enum is used to represent the High Dynamic Range type during image encoding/decoding.
+/// There are alao other HDR type in history before ISO Standard (ISO 21496-1), including Google and Apple's old OSs captured photos, but which is non-standard and we do not support.
+typedef NS_ENUM(NSUInteger, SDImageHDRType) {
+    /// SDR, mostly only 8 bits color per components, RGBA8
+    SDImageHDRTypeSDR = 0,
+    /// ISO HDR (supported by modern format only, like HEIF/AVIF/JPEG-XL)
+    SDImageHDRTypeISOHDR = 1,
+    /// ISO Gain Map based HDR (supported by nearly all format, including tranditional JPEG, which stored the gain map into XMP)
+    SDImageHDRTypeISOGainMap = 2,
+};
+
 /// Byte alignment the bytes size with alignment
 /// - Parameters:
 ///   - size: The bytes size

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -895,6 +895,21 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
         maxPixelSize = maxPixelSizeValue.CGSizeValue;
 #endif
     }
+    // HDR Encoding
+    NSUInteger encodeToHDR = 0;
+    if (options[SDImageCoderEncodeToHDR]) {
+        encodeToHDR = [options[SDImageCoderEncodeToHDR] unsignedIntegerValue];
+    }
+    if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
+        if (encodeToHDR == 1) {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+        } else if (encodeToHDR == 2) {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+        } else {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+        }
+    }
+    
     CGFloat pixelWidth = (CGFloat)CGImageGetWidth(imageRef);
     CGFloat pixelHeight = (CGFloat)CGImageGetHeight(imageRef);
     CGFloat finalPixelSize = 0;

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -28,6 +28,12 @@ static CGImageSourceRef (*SDCGImageGetImageSource)(CGImageRef);
 
 // Specify File Size for lossy format encoding, like JPEG
 static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestinationRequestedFileSize";
+// Support Xcode 15 SDK, use raw value instead of symbol
+static NSString * kSDCGImageDestinationEncodeRequest = @"kCGImageDestinationEncodeRequest";
+static NSString * kSDCGImageDestinationEncodeToSDR = @"kCGImageDestinationEncodeToSDR";
+static NSString * kSDCGImageDestinationEncodeToISOHDR = @"kCGImageDestinationEncodeToISOHDR";
+static NSString * kSDCGImageDestinationEncodeToISOGainmap = @"kCGImageDestinationEncodeToISOGainmap";
+
 
 // This strip the un-wanted CGImageProperty, like the internal CGImageSourceRef in iOS 15+
 // However, CGImageCreateCopy still keep those CGImageProperty, not suit for our use case
@@ -281,6 +287,18 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     BOOL _lazyDecode;
     BOOL _decodeToHDR;
 }
+
+#if SD_IMAGEIO_HDR_ENCODING
++ (void)initialize {
+    if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
+        // Use SDK instead of raw value
+        kSDCGImageDestinationEncodeRequest = (__bridge NSString *)kCGImageDestinationEncodeRequest;
+        kSDCGImageDestinationEncodeToSDR = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+        kSDCGImageDestinationEncodeToISOHDR = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+        kSDCGImageDestinationEncodeToISOGainmap = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+    }
+}
+#endif
 
 - (void)dealloc
 {
@@ -902,11 +920,11 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     }
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
         if (encodeToHDR == 1) {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOHDR;
         } else if (encodeToHDR == 2) {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOGainmap;
         } else {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToSDR;
         }
     }
     

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -919,9 +919,9 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
         encodeToHDR = [options[SDImageCoderEncodeToHDR] unsignedIntegerValue];
     }
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
-        if (encodeToHDR == 1) {
+        if (encodeToHDR == SDImageHDRTypeISOHDR) {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOHDR;
-        } else if (encodeToHDR == 2) {
+        } else if (encodeToHDR == SDImageHDRTypeISOGainMap) {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOGainmap;
         } else {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToSDR;

--- a/SDWebImage/Core/SDImageIOCoder.m
+++ b/SDWebImage/Core/SDImageIOCoder.m
@@ -405,9 +405,9 @@ static NSString * kSDCGImageDestinationEncodeToISOGainmap = @"kCGImageDestinatio
         encodeToHDR = [options[SDImageCoderEncodeToHDR] unsignedIntegerValue];
     }
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
-        if (encodeToHDR == 1) {
+        if (encodeToHDR == SDImageHDRTypeISOHDR) {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOHDR;
-        } else if (encodeToHDR == 2) {
+        } else if (encodeToHDR == SDImageHDRTypeISOGainMap) {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOGainmap;
         } else {
             properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToSDR;

--- a/SDWebImage/Core/SDImageIOCoder.m
+++ b/SDWebImage/Core/SDImageIOCoder.m
@@ -381,6 +381,21 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
         maxPixelSize = maxPixelSizeValue.CGSizeValue;
 #endif
     }
+    // HDR Encoding
+    NSUInteger encodeToHDR = 0;
+    if (options[SDImageCoderEncodeToHDR]) {
+        encodeToHDR = [options[SDImageCoderEncodeToHDR] unsignedIntegerValue];
+    }
+    if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
+        if (encodeToHDR == 1) {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+        } else if (encodeToHDR == 2) {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+        } else {
+            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+        }
+    }
+    
     CGFloat pixelWidth = (CGFloat)CGImageGetWidth(imageRef);
     CGFloat pixelHeight = (CGFloat)CGImageGetHeight(imageRef);
     CGFloat finalPixelSize = 0;

--- a/SDWebImage/Core/SDImageIOCoder.m
+++ b/SDWebImage/Core/SDImageIOCoder.m
@@ -18,6 +18,12 @@
 
 // Specify File Size for lossy format encoding, like JPEG
 static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestinationRequestedFileSize";
+// Support Xcode 15 SDK, use raw value instead of symbol
+static NSString * kSDCGImageDestinationEncodeRequest = @"kCGImageDestinationEncodeRequest";
+static NSString * kSDCGImageDestinationEncodeToSDR = @"kCGImageDestinationEncodeToSDR";
+static NSString * kSDCGImageDestinationEncodeToISOHDR = @"kCGImageDestinationEncodeToISOHDR";
+static NSString * kSDCGImageDestinationEncodeToISOGainmap = @"kCGImageDestinationEncodeToISOGainmap";
+
 
 @implementation SDImageIOCoder {
     size_t _width, _height;
@@ -30,6 +36,18 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     BOOL _lazyDecode;
     BOOL _decodeToHDR;
 }
+
+#if SD_IMAGEIO_HDR_ENCODING
++ (void)initialize {
+    if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
+        // Use SDK instead of raw value
+        kSDCGImageDestinationEncodeRequest = (__bridge NSString *)kCGImageDestinationEncodeRequest;
+        kSDCGImageDestinationEncodeToSDR = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+        kSDCGImageDestinationEncodeToISOHDR = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+        kSDCGImageDestinationEncodeToISOGainmap = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+    }
+}
+#endif
 
 - (void)dealloc {
     if (_imageSource) {
@@ -388,11 +406,11 @@ static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestination
     }
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
         if (encodeToHDR == 1) {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOHDR;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOHDR;
         } else if (encodeToHDR == 2) {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToISOGainmap;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToISOGainmap;
         } else {
-            properties[(__bridge NSString *)kCGImageDestinationEncodeRequest] = (__bridge NSString *)kCGImageDestinationEncodeToSDR;
+            properties[kSDCGImageDestinationEncodeRequest] = kSDCGImageDestinationEncodeToSDR;
         }
     }
     

--- a/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
+++ b/SDWebImage/Private/SDImageIOAnimatedCoderInternal.h
@@ -10,6 +10,9 @@
 #import <ImageIO/ImageIO.h>
 #import "SDImageIOAnimatedCoder.h"
 
+// Xcode 16 SDK contains HDR encoding API, but we still support Xcode 15
+#define SD_IMAGEIO_HDR_ENCODING (__IPHONE_OS_VERSION_MAX_ALLOWED >= 180000)
+
 // AVFileTypeHEIC/AVFileTypeHEIF is defined in AVFoundation via iOS 11, we use this without import AVFoundation
 #define kSDUTTypeHEIC  ((__bridge CFStringRef)@"public.heic")
 #define kSDUTTypeHEIF  ((__bridge CFStringRef)@"public.heif")

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -891,9 +891,11 @@ withLocalImageURL:(NSURL *)imageUrl
 
 - (NSDictionary *)gainMapFromImageSource:(CGImageSourceRef)source {
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
-        CFDictionaryRef HDRGainMap = CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeHDRGainMap);
         CFDictionaryRef ISOGainMap = CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeISOGainMap);
+        CFDictionaryRef HDRGainMap = CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeHDRGainMap);
         NSDictionary *result = ISOGainMap ? (__bridge_transfer NSDictionary *)ISOGainMap : (__bridge_transfer NSDictionary *)HDRGainMap;
+        if (HDRGainMap) CFRelease(HDRGainMap);
+        if (ISOGainMap) CFRelease(ISOGainMap);
         return result;
     } else {
         return nil;

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -704,7 +704,7 @@
 }
 
 - (void)test34ThatHDREncodeWorks {
-    // FIXME: Encoding need iOS 18+/macOS 15+
+    // FIXME: Encoding need iOS 18+/macOS 15+, No simulator
     // GitHub Action virtualization framework contains issue for Gain Map HDR convert:
     if (SDTestCase.isCI) {
         return;
@@ -720,7 +720,7 @@
             UIImage *HDRImage = [SDImageIOCoder.sharedCoder decodedImageWithData:data options:@{SDImageCoderDecodeToHDR : @(YES)}];
             float headroom = CGImageGetContentHeadroom(HDRImage.CGImage);
             expect(headroom).beGreaterThan(1);
-            
+#if !TARGET_OS_SIMULATOR
             NSArray *encodeFormats = @[@"heic", @"jpeg"];
             for (NSString *encodeFormat in encodeFormats) {
                 NSLog(@"Testing HDR encodde from original : %@ to %@", decodeFormat, encodeFormat);
@@ -730,9 +730,9 @@
                     // JPEG with XMP Gain Map
                     format = SDImageFormatJPEG;
                 }
-                NSData *SDRData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(0)}];
-                NSData *HDRData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(1)}];
-                NSData *HDRGainMapData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(2)}];
+                NSData *SDRData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(SDImageHDRTypeSDR)}];
+                NSData *HDRData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(SDImageHDRTypeISOHDR)}];
+                NSData *HDRGainMapData = [SDImageIOCoder.sharedCoder encodedDataWithImage:HDRImage format:format options:@{SDImageCoderEncodeToHDR : @(SDImageHDRTypeISOGainMap)}];
                 expect(SDRData).notTo.beNil();
                 expect(HDRData).notTo.beNil();
                 expect(HDRGainMapData).notTo.beNil();
@@ -756,6 +756,7 @@
                 expect(headroom).equal(1);
                 CFRelease(source);
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This just forward the options, no extra logic, really simple changes

To test Apple ImageIO HDR encoding, you need iOS 18 and macOS 15 device (not simulator) 

