### PR TITLE
Added support to encode APNG instead of GIF, when no animated image format provided

### DIFF
--- a/SDWebImage/Core/SDImageCache.m
+++ b/SDWebImage/Core/SDImageCache.m
@@ -276,7 +276,11 @@ static NSString * _defaultDiskCacheDirectory;
             if (format == SDImageFormatUndefined) {
                 // If image is animated, use GIF (APNG may be better, but has bugs before macOS 10.14)
                 if (image.sd_imageFrameCount > 1) {
-                    format = SDImageFormatGIF;
+                    if (@available(iOS 12.0, tvOS 12.0, macOS 10.14, watchOS 5.0, *)) {
+                        format = SDImageFormatPNG;
+                    } else {
+                        format = SDImageFormatGIF;
+                    }
                 } else {
                     // If we do not have any data to detect image format, check whether it contains alpha channel to use PNG or JPEG format
                     format = [SDImageCoderHelper CGImageContainsAlpha:image.CGImage] ? SDImageFormatPNG : SDImageFormatJPEG;

--- a/SDWebImage/Core/SDImageCoderHelper.h
+++ b/SDWebImage/Core/SDImageCoderHelper.h
@@ -68,7 +68,8 @@ typedef struct SDImagePixelFormat {
 /**
  Return an animated image with frames array.
  For UIKit, this will apply the patch and then create animated UIImage. The patch is because that `+[UIImage animatedImageWithImages:duration:]` just use the average of duration for each image. So it will not work if different frame has different duration. Therefore we repeat the specify frame for specify times to let it work.
- For AppKit, NSImage does not support animates other than GIF. This will try to encode the frames to GIF format and then create an animated NSImage for rendering. Attention the animated image may loss some detail if the input frames contain full alpha channel because GIF only supports 1 bit alpha channel. (For 1 pixel, either transparent or not)
+ For AppKit before macOS 10.13, NSImage does not support animates other than GIF. This will try to encode the frames to GIF format and then create an animated NSImage for rendering. Attention the animated image may loss some detail if the input frames contain full alpha channel because GIF only supports 1 bit alpha channel. (For 1 pixel, either transparent or not)
+ For AppKit after macOS 10.14, use APNG format, which has a better render result.
 
  @param frames The frames array. If no frames or frames is empty, return nil
  @return A animated image for rendering on UIImageView(UIKit) or NSImageView(AppKit)

--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -175,6 +175,12 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #else
     
     NSMutableData *imageData = [NSMutableData data];
+    SDImageFormat format;
+    if (@available(iOS 12.0, tvOS 12.0, macOS 10.14, watchOS 5.0, *)) {
+        format = SDImageFormatPNG;
+    } else {
+        format = SDImageFormatGIF;
+    }
     CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
     // Create an image destination. GIF does not support EXIF image orientation
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frameCount, NULL);

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -515,7 +515,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
         UIImage *diskImage = [SDImageCache.sharedImageCache imageFromDiskCacheForKey:kAnimatedImageKey5];
         // Should save to GIF
         expect(diskImage.sd_isAnimated).beTruthy();
-        expect(diskImage.sd_imageFormat).equal(SDImageFormatGIF);
+        if (@available(iOS 12.0, tvOS 12.0, macOS 10.14, watchOS 5.0, *)) {
+            expect(diskImage.sd_imageFormat).equal(SDImageFormatPNG);
+        } else {
+            expect(diskImage.sd_imageFormat).equal(SDImageFormatGIF);
+        }
         [expectation5 fulfill];
     }];
     

--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -893,14 +893,16 @@ withLocalImageURL:(NSURL *)imageUrl
 - (NSDictionary *)gainMapFromImageSource:(CGImageSourceRef)source {
     if (@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)) {
         CFDictionaryRef ISOGainMap = CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeISOGainMap);
+        if (ISOGainMap) {
+            return (__bridge_transfer NSDictionary *)ISOGainMap;
+        }
         CFDictionaryRef HDRGainMap = CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeHDRGainMap);
-        NSDictionary *result = ISOGainMap ? (__bridge_transfer NSDictionary *)ISOGainMap : (__bridge_transfer NSDictionary *)HDRGainMap;
-        if (HDRGainMap) CFRelease(HDRGainMap);
-        if (ISOGainMap) CFRelease(ISOGainMap);
-        return result;
-    } else {
+        if (HDRGainMap) {
+            return (__bridge_transfer NSDictionary *)HDRGainMap;
+        }
         return nil;
     }
+    return nil;
 }
 
 #pragma mark - Utils


### PR DESCRIPTION


### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This can get better animation encoding quality, APNG is far more better than GIF. And since it's already used by many other platform, I think it's time to convert our solution for some cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated images now use PNG on iOS 12+/tvOS 12+/macOS 10.14+/watchOS 5+, falling back to GIF on older OS versions for improved rendering.

* **Documentation**
  * Docs updated to reflect platform-specific animated image format support and AppKit behavior across macOS versions.

* **Tests**
  * Test expectations adjusted to account for platform-dependent animated image format selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->