### PR TITLE
Try to move the SDWebImageDownloaderOperation dataTask property initialization into synchronized lock to avoid thread-safe issue

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -168,6 +168,7 @@
 }
 
 - (void)start {
+    NSURLSessionTask *dataTask = nil;
     @synchronized (self) {
         if (self.isCancelled) {
             if (!self.isFinished) self.finished = YES;
@@ -228,22 +229,23 @@
             return;
         }
         
-        self.dataTask = [session dataTaskWithRequest:self.request];
-        self.executing = YES;
+        dataTask = [session dataTaskWithRequest:self.request];
     }
 
-    if (self.dataTask) {
+    if (dataTask) {
         if (self.options & SDWebImageDownloaderHighPriority) {
-            self.dataTask.priority = NSURLSessionTaskPriorityHigh;
+            dataTask.priority = NSURLSessionTaskPriorityHigh;
         } else if (self.options & SDWebImageDownloaderLowPriority) {
-            self.dataTask.priority = NSURLSessionTaskPriorityLow;
+            dataTask.priority = NSURLSessionTaskPriorityLow;
         } else {
-            self.dataTask.priority = NSURLSessionTaskPriorityDefault;
+            dataTask.priority = NSURLSessionTaskPriorityDefault;
         }
-        [self.dataTask resume];
         NSArray<SDWebImageDownloaderOperationToken *> *tokens;
         @synchronized (self) {
             tokens = [self.callbackTokens copy];
+            self.dataTask = dataTask;
+            self.executing = YES;
+            [self.dataTask resume];
         }
         for (SDWebImageDownloaderOperationToken *token in tokens) {
             if (token.progressBlock) {


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This close #3842 

Maybe there are better way to fix, but this is the simplest one in my mind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and reliability of image download operations by preventing race conditions when starting and resuming downloads.
  * Ensured task priority settings and resume happen in a safe sequence to avoid unexpected behavior under concurrent download scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->