### PR TITLE
Fix locking mechanism to avoid iOS 26 crash with progressiveLoad concurrency

### DIFF
--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -313,10 +313,19 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
 
 - (void)didReceiveMemoryWarning:(NSNotification *)notification
 {
+    // Incremental decoding may concurrently read/write _imageSource from the
+    // frame fetch queue and updateIncrementalData:; hold the same lock to
+    // prevent races with CGImageSourceRemoveCacheAtIndex.
+    if (_incremental) {
+        SD_LOCK(_lock);
+    }
     if (_imageSource) {
         for (size_t i = 0; i < _frameCount; i++) {
             CGImageSourceRemoveCacheAtIndex(_imageSource, i);
         }
+    }
+    if (_incremental) {
+        SD_UNLOCK(_lock);
     }
 }
 

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -786,10 +786,14 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     
     // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
     // Thanks to the author @Nyx0uf
-    
+
+    // Lock before updating the image source to prevent concurrent access from the frame fetch queue.
+    // CGImageSource is not thread-safe for simultaneous read+write.
+    SD_LOCK(_lock);
+
     // Update the data source, we must pass ALL the data, not just the new bytes
     CGImageSourceUpdateData(_imageSource, (__bridge CFDataRef)data, finished);
-    
+
     if (_width + _height == 0) {
         CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(_imageSource, 0, NULL);
         if (properties) {
@@ -800,12 +804,10 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
             CFRelease(properties);
         }
     }
-    
-    SD_LOCK(_lock);
+
     // For animated image progressive decoding because the frame count and duration may be changed.
     [self scanAndCheckFramesValidWithImageSource:_imageSource];
-    SD_UNLOCK(_lock);
-    
+
     // Scale down to limit bytes if need
     if (_limitBytes > 0) {
         // Hack since ImageIO public API (not CGImageDecompressor/CMPhoto) always return back RGBA8888 CGImage
@@ -815,6 +817,8 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
         _thumbnailSize = framePixelSize;
         _preserveAspectRatio = YES;
     }
+
+    SD_UNLOCK(_lock);
 }
 
 - (UIImage *)incrementalDecodedImageWithOptions:(SDImageCoderOptions *)options {
@@ -828,7 +832,9 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
         if (scaleFactor != nil) {
             scale = MAX([scaleFactor doubleValue], 1);
         }
+        SD_LOCK(_lock);
         image = [self.class createFrameAtIndex:0 source:_imageSource scale:scale preserveAspectRatio:_preserveAspectRatio thumbnailSize:_thumbnailSize lazyDecode:_lazyDecode animatedImage:NO decodeToHDR:_finished ? _decodeToHDR : NO];
+        SD_UNLOCK(_lock);
         if (image) {
             image.sd_imageFormat = self.class.imageFormat;
         }

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -781,15 +781,16 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     if (_finished) {
         return;
     }
-    _imageData = data;
-    _finished = finished;
-    
     // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
     // Thanks to the author @Nyx0uf
 
-    // Lock before updating the image source to prevent concurrent access from the frame fetch queue.
+    // Lock before updating state and the image source to prevent concurrent access from the frame fetch queue.
     // CGImageSource is not thread-safe for simultaneous read+write.
+    // _imageData and _finished must be set inside the lock so readers cannot observe
+    // _finished == YES while _imageSource still has old data.
     SD_LOCK(_lock);
+    _imageData = data;
+    _finished = finished;
 
     // Update the data source, we must pass ALL the data, not just the new bytes
     CGImageSourceUpdateData(_imageSource, (__bridge CFDataRef)data, finished);

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -835,19 +835,19 @@ static BOOL SDImageIOPNGPluginBuggyNeedWorkaround(void) {
     NSCParameterAssert(_incremental);
     UIImage *image;
     
+    // Create the image
+    CGFloat scale = _scale;
+    NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+    if (scaleFactor != nil) {
+        scale = MAX([scaleFactor doubleValue], 1);
+    }
+    SD_LOCK(_lock);
     if (_width + _height > 0) {
-        // Create the image
-        CGFloat scale = _scale;
-        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
-        if (scaleFactor != nil) {
-            scale = MAX([scaleFactor doubleValue], 1);
-        }
-        SD_LOCK(_lock);
         image = [self.class createFrameAtIndex:0 source:_imageSource scale:scale preserveAspectRatio:_preserveAspectRatio thumbnailSize:_thumbnailSize lazyDecode:_lazyDecode animatedImage:NO decodeToHDR:_finished ? _decodeToHDR : NO];
-        SD_UNLOCK(_lock);
-        if (image) {
-            image.sd_imageFormat = self.class.imageFormat;
-        }
+    }
+    SD_UNLOCK(_lock);
+    if (image) {
+        image.sd_imageFormat = self.class.imageFormat;
     }
     
     return image;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:

https://github.com/SDWebImage/SDWebImage/issues/3839

### Pull Request Description

Lock before updating the image source to prevent concurrent access from the frame fetch queue.
CGImageSource is not thread-safe for simultaneous read+write.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety during incremental animated image decoding to prevent concurrent access to internal image data.
  * Prevented race conditions when updating incremental data and cache, reducing crashes and visual artifacts.
  * Stabilized first-frame creation and frame validation under concurrent decoding workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->