### PR TITLE
Fix AppKit SDImageCoderHelper does not use APNG instead of GIF for animated image creation

### DIFF
--- a/Tests/Tests/SDImageCoderTests.m
+++ b/Tests/Tests/SDImageCoderTests.m
@@ -450,7 +450,18 @@
     
     // Test old API
     UIImage *animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
-    NSData *data = [SDImageGIFCoder.sharedCoder encodedDataWithImage:animatedImage format:SDImageFormatGIF options:nil];
+    SDImageFormat format;
+    if (@available(iOS 12.0, tvOS 12.0, macOS 10.14, watchOS 5.0, *)) {
+        format = SDImageFormatPNG;
+    } else {
+        format = SDImageFormatGIF;
+    }
+    NSData *data;
+    if (format == SDImageFormatPNG) {
+        data = [SDImageAPNGCoder.sharedCoder encodedDataWithImage:animatedImage format:format options:nil];;
+    } else {
+        data = [SDImageGIFCoder.sharedCoder encodedDataWithImage:animatedImage format:format options:nil];
+    }
     expect(data).notTo.beNil();
 
 #if SD_MAC
@@ -458,7 +469,7 @@
     SDAnimatedImageRep *rep = (SDAnimatedImageRep *)animatedImage.representations.firstObject;
     expect([rep isKindOfClass:SDAnimatedImageRep.class]);
     expect(rep.animatedImageData).equal(data);
-    expect(rep.animatedImageFormat).equal(SDImageFormatGIF);
+    expect(rep.animatedImageFormat).equal(format);
 #endif
     
     // Test new API


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This continue #3870 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized animated image encoding with intelligent platform-based format selection, automatically choosing PNG/APNG for modern platforms or GIF for broader compatibility
  * Added new utility methods for image dimension calculations with aspect ratio preservation and hardware compatibility verification

* **Improvements**
  * Strengthened encoding reliability with enhanced error handling and nil-safety checks in the pipeline
<!-- end of auto-generated comment: release notes by coderabbit.ai -->