### PR TITLE
Fix AppKit SDImageCoderHelper does not use APNG instead of GIF for animated image creation

### DIFF
--- a/SDWebImage/Core/SDImageCoderHelper.m
+++ b/SDWebImage/Core/SDImageCoderHelper.m
@@ -181,7 +181,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     } else {
         format = SDImageFormatGIF;
     }
-    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
+    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:format];
     // Create an image destination. GIF does not support EXIF image orientation
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frameCount, NULL);
     if (!imageDestination) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

not used ‘format‘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animated image export to respect the selected format preference. Previously, animated images were always saved as GIF regardless of format selection; they now correctly use the chosen format (e.g., PNG).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->