### PR TITLE
Switched image encoding to a context-aware approach with a safe fallback, allowing per-request encoder selection without changing the public API.

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -279,7 +279,11 @@ static NSString * _defaultDiskCacheDirectory;
                     format = [SDImageCoderHelper CGImageContainsAlpha:image.CGImage] ? SDImageFormatPNG : SDImageFormatJPEG;
                 }
             }
-            NSData *encodedData = [[SDImageCodersManager sharedManager] encodedDataWithImage:image format:format options:context[SDWebImageContextImageEncodeOptions]];
+            id<SDImageCoder> imageCoder = context[SDWebImageContextImageCoder];
+            if (!imageCoder) {
+                imageCoder = [SDImageCodersManager sharedManager];
+            }
+            NSData *encodedData = [imageCoder encodedDataWithImage:image format:format options:context[SDWebImageContextImageEncodeOptions]];
             dispatch_async(self.ioQueue, ^{
                 [self _storeImageDataToDisk:encodedData forKey:key];
                 [self _archivedDataWithImage:image forKey:key];


### PR DESCRIPTION
storeImage时，需要获取context中的SDWebImageContextImageCoder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched image encoding to a context-aware approach with a safe fallback, allowing per-request encoder selection without changing the public API.

* **Bug Fixes**
  * Improved reliability of image encoding by gracefully handling cases where a custom encoder isn’t provided, reducing potential errors and crashes.

* **New Features**
  * Added runtime configurability for image encoding, improving compatibility with custom image encoders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->