### PR TITLE
SDAnimatedImageView, 判断前后image相同时会return，若外部利用runtime覆盖UIImageView.setImage，SDAnimatedImageView这个行为会阻断调用栈

### DIFF
--- a/SDWebImage/Core/SDAnimatedImageView.m
+++ b/SDWebImage/Core/SDAnimatedImageView.m
@@ -177,6 +177,7 @@
 - (void)setImage:(UIImage *)image
 {
     if (self.image == image) {
+        super.image = image;
         return;
     }
     


### PR DESCRIPTION
SDAnimatedImageView, 判断前后image相同时会return，若外部利用runtime覆盖UIImageView.setImage，SDAnimatedImageView这个行为会阻断调用栈，这里应该保持UIImageView的默认行为，调用super.image = image;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an image synchronization issue that could occur when repeated image assignments were made, ensuring consistent display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->