### PR TITLE
Use partial heap selection instead of a full sort for disk cache eviction

### DIFF
--- a/SDWebImage/Core/SDDiskCache.m
+++ b/SDWebImage/Core/SDDiskCache.m
@@ -13,6 +13,59 @@
 
 static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDiskCache";
 
+/// One cache file candidate for the size-based cleanup pass in `removeExpiredData`.
+/// `url` is owned by the `cacheFiles` dictionary, which outlives every heap operation below,
+/// so it's held unretained to keep the heap a cheap-to-swap POD array. The content date is
+/// unboxed once into a primitive so the heap comparisons don't pay for `-[NSDate compare:]`
+/// message sends (ordering is unchanged: `-[NSDate compare:]` orders by this very value).
+typedef struct {
+    __unsafe_unretained NSURL *url;
+    NSTimeInterval date;
+    NSUInteger size;
+} SDDiskCacheEntry;
+
+/// Restore the min-heap invariant (oldest content date at the root) for the subtree rooted at `index`. O(log n).
+static void SDDiskCacheHeapSiftDown(SDDiskCacheEntry * _Nonnull heap, NSUInteger count, NSUInteger index) {
+    while (YES) {
+        NSUInteger oldest = index;
+        NSUInteger left = index * 2 + 1;
+        NSUInteger right = left + 1;
+        if (left < count && heap[left].date < heap[oldest].date) {
+            oldest = left;
+        }
+        if (right < count && heap[right].date < heap[oldest].date) {
+            oldest = right;
+        }
+        if (oldest == index) {
+            break;
+        }
+        SDDiskCacheEntry temp = heap[index];
+        heap[index] = heap[oldest];
+        heap[oldest] = temp;
+        index = oldest;
+    }
+}
+
+/// Heapify an unordered array in place using Floyd's bottom-up algorithm. O(n), no comparison for the leaf half.
+static void SDDiskCacheHeapBuild(SDDiskCacheEntry * _Nonnull heap, NSUInteger count) {
+    // Iterate the internal nodes backwards. `count / 2` is one past the last internal node,
+    // so the loop counter is kept 1-based to stay safe on the unsigned type.
+    for (NSUInteger i = count / 2; i > 0; i--) {
+        SDDiskCacheHeapSiftDown(heap, count, i - 1);
+    }
+}
+
+/// Remove and return the entry with the oldest content date, shrinking `count` by one. O(log n).
+static SDDiskCacheEntry SDDiskCacheHeapPopOldest(SDDiskCacheEntry * _Nonnull heap, NSUInteger * _Nonnull count) {
+    SDDiskCacheEntry oldest = heap[0];
+    *count -= 1;
+    if (*count > 0) {
+        heap[0] = heap[*count];
+        SDDiskCacheHeapSiftDown(heap, *count, 0);
+    }
+    return oldest;
+}
+
 @interface SDDiskCache ()
 
 @property (nonatomic, copy) NSString *diskCachePath;
@@ -221,21 +274,53 @@ static NSString * const SDDiskCacheExtendedAttributeName = @"com.hackemist.SDDis
         // Target half of our maximum cache size for this cleanup pass.
         const NSUInteger desiredCacheSize = maxDiskSize / 2;
         
-        // Sort the remaining cache files by their last modification time or last access time (oldest first).
-        NSArray<NSURL *> *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
-                                                                 usingComparator:^NSComparisonResult(id obj1, id obj2) {
-                                                                     return [obj1[cacheContentDateKey] compare:obj2[cacheContentDateKey]];
-                                                                 }];
-        
-        // Delete files until we fall below our desired cache size.
-        for (NSURL *fileURL in sortedFiles) {
-            if ([self.fileManager removeItemAtURL:fileURL error:nil]) {
-                NSDictionary<NSString *, id> *resourceValues = cacheFiles[fileURL];
-                NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
-                currentCacheSize -= totalAllocatedSize.unsignedIntegerValue;
-                
-                if (currentCacheSize < desiredCacheSize) {
-                    break;
+        // A full sort of every remaining cache file is more work than we need: we only ever
+        // consume the oldest `k` entries, so heapify in O(n) and pop just those in O(k log n)
+        // instead of ordering all n in O(n log n). The content date is also unboxed to a
+        // primitive up front, so the heap comparisons are plain double compares rather than
+        // `-[NSDate compare:]` message sends.
+        NSUInteger heapCount = cacheFiles.count;
+        SDDiskCacheEntry *heap = heapCount > 0 ? malloc(heapCount * sizeof(SDDiskCacheEntry)) : NULL;
+        if (heap) {
+            __block NSUInteger index = 0;
+            [cacheFiles enumerateKeysAndObjectsUsingBlock:^(NSURL *fileURL, NSDictionary<NSString *, id> *resourceValues, BOOL *stop) {
+                heap[index].url = fileURL;
+                heap[index].date = [(NSDate *)resourceValues[cacheContentDateKey] timeIntervalSinceReferenceDate];
+                heap[index].size = [(NSNumber *)resourceValues[NSURLTotalFileAllocatedSizeKey] unsignedIntegerValue];
+                index++;
+            }];
+            SDDiskCacheHeapBuild(heap, heapCount);
+
+            // Delete files, oldest first, until we fall below our desired cache size.
+            while (heapCount > 0) {
+                SDDiskCacheEntry entry = SDDiskCacheHeapPopOldest(heap, &heapCount);
+                if ([self.fileManager removeItemAtURL:entry.url error:nil]) {
+                    currentCacheSize -= entry.size;
+
+                    if (currentCacheSize < desiredCacheSize) {
+                        break;
+                    }
+                }
+            }
+            free(heap);
+        } else {
+            // Allocation failed, fall back to sorting the remaining cache files by their
+            // last modification time or last access time (oldest first).
+            NSArray<NSURL *> *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
+                                                                     usingComparator:^NSComparisonResult(id obj1, id obj2) {
+                                                                         return [obj1[cacheContentDateKey] compare:obj2[cacheContentDateKey]];
+                                                                     }];
+
+            // Delete files until we fall below our desired cache size.
+            for (NSURL *fileURL in sortedFiles) {
+                if ([self.fileManager removeItemAtURL:fileURL error:nil]) {
+                    NSDictionary<NSString *, id> *resourceValues = cacheFiles[fileURL];
+                    NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+                    currentCacheSize -= totalAllocatedSize.unsignedIntegerValue;
+
+                    if (currentCacheSize < desiredCacheSize) {
+                        break;
+                    }
                 }
             }
         }

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -634,6 +634,82 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)test45DiskCacheRemoveExpiredDataEvictsExactlyTheOldestFiles {
+    // Pins the size-based eviction contract of `-removeExpiredData`: the files deleted are
+    // exactly the oldest ones, and no more of them than needed to drop below maxDiskSize / 2.
+    // This is algorithm-independent, so it holds for the full-sort and the partial-selection
+    // (heap) implementation alike.
+    NSString *cachePath = [[self userCacheDirectory] stringByAppendingPathComponent:@"disk-eviction-order"];
+    // Use a dedicated config rather than the shared `defaultCacheConfig` singleton
+    SDImageCacheConfig *config = [[SDImageCacheConfig alloc] init];
+    config.maxDiskAge = -1; // disable the age-based pass, we only exercise the size-based one
+    config.diskCacheExpireType = SDImageCacheConfigExpireTypeModificationDate;
+    SDDiskCache *diskCache = [[SDDiskCache alloc] initWithCachePath:cachePath config:config];
+    [diskCache removeAllData];
+    expect(diskCache.totalCount).equal(0);
+
+    // Seed `fileCount` equally sized files. Keys are written in a shuffled order and each key's
+    // modification date is derived from its index, so neither the on-disk enumeration order nor
+    // the insertion order matches the date order -- an implementation that leaked input order
+    // instead of ordering by date would fail below.
+    const NSUInteger fileCount = 64;
+    NSMutableArray<NSNumber *> *insertionOrder = [NSMutableArray arrayWithCapacity:fileCount];
+    for (NSUInteger i = 0; i < fileCount; i++) {
+        [insertionOrder addObject:@(i)];
+    }
+    for (NSUInteger i = fileCount; i > 1; i--) {
+        [insertionOrder exchangeObjectAtIndex:(i - 1) withObjectAtIndex:(arc4random_uniform((uint32_t)i))];
+    }
+
+    NSUInteger length = 16;
+    void *bytes = calloc(length, 1);
+    NSData *data = [NSData dataWithBytes:bytes length:length];
+    free(bytes);
+
+    NSDate *baseDate = [NSDate dateWithTimeIntervalSinceNow:-3600];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    for (NSNumber *boxedIndex in insertionOrder) {
+        NSUInteger i = boxedIndex.unsignedIntegerValue;
+        NSString *key = [NSString stringWithFormat:@"evict-%02lu", (unsigned long)i];
+        [diskCache setData:data forKey:key];
+        // index 0 is the oldest, index fileCount-1 the newest, all dates distinct
+        NSDate *modificationDate = [baseDate dateByAddingTimeInterval:(NSTimeInterval)i];
+        NSError *error = nil;
+        [fileManager setAttributes:@{NSFileModificationDate : modificationDate}
+                     ofItemAtPath:[diskCache cachePathForKey:key]
+                            error:&error];
+        expect(error).beNil();
+    }
+    expect(diskCache.totalCount).equal(fileCount);
+
+    // `removeExpiredData` accounts for the *allocated* size of each file, which is block
+    // granular, so read it back from the filesystem rather than assuming the byte length.
+    NSURL *probeURL = [NSURL fileURLWithPath:[diskCache cachePathForKey:@"evict-00"]];
+    NSNumber *allocatedSize = nil;
+    [probeURL getResourceValue:&allocatedSize forKey:NSURLTotalFileAllocatedSizeKey error:nil];
+    NSUInteger fileSize = allocatedSize.unsignedIntegerValue;
+    expect(fileSize).beGreaterThan(0);
+
+    // Trigger the size pass with maxDiskSize = 16 files, so the target is 8 files worth of
+    // bytes. Deleting oldest-first stops as soon as the remainder is *below* the target, which
+    // leaves 7 files -- the 7 newest.
+    config.maxDiskSize = 16 * fileSize;
+    const NSUInteger expectedRemaining = 7;
+    [diskCache removeExpiredData];
+
+    expect(diskCache.totalCount).equal(expectedRemaining);
+    for (NSUInteger i = 0; i < fileCount; i++) {
+        NSString *key = [NSString stringWithFormat:@"evict-%02lu", (unsigned long)i];
+        if (i >= fileCount - expectedRemaining) {
+            expect([diskCache containsDataForKey:key]).beTruthy();
+        } else {
+            expect([diskCache containsDataForKey:key]).beFalsy();
+        }
+    }
+
+    [diskCache removeAllData];
+}
+
 #if SD_UIKIT
 - (void)test46MemoryCacheWeakCache {
     SDMemoryCache *memoryCache = [[SDMemoryCache alloc] init];


### PR DESCRIPTION
Fixes #3815

### Problem

`-[SDDiskCache removeExpiredData]` fully sorts every remaining cache file by content date before deleting the oldest ones, even though only the oldest `k` entries are ever consumed.

### Change

A binary min-heap keyed on content date: heapify in O(n), then pop only the entries actually deleted in O(k log n), instead of ordering all n in O(n log n). Two further changes carry most of the measured win:

- the content date is unboxed to a primitive `NSTimeInterval` once per file, so heap comparisons are double compares rather than `-[NSDate compare:]` message sends;
- entries are gathered with `-enumerateKeysAndObjectsUsingBlock:`, avoiding a dictionary lookup per file.

The helpers are file-static in `SDDiskCache.m` — no public API change. If the allocation fails it falls back to the previous sort, so there is no functional regression under memory pressure.

### A correction to the issue's premise

The issue assumes `k` is small relative to `n`. It isn't: `desiredCacheSize` is `maxDiskSize / 2` while the pass only triggers above `maxDiskSize`, so each cleanup evicts down to half the limit and `k ≈ n/2`.

I measured a straightforward min-heap on that basis first, and it gained almost nothing — roughly 1.1x, and actually **slower** (0.85x) at n=200,000, because materializing all n entries costs a dictionary lookup and an `NSNumber` unboxing per file that the current code only pays for the k files it deletes. The gain below comes from the heap *plus* the primitive key, not from partial selection alone.

### Performance (macOS, 10 cores, equally sized files)

| n | k ≈ n/2 | small k (~20) |
|---|---|---|
| 500 | 4.44x | 4.19x |
| 2,000 | 3.37x | 2.99x |
| 10,000 | 2.67x | 2.67x |
| 50,000 | 2.58x | 2.43x |
| 200,000 | 2.40x | 1.70x |

### Behaviour

Unchanged: oldest-first, `currentCacheSize` decremented only on successful removal, same `< desiredCacheSize` break. `-[NSDate compare:]` orders by `timeIntervalSinceReferenceDate`, so comparing that double is the same total order. Across 2000 randomized trials with distinct dates, the eviction set and eviction order are identical to the old code.

With duplicate dates the evicted *set* can differ while the *count* is always identical. The previous order among equal dates was already unspecified — `NSSortConcurrent` is an unstable parallel sort over arbitrary dictionary key order — so this is a different arbitrary choice within an already-undefined set rather than a behavioural change.

### Tests

New `test45DiskCacheRemoveExpiredDataEvictsExactlyTheOldestFiles` seeds 64 equally sized files with distinct modification dates written in shuffled order, reads the allocated block size off the filesystem, and asserts the exact surviving set file-by-file. I sanity-checked that the test has teeth by inverting the heap to a max-heap, which makes it fail with 14 assertion failures.

`SDImageCacheTests` passes 47/47 on macOS and 48/48 on the iOS Simulator. The full `Tests Mac` suite has 5 failures (`SDAnimatedImageTest/test22AnimatedImageViewCategory`, `SDWebImageDecoderTests/test16ThatHEICAnimatedWorks`) which reproduce identically on unmodified `master` — HEIC/animated decoding on Xcode 26 / macOS 26, unrelated to the disk cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk-cache cleanup to consistently remove the oldest files first when reducing cache size.
  * Preserved the existing cleanup behavior when optimized processing is unavailable.

* **Tests**
  * Added coverage verifying that size-based expiration removes only the oldest cache files and retains newer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->