### PR TITLE
Avoid self if be nil in block.

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -242,12 +242,18 @@
         @weakify(self);
         self.player.animationFrameHandler = ^(NSUInteger index, UIImage * frame) {
             @strongify(self);
+            if (!self) {
+                return;
+            }
             self.currentFrameIndex = index;
             self.currentFrame = frame;
             [self.imageViewLayer setNeedsDisplay];
         };
         self.player.animationLoopHandler = ^(NSUInteger loopCount) {
             @strongify(self);
+            if (!self) {
+                return;
+            }
             // Progressive image reach the current last frame index. Keep the state and pause animating. Wait for later restart
             if (self.isProgressive) {
                 NSUInteger lastFrameIndex = self.player.totalFrameCount - 1;

--- a/SDWebImage/Core/SDImageCachesManager.m
+++ b/SDWebImage/Core/SDImageCachesManager.m
@@ -444,6 +444,9 @@
     @weakify(self);
     [cache queryImageForKey:key options:options context:context cacheType:queryCacheType completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         @strongify(self);
+        if (!self) {
+            return;
+        }
         if (operation.isCancelled) {
             // Cancelled
             return;
@@ -479,6 +482,9 @@
     @weakify(self);
     [cache storeImage:image imageData:imageData forKey:key options:options context:context cacheType:cacheType completion:^{
         @strongify(self);
+        if (!self) {
+            return;
+        }
         // Next
         [self serialStoreImage:image imageData:imageData forKey:key options:options context:context cacheType:cacheType completion:completionBlock enumerator:enumerator];
     }];
@@ -497,6 +503,9 @@
     @weakify(self);
     [cache removeImageForKey:key cacheType:cacheType completion:^{
         @strongify(self);
+        if (!self) {
+            return;
+        }
         // Next
         [self serialRemoveImageForKey:key cacheType:cacheType completion:completionBlock enumerator:enumerator];
     }];
@@ -517,6 +526,9 @@
     @weakify(self);
     [cache containsImageForKey:key cacheType:cacheType completion:^(SDImageCacheType containsCacheType) {
         @strongify(self);
+        if (!self) {
+            return;
+        }
         if (operation.isCancelled) {
             // Cancelled
             return;
@@ -552,6 +564,9 @@
     @weakify(self);
     [cache clearWithCacheType:cacheType completion:^{
         @strongify(self);
+        if (!self) {
+            return;
+        }
         // Next
         [self serialClearWithCacheType:cacheType completion:completionBlock enumerator:enumerator];
     }];

--- a/SDWebImage/Core/UIButton+WebCache.m
+++ b/SDWebImage/Core/UIButton+WebCache.m
@@ -73,6 +73,9 @@
                              context:mutableContext
                        setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            @strongify(self);
+                           if (!self) {
+                               return;
+                           }
                            [self setImage:image forState:state];
                        }
                             progress:progressBlock

--- a/SDWebImage/Core/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/Core/UIImageView+HighlightedWebCache.m
@@ -60,6 +60,9 @@
                              context:mutableContext
                        setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            @strongify(self);
+                           if (!self) {
+                               return;
+                           }
                            self.highlightedImage = image;
                        }
                             progress:progressBlock


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Add condition statement `if (!self) { return; }` to avoid self being nil in block and ensure the logic executes only when self is valid.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by preventing potential crashes when certain image loading or animation operations are performed on deallocated views or objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->