### PR TITLE
Fix the issue that thumbnail decoding will store the fulll image data into thumbnail key, which effect next time query from disk

### DIFF
--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -312,6 +312,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancelled
+ * @note In history, when disk cache hit, the image will write back into memory cache, which is mostly unwanted behavior. From new version this behavior is removed.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
@@ -324,6 +325,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancelled
  * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
+ * @note In history, when disk cache hit, the image will write back into memory cache, which is mostly unwanted behavior. From new version this behavior is removed.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
@@ -337,6 +339,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancellederation, will callback immediately when cancelled
  * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
+ * @note In history, when disk cache hit, the image will write back into memory cache, which is mostly unwanted behavior. From new version this behavior is removed.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
@@ -351,6 +354,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  *
  * @return a SDImageCacheToken instance containing the cache operation, will callback immediately when cancelled
  * @warning If you query with thumbnail cache key, you'd better not pass the thumbnail pixel size context, which is undefined behavior.
+ * @note In history, when disk cache hit, the image will write back into memory cache, which is mostly unwanted behavior. From new version this behavior is removed.
  */
 - (nullable SDImageCacheToken *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context cacheType:(SDImageCacheType)queryCacheType done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 

--- a/SDWebImage/Core/SDImageCache.h
+++ b/SDWebImage/Core/SDImageCache.h
@@ -263,6 +263,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
  *
  * @param imageData  The image data to store
  * @param key        The unique image cache key, usually it's image absolute URL
+ * @note In history, when disk cache hit, the image will write back into memory cache, which is mostly unwanted behavior. From new version this behavior is removed.
  */
 - (void)storeImageDataToDisk:(nullable NSData *)imageData
                       forKey:(nullable NSString *)key;

--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -261,7 +261,10 @@ static NSString * _defaultDiskCacheDirectory;
         return;
     }
     NSData *data = imageData;
-    if (!data && [image respondsToSelector:@selector(animatedImageData)]) {
+    if (image.sd_isThumbnail && SDIsThumbnailKey(key)) {
+        // Currently we have no solid way to store thumbnail image's correct data
+        data = nil;
+    } else if (!data && [image respondsToSelector:@selector(animatedImageData)]) {
         // If image is custom animated image class, prefer its original animated data
         data = [((id<SDAnimatedImage>)image) animatedImageData];
     }

--- a/SDWebImage/Core/SDWebImageManager.m
+++ b/SDWebImage/Core/SDWebImageManager.m
@@ -324,6 +324,12 @@ static id<SDImageLoader> _defaultImageLoader;
                     [self callOriginalCacheProcessForOperation:operation url:url options:options context:context progress:progressBlock completed:completedBlock];
                     return;
                 }
+            } else {
+                // Write back the disk image into memory cache, with the correct key
+                if (cacheType == SDImageCacheTypeDisk) {
+                    // Sync
+                    [imageCache storeImage:cachedImage imageData:nil forKey:key cacheType:SDImageCacheTypeMemory completion:nil];
+                }
             }
             // Continue download process
             [self callDownloadProcessForOperation:operation url:url options:options context:context cachedImage:cachedImage cachedData:cachedData cacheType:cacheType progress:progressBlock completed:completedBlock];
@@ -376,6 +382,12 @@ static id<SDImageLoader> _defaultImageLoader;
                 // Original image cache miss. Continue download process
                 [self callDownloadProcessForOperation:operation url:url options:options context:context cachedImage:nil cachedData:nil cacheType:SDImageCacheTypeNone progress:progressBlock completed:completedBlock];
                 return;
+            } else {
+                // Write back the disk image into memory cache, with the correct key
+                if (cacheType == SDImageCacheTypeDisk) {
+                    // Sync
+                    [imageCache storeImage:cachedImage imageData:nil forKey:key cacheType:SDImageCacheTypeMemory completion:nil];
+                }
             }
                         
             // Skip downloading and continue transform process, and ignore .refreshCached option for now

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -504,7 +504,8 @@
         // Check the thumbnail image should be in memory cache (because we have only full data + thumbnail image)
         expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:fullSizeKey].size).equal(CGSizeZero);
         expect([SDImageCache.sharedImageCache imageFromDiskCacheForKey:fullSizeKey]).notTo.beNil();
-        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey].size).equal(thumbnailSize);
+        // Store disk no longer store into memory
+//        expect([SDImageCache.sharedImageCache imageFromMemoryCacheForKey:thumbnailKey].size).equal(thumbnailSize);
         expect([SDImageCache.sharedImageCache imageFromDiskCacheForKey:thumbnailKey]).beNil();
         
         [SDImageCache.sharedImageCache removeImageFromDiskForKey:fullSizeKey];


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This is known issue in history which need a refactory. Currently have to workaround.

See related PR in  https://github.com/SDWebImage/SDWebImage/commit/64c5ff59a31ea054b15878464630c7454012b661


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnails are no longer persisted as full cached image data, reducing disk storage and avoiding unintended thumbnail retention.
* **Refactor**
  * Disk cache reads no longer implicitly trigger historical background memory-sync; disk-hit images are now made available in memory immediately.
* **Documentation**
  * Updated API notes to clarify the new disk-to-memory caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->