### PR TITLE
Prevent duplicate downloader completion on reentrant cancel

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -735,13 +735,7 @@ didReceiveResponse:(NSURLResponse *)response
         tokens = [self.callbackTokens copy];
     }
     for (SDWebImageDownloaderOperationToken *token in tokens) {
-        SDWebImageDownloaderCompletedBlock completedBlock = token.completedBlock;
-        if (completedBlock) {
-            SDCallbackQueue *queue = self.context[SDWebImageContextCallbackQueue];
-            [(queue ?: SDCallbackQueue.mainQueue) async:^{
-                completedBlock(image, imageData, error, finished);
-            }];
-        }
+        [self callCompletionBlockWithToken:token image:image imageData:imageData error:error finished:finished];
     }
 }
 
@@ -750,7 +744,14 @@ didReceiveResponse:(NSURLResponse *)response
                            imageData:(nullable NSData *)imageData
                                error:(nullable NSError *)error
                             finished:(BOOL)finished {
-    SDWebImageDownloaderCompletedBlock completedBlock = token.completedBlock;
+    SDWebImageDownloaderCompletedBlock completedBlock;
+    @synchronized (self) {
+        completedBlock = token.completedBlock;
+        // A terminal callback consumes the block so a synchronous cancel cannot call it again.
+        if (finished) {
+            token.completedBlock = nil;
+        }
+    }
     if (completedBlock) {
         SDCallbackQueue *queue = self.context[SDWebImageContextCallbackQueue];
         [(queue ?: SDCallbackQueue.mainQueue) async:^{

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -194,6 +194,38 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)testThatSynchronouslyCancellingFromCompletionCallsCompletionOnce {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Synchronous cancel does not call completion again"];
+    SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
+    downloader.downloadQueue.suspended = YES;
+    SDCallbackQueue *callbackQueue = [[SDCallbackQueue alloc] initWithDispatchQueue:dispatch_get_main_queue()];
+    callbackQueue.policy = SDCallbackPolicyInvoke;
+    NSURL *imageURL = [NSURL fileURLWithPath:self.testPNGPath];
+    __block NSUInteger callbackCount = 0;
+    __block SDWebImageDownloadToken *token;
+    token = [downloader downloadImageWithURL:imageURL
+                                     options:0
+                                     context:@{SDWebImageContextCallbackQueue : callbackQueue}
+                                    progress:nil
+                                   completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+        callbackCount++;
+        if (callbackCount == 1) {
+            expect(image).notTo.beNil();
+            expect(data).notTo.beNil();
+            expect(error).to.beNil();
+            expect(finished).to.beTruthy();
+            [token cancel];
+            [expectation fulfill];
+        }
+    }];
+    downloader.downloadQueue.suspended = NO;
+
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:^(NSError * _Nullable error) {
+        expect(callbackCount).equal(1);
+        [downloader invalidateSessionAndCancel:YES];
+    }];
+}
+
 - (void)test11ThatCancelAllDownloadWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAllDownloads"];
     // Previous test case download may not finished, so we just check the download count should + 1 after new request


### PR DESCRIPTION
## Summary

- guarantee that each downloader callback token receives at most one terminal completion
- keep progressive (`finished == NO`) callbacks unchanged
- add a deterministic regression test for synchronously cancelling a token from its success completion

Fixes #3834.

## Root cause

The downloader copied a token's completion block when dispatching a successful terminal result but left the same block stored on the token until the operation's later cleanup. If user code synchronously called `cancel` from that success completion, the cancellation path could read the still-stored block and dispatch a second terminal completion with `SDWebImageErrorCancelled`.

## Implementation

Terminal completion dispatch now atomically takes and clears the token's completion block under the operation's existing synchronization lock. Whichever terminal result wins the race consumes the block; later success, error, or cancellation paths become no-ops for that token. Non-terminal progressive callbacks do not clear the block.

The multi-token completion path now delegates to the same per-token helper so all terminal paths share this guarantee.

## Validation

- regression test before the fix: failed deterministically with `expected: 1, got: 2`
- regression test after the fix: passed on macOS
- regression test after the fix: passed on an iOS 26.2 simulator
- full `SDWebImageDownloaderTests` suite on macOS: passed
- `swift build`: passed
- full macOS suite: 225/230 passed; the five isolated failures are unrelated environment/external-fixture failures (including an existing Giphy URL returning HTTP 404, HEIC support, file attributes, and cache assertions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download completion callbacks being invoked more than once when a download is synchronously cancelled from within its completion handler.
  * Improved callback handling to ensure each completed download triggers its completion callback only once.

* **Tests**
  * Added coverage for synchronous cancellation from a completion callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->