### PR TITLE
Do not ignore blendMode in SDImageTintTransformer

### DIFF
--- a/SDWebImage/Core/SDImageTransformer.m
+++ b/SDWebImage/Core/SDImageTransformer.m
@@ -309,7 +309,7 @@ NSString * _Nullable SDThumbnailedKeyForKey(NSString * _Nullable key, CGSize thu
     if (!image) {
         return nil;
     }
-    return [image sd_tintedImageWithColor:self.tintColor];
+    return [image sd_tintedImageWithColor:self.tintColor blendMode:self.blendMode];
 }
 
 @end


### PR DESCRIPTION
This looks like an oversight where we have a blend mode but ignore it, instead implicitly always using `kCGBlendModeSourceIn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved image tinting to support custom blend modes, offering more control over how tint colors are applied to images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->