### PR TITLE
crashfix: SDImageIOAnimatedCoder crash

### DIFF
--- a/SDWebImage/Private/SDImageFramePool.m
+++ b/SDWebImage/Private/SDImageFramePool.m
@@ -109,11 +109,14 @@ SD_LOCK_DECLARE_STATIC(_providerFramePoolMapLock);
     
     if (self.fetchQueue.operationCount == 0) {
         // Prefetch next frame in background queue
-        id<SDAnimatedImageProvider> animatedProvider = self.provider;
         @weakify(self);
         NSOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
             @strongify(self);
             if (!self) {
+                return;
+            }
+            id<SDAnimatedImageProvider> animatedProvider = self.provider;
+            if (!animatedProvider) {
                 return;
             }
             UIImage *frame = [animatedProvider animatedImageFrameAtIndex:index];


### PR DESCRIPTION
This merge request fixes / refers to the following issues: 

Thread 39 name:
Thread 39 Crashed:
0 libsystem_platform.dylib 0x00000001f3f6691c _platform_memmove + 76 (:-1)
1 ImageIO 0x00000001ac462d58 GIFBufferInfo::GIFBufferInfo(unsigned char*, bool, unsigned int, unsigned int, unsigned int) + 108 (GIF_common.cpp:38)
2 ImageIO 0x00000001ac474b34 std::__1::__shared_ptr_emplace<GIFBufferInfo, std::__1::allocator >::__shared_ptr_emplace<unsigned char*&, bool, unsigned int&, unsigned int&, unsigned int>(std::__1::allocator<GIFBu... + 76 (shared_ptr.h:298)
3 ImageIO 0x00000001ac474ab4 std::__1::shared_ptr std::__1::allocate_shared<GIFBufferInfo, std::__1::allocator, unsigned char*&, bool, unsigned int&, unsigned int&, unsigned int, void>(std::__1::a... + 88 (shared_ptr.h:292)
4 ImageIO 0x00000001ac4743a4 GIFReadPlugin::copyImageBlockSet(InfoRec*, CGImageProvider*, CGRect, CGSize, __CFDictionary const*) + 800 (shared_ptr.h:1115)
5 ImageIO 0x00000001ac294ef4 IIO_Reader::CopyImageBlockSetProc(void*, CGImageProvider*, CGRect, CGSize, __CFDictionary const*) + 280 (IIOReader.cpp:1444)
6 ImageIO 0x00000001ac2909d0 IIOImageProviderInfo::copyImageBlockSetWithOptions(CGImageProvider*, CGRect, CGSize, __CFDictionary const*) + 744 (CGImagePlus.cpp:2321)
7 ImageIO 0x00000001ac298acc IIOImageProviderInfo::CopyImageBlockSetWithOptions(void*, CGImageProvider*, CGRect, CGSize, __CFDictionary const*) + 828 (CGImagePlus.cpp:2630)
8 CoreGraphics 0x00000001a8b92da4 imageProvider_retain_data + 92 (CGDataProviderImageProvider.c:91)
9 CoreGraphics 0x00000001a8bb3cac CGDataProviderRetainData + 80 (CGDataProvider.c:921)
10 CoreGraphics 0x00000001a8bd1930 provider_for_destination_retain_data + 28 (CGDataProviderForDestination.c:705)
11 CoreGraphics 0x00000001a8bb3cac CGDataProviderRetainData + 80 (CGDataProvider.c:921)
12 CoreGraphics 0x00000001a8b8fb18 CGAccessSessionCreate + 108 (CGAccessSession.c:71)
13 CoreGraphics 0x00000001a8b57f00 img_data_lock + 2364 (CGSImage.c:4934)
14 CoreGraphics 0x00000001a8ba369c CGSImageDataLock + 1320 (CGSImage.c:5847)
15 CoreGraphics 0x00000001a8b72718 ripc_AcquireRIPImageData + 728 (RIPImage.c:337)
16 CoreGraphics 0x00000001a8b91f7c ripc_DrawImage + 804 (RIPContext.c:1432)
17 CoreGraphics 0x00000001a8b645ac CGContextDrawImageWithOptions + 1380 (CGContextDelegate.c:472)
18 MyApp 0x00000001026afc28 +[SDImageCoderHelper CGImageCreateDecoded:orientation:] + 660 (SDImageCoderHelper.m:481)
19 MyApp 0x00000001026b3840 +[SDImageIOAnimatedCoder createFrameAtIndex:source:scale:preserveAspectRatio:thumbnailSize:lazyDecode:animatedImage:decodeToHDR:] + 1172 (SDImageIOAnimatedCoder.m:535)
20 MyApp 0x00000001026b5744 -[SDImageIOAnimatedCoder safeAnimatedImageFrameAtIndex:] + 108 (SDImageIOAnimatedCoder.m:1149)
21 MyApp 0x00000001026b5628 -[SDImageIOAnimatedCoder animatedImageFrameAtIndex:] + 92 (SDImageIOAnimatedCoder.m:1143)
22 MyApp 0x000000010269fb64 -[SDAnimatedImage animatedImageFrameAtIndex:] + 152 (SDAnimatedImage.m:307)
23 MyApp 0x00000001026b2360 __41-[SDImageFramePool prefetchFrameAtIndex:]_block_invoke + 48 (SDImageFramePool.m:119)
24 Foundation 0x00000001a142b2f0 NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK + 24 (NSOperation.m:1545)
25 Foundation 0x00000001a13ff4a0 -[NSBlockOperation main] + 104 (NSOperation.m:1564)
26 Foundation 0x00000001a13ff430 NSOPERATION_IS_INVOKING_MAIN + 16 (NSOperation.m:2189)
27 Foundation 0x00000001a13c07d8 -[NSOperation start] + 708 (NSOperation.m:2206)
28 Foundation 0x00000001a13c050c NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION + 16 (NSOperation.m:2220)
29 Foundation 0x00000001a13c5c20 __NSOQSchedule_f + 172 (NSOperation.m:2231)
30 libdispatch.dylib 0x00000001ae585114 _dispatch_block_async_invoke2 + 148 (queue.c:555)
31 libdispatch.dylib 0x00000001ae575fdc _dispatch_client_callout + 20 (object.m:560)
32 libdispatch.dylib 0x00000001ae57946c _dispatch_continuation_pop + 504 (inline_internal.h:2632)
33 libdispatch.dylib 0x00000001ae578b6c _dispatch_async_redirect_invoke + 736 (queue.c:830)
34 libdispatch.dylib 0x00000001ae587a6c _dispatch_root_queue_drain + 396 (inline_internal.h:0)
35 libdispatch.dylib 0x00000001ae588284 _dispatch_worker_thread2 + 164 (queue.c:7052)
36 libsystem_pthread.dylib 0x00000001f3ffbdbc _pthread_wqthread + 228 (pthread.c:2631)
37 libsystem_pthread.dylib 0x00000001f3ffbb98 start_wqthread + 8 (:-1)

### Pull Request Description

When the animated image is released, and still call the code may lead to crash: 
UIImage *frame = [animatedProvider animatedImageFrameAtIndex:index];

So here adding a code protection。Please let me know if you have any questions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when handling animated images by ensuring proper validation of the image provider during background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->