### PR TITLE
[Xcode 26] - Fix watchOS build error with UITraitCollection in the new SDK

### DIFF
--- a/SDWebImage/Core/SDAnimatedImage.h
+++ b/SDWebImage/Core/SDAnimatedImage.h
@@ -76,7 +76,7 @@ NS_SWIFT_NONISOLATED
 // @note Before 5.19, these initializer will return nil for static image (when all candidate SDAnimatedImageCoder returns nil instance), like JPEG data. After 5.19, these initializer will retry for static image as well, so JPEG data will return non-nil instance. For vector image(PDF/SVG), always return nil.
 // @note When the animated image frame count <= 1, all the `SDAnimatedImageProvider` protocol methods will return nil or 0 value, you'd better check the frame count before usage and keep fallback.
 + (nullable instancetype)imageNamed:(nonnull NSString *)name; // Cache in memory, no Asset Catalog support
-#if __has_include(<UIKit/UITraitCollection.h>)
+#if __has_include(<UIKit/UITraitCollection.h>) && !SD_WATCH
 + (nullable instancetype)imageNamed:(nonnull NSString *)name inBundle:(nullable NSBundle *)bundle compatibleWithTraitCollection:(nullable UITraitCollection *)traitCollection; // Cache in memory, no Asset Catalog support
 #else
 + (nullable instancetype)imageNamed:(nonnull NSString *)name inBundle:(nullable NSBundle *)bundle; // Cache in memory, no Asset Catalog support

--- a/SDWebImage/Core/SDAnimatedImage.m
+++ b/SDWebImage/Core/SDAnimatedImage.m
@@ -44,14 +44,14 @@ static CGFloat SDImageScaleFromPath(NSString *string) {
 
 #pragma mark - UIImage override method
 + (instancetype)imageNamed:(NSString *)name {
-#if __has_include(<UIKit/UITraitCollection.h>)
+#if __has_include(<UIKit/UITraitCollection.h>) && !SD_WATCH
     return [self imageNamed:name inBundle:nil compatibleWithTraitCollection:nil];
 #else
     return [self imageNamed:name inBundle:nil];
 #endif
 }
 
-#if __has_include(<UIKit/UITraitCollection.h>)
+#if __has_include(<UIKit/UITraitCollection.h>) && !SD_WATCH
 + (instancetype)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle compatibleWithTraitCollection:(UITraitCollection *)traitCollection {
 #if SD_VISION
     if (!traitCollection) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

The UITraitCollection header is available on watchOS but UITraitCollection isn't

Fixes https://github.com/SDWebImage/SDWebImage/issues/3818



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading images on watchOS and other platforms without trait collection support by introducing an alternative image loading method.
- **Bug Fixes**
  - Improved platform compatibility by ensuring trait collection-based image loading methods are not available on watchOS, preventing potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->