### PR TITLE
feat: Enable `DEFINES_MODULE` again

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -29,7 +29,8 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'SUPPORTS_MACCATALYST' => 'YES',
-    'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'NO'
+    'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'NO',
+    'DEFINES_MODULE' => 'YES'
   }
 
   s.subspec 'Core' do |core|


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

If SDWebImage is imported in a Swift library with frameworks enabled (`use_frameworks!`), the pod install process fails because it does not define a module. I need modules in my [nitro](https://github.com/mrousavy/nitro) libraries, such as [react-native-nitro-image](https://github.com/mrousavy/react-native-nitro-image) - which uses SDWebImage.

To fix this, you need to set `DEFINES_MODULE` to `YES` in your pod config.

This was already done 7 years ago by @zhongwuzw in https://github.com/SDWebImage/SDWebImage/pull/2549, then reverted just two months later by @dreampiggy in https://github.com/SDWebImage/SDWebImage/pull/2604 because it broke the build in some projects:

- https://github.com/SDWebImage/SDWebImage/issues/2601
- https://github.com/CocoaPods/CocoaPods/issues/7584

Those issue reports are 6 years old and have been closed since many years, hinting that the issue has already been fixed. I have not had any issues with modules in Swift for at least 4 years too, so I think this is safe to add now. Let's test this enough before shipping though.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to define the module when integrating via CocoaPods, improving Swift interoperability and enabling clean `import` usage.
  - Enhances compatibility with Catalyst and other modular build environments.
  - No changes to public APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->